### PR TITLE
soft delete

### DIFF
--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -35,6 +35,113 @@ mod test {
         assert_eq!(pet.id, 1);
         assert_eq!(pet.name, name);
         assert_eq!(pet.active, false);
+        assert_eq!(pet.archived, false);
+    }
+
+    #[test]
+    fn test_archive_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        assert!(client.get_pet(&pet_id).is_some());
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id);
+        assert_eq!(archived.get(0).unwrap().archived, true);
+    }
+
+    #[test]
+    fn test_archived_pets_not_in_normal_queries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id1 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+        let pet_id2 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Luna"),
+            &String::from_str(&env, "2021-05-15"),
+            &Gender::Female,
+            &Species::Cat,
+            &String::from_str(&env, "Siamese"),
+            &PrivacyLevel::Public,
+        );
+
+        let by_owner = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner.len(), 2);
+
+        client.archive_pet(&pet_id1);
+
+        let by_owner_after = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner_after.len(), 1);
+        assert_eq!(by_owner_after.get(0).unwrap().id, pet_id2);
+
+        assert!(client.get_pet(&pet_id1).is_none());
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id1);
+    }
+
+    #[test]
+    fn test_restore_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        client.restore_pet(&pet_id);
+        let pet = client.get_pet(&pet_id).unwrap();
+        assert_eq!(pet.id, pet_id);
+        assert_eq!(pet.archived, false);
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 0);
     }
 
     #[test]
@@ -1008,6 +1115,113 @@ mod test {
         assert_eq!(pet.id, 1);
         assert_eq!(pet.name, name);
         assert_eq!(pet.active, false);
+        assert_eq!(pet.archived, false);
+    }
+
+    #[test]
+    fn test_archive_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        assert!(client.get_pet(&pet_id).is_some());
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id);
+        assert_eq!(archived.get(0).unwrap().archived, true);
+    }
+
+    #[test]
+    fn test_archived_pets_not_in_normal_queries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id1 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+        let pet_id2 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Luna"),
+            &String::from_str(&env, "2021-05-15"),
+            &Gender::Female,
+            &Species::Cat,
+            &String::from_str(&env, "Siamese"),
+            &PrivacyLevel::Public,
+        );
+
+        let by_owner = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner.len(), 2);
+
+        client.archive_pet(&pet_id1);
+
+        let by_owner_after = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner_after.len(), 1);
+        assert_eq!(by_owner_after.get(0).unwrap().id, pet_id2);
+
+        assert!(client.get_pet(&pet_id1).is_none());
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id1);
+    }
+
+    #[test]
+    fn test_restore_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        client.restore_pet(&pet_id);
+        let pet = client.get_pet(&pet_id).unwrap();
+        assert_eq!(pet.id, pet_id);
+        assert_eq!(pet.archived, false);
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 0);
     }
 
     #[test]
@@ -1847,6 +2061,113 @@ mod test {
         assert_eq!(pet.id, 1);
         assert_eq!(pet.name, name);
         assert_eq!(pet.active, false);
+        assert_eq!(pet.archived, false);
+    }
+
+    #[test]
+    fn test_archive_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        assert!(client.get_pet(&pet_id).is_some());
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id);
+        assert_eq!(archived.get(0).unwrap().archived, true);
+    }
+
+    #[test]
+    fn test_archived_pets_not_in_normal_queries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id1 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+        let pet_id2 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Luna"),
+            &String::from_str(&env, "2021-05-15"),
+            &Gender::Female,
+            &Species::Cat,
+            &String::from_str(&env, "Siamese"),
+            &PrivacyLevel::Public,
+        );
+
+        let by_owner = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner.len(), 2);
+
+        client.archive_pet(&pet_id1);
+
+        let by_owner_after = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner_after.len(), 1);
+        assert_eq!(by_owner_after.get(0).unwrap().id, pet_id2);
+
+        assert!(client.get_pet(&pet_id1).is_none());
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id1);
+    }
+
+    #[test]
+    fn test_restore_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        client.restore_pet(&pet_id);
+        let pet = client.get_pet(&pet_id).unwrap();
+        assert_eq!(pet.id, pet_id);
+        assert_eq!(pet.archived, false);
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 0);
     }
 
     #[test]
@@ -2507,6 +2828,113 @@ mod test {
         assert_eq!(pet.id, 1);
         assert_eq!(pet.name, name);
         assert_eq!(pet.active, false);
+        assert_eq!(pet.archived, false);
+    }
+
+    #[test]
+    fn test_archive_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        assert!(client.get_pet(&pet_id).is_some());
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id);
+        assert_eq!(archived.get(0).unwrap().archived, true);
+    }
+
+    #[test]
+    fn test_archived_pets_not_in_normal_queries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id1 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+        let pet_id2 = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Luna"),
+            &String::from_str(&env, "2021-05-15"),
+            &Gender::Female,
+            &Species::Cat,
+            &String::from_str(&env, "Siamese"),
+            &PrivacyLevel::Public,
+        );
+
+        let by_owner = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner.len(), 2);
+
+        client.archive_pet(&pet_id1);
+
+        let by_owner_after = client.get_pets_by_owner(&owner);
+        assert_eq!(by_owner_after.len(), 1);
+        assert_eq!(by_owner_after.get(0).unwrap().id, pet_id2);
+
+        assert!(client.get_pet(&pet_id1).is_none());
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().id, pet_id1);
+    }
+
+    #[test]
+    fn test_restore_pet() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Golden Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        client.archive_pet(&pet_id);
+        assert!(client.get_pet(&pet_id).is_none());
+
+        client.restore_pet(&pet_id);
+        let pet = client.get_pet(&pet_id).unwrap();
+        assert_eq!(pet.id, pet_id);
+        assert_eq!(pet.archived, false);
+
+        let archived = client.get_archived_pets(&owner);
+        assert_eq!(archived.len(), 0);
     }
 
     #[test]
@@ -2972,6 +3400,15 @@ mod test {
 
     #[test]
     fn test_mark_medication_completed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+        let vet = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
             &String::from_str(&env, "Pet"),
             &String::from_str(&env, "2020"),
             &Gender::Male,
@@ -3179,6 +3616,13 @@ mod test {
     #[test]
     #[should_panic(expected = "Invalid IPFS hash")]
     fn test_add_pet_photo_invalid_hash() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
             &String::from_str(&env, "Chip"),
             &String::from_str(&env, "2023-06-15"),
             &Gender::Male,


### PR DESCRIPTION
## Archive pets instead of deleting

### Summary
Adds archiving for pets so records can be hidden without losing data. Use case: pets that pass away or are rehomed stay in history for medical/legal reasons but are excluded from normal lists.

### Changes

**Contract (`stellar-contracts/src/lib.rs`)**
- **`Pet`**: added `archived: bool` and `photo_hashes: Vec<String>` (latter was missing from the struct).
- **`PetProfile`**: added `archived: bool`.
- **`register_pet`**: new pets get `archived: false` and `photo_hashes: Vec::new(&env)`.
- **`get_pet`**: returns `None` for archived pets (they are hidden from normal lookup).
- **`archive_pet(env, pet_id)`**: owner-only; sets `archived = true`, updates `updated_at`.
- **`restore_pet(env, pet_id)`**: owner-only; sets `archived = false`, updates `updated_at`.
- **`get_archived_pets(env, owner)`**: returns `Vec<PetProfile>` of archived pets for that owner.
- **`build_pet_profile`**: private helper to build `PetProfile` from `Pet` (used by `get_pet` and `get_archived_pets`).

**Query behavior**
- `get_all_pets_by_owner`, `get_pets_by_owner`, `get_pets_by_species`, and `get_active_pets` all use `get_pet`, so archived pets are automatically excluded.

**Tests (`stellar-contracts/src/test.rs`)**
- `test_archive_pet`: archive pet, assert hidden from `get_pet` and present in `get_archived_pets`.
- `test_archived_pets_not_in_normal_queries`: two pets, archive one, assert only the other in `get_pets_by_owner` and archived one in `get_archived_pets`.
- `test_restore_pet`: archive then restore, assert pet visible again and not in `get_archived_pets`.
- `test_register_pet`: assert new pet has `archived == false`.

**Other fixes (pre-existing)**
- Closed unclosed delimiters in `migrate_version`, `species_to_string`, and `VetReview`; fixed duplicate/broken `add_medication_to_record`; corrected `AvailabilitySlot` and restored missing `DataKey` variants; fixed two tests missing setup; removed duplicate `mod test` in `lib.rs`.

### Branch
`feature/archive-pets`

closes #94 