### PR TITLE
feature/contract-events

### DIFF
--- a/stellar-contracts/EVENTS.md
+++ b/stellar-contracts/EVENTS.md
@@ -1,0 +1,38 @@
+# PetChain Contract Events
+
+All major contract actions emit events via `env.events().publish()` so frontends and backends can react to on-chain changes in real-time. Events are indexed by topic and optional key (e.g. `pet_id`) for efficient filtering.
+
+## Event list
+
+| Topic | When | Data structure | Index key |
+|-------|------|----------------|-----------|
+| **PetRegistered** | `register_pet()` | `PetRegisteredEvent`: pet_id, owner, name, species, timestamp | pet_id |
+| **PetUpdated** | `update_pet_profile()` | `PetUpdatedEvent`: pet_id, updated_by, timestamp | pet_id |
+| **RecordAdded** | `add_medical_record()` | `RecordAddedEvent`: pet_id, record_id, vet_address, timestamp | pet_id |
+| **VaccinationAdded** | `add_vaccination()` | `VaccinationAddedEvent`: vaccine_id, pet_id, veterinarian, vaccine_type, next_due_date, timestamp | pet_id |
+| **AccessGranted** | `grant_access()` | `AccessGrantedEvent`: pet_id, granter, grantee, access_level, expires_at, timestamp | pet_id |
+| **AccessRevoked** | `revoke_access()` | `AccessRevokedEvent`: pet_id, granter, grantee, timestamp | pet_id |
+| **PetOwnershipTransferred** | `transfer_ownership()` / multisig transfer | `PetOwnershipTransferredEvent`: pet_id, old_owner, new_owner, timestamp | (topic only or proposal id) |
+| **TagLinked** | `link_tag()` | `TagLinkedEvent`: tag_id, pet_id, owner, timestamp | pet_id |
+| **LostPetReported** | `report_lost()` | `LostPetReportedEvent`: alert_id, pet_id, reported_by, timestamp | pet_id |
+
+Additional events (same pattern):
+
+- **TAG_DEACTIVATED** / **TAG_REACTIVATED** – tag lifecycle
+- **MedicalRecordAdded** – legacy alias; prefer **RecordAdded** for new indexing
+- **TreatmentAdded**, **InsuranceAdded**, **InsuranceUpdated**, **InsuranceClaimSubmitted**, **InsuranceClaimStatusUpdated** – medical/insurance flows
+
+## Indexing
+
+- **By topic**: Subscribe to e.g. `PetRegistered` to see all new registrations.
+- **By key**: When the first topic element is `(topic, pet_id)`, indexers can filter by `pet_id` to get events for a single pet.
+- **By contract**: All events are emitted by the contract instance; filter by contract ID to get only PetChain events.
+
+## Usage
+
+Off-chain services should listen for these topics and persist or forward events for:
+
+- Real-time UI updates (e.g. “New vaccination recorded”)
+- Analytics and dashboards
+- Access and audit logs
+- Lost-pet alert feeds

--- a/stellar-contracts/src/test_events.rs
+++ b/stellar-contracts/src/test_events.rs
@@ -1,0 +1,181 @@
+//! Tests for contract event emission, event data, and indexing.
+//! Events enable off-chain tracking and real-time frontend/backend updates.
+
+use crate::*;
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events, Address, Env, String, TryFromVal,
+};
+
+fn register_test_pet(env: &Env, client: &PetChainContractClient, owner: &Address) -> u64 {
+    client.register_pet(
+        owner,
+        &String::from_str(env, "TestPet"),
+        &String::from_str(env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(env, "Breed"),
+        &String::from_str(env, "Brown"),
+        &20u32,
+        &None,
+        &PrivacyLevel::Public,
+    )
+}
+
+fn topic_matches(env: &Env, topics: &soroban_sdk::Vec<soroban_sdk::Val>, name: &str) -> bool {
+    if topics.len() == 0 {
+        return false;
+    }
+    let expected_str = String::from_str(env, name);
+    match topics.get(0) {
+        Some(v) => {
+            // Contract uses String::from_str for topic names
+            String::try_from_val(env, &v).map(|s| s == expected_str).unwrap_or(false)
+        }
+        None => false,
+    }
+}
+
+#[test]
+fn test_pet_registered_event_emission() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let pet_id = register_test_pet(&env, &client, &owner);
+
+    let events = env.events().all();
+    assert!(!events.is_empty(), "At least one event should be emitted");
+    let has_pet_registered = events
+        .iter()
+        .any(|(_, topics, _)| topic_matches(&env, &topics, "PetRegistered"));
+    assert!(has_pet_registered, "PetRegistered event should be emitted");
+    assert_eq!(pet_id, 1);
+}
+
+#[test]
+fn test_pet_registered_event_data() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let _pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Buddy"),
+        &String::from_str(&env, "2019-05-15"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Golden Retriever"),
+        &String::from_str(&env, "Golden"),
+        &25u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let events = env.events().all();
+    let reg_count = events
+        .iter()
+        .filter(|(_, topics, _)| topic_matches(&env, &topics, "PetRegistered"))
+        .count();
+    assert_eq!(reg_count, 1, "Exactly one PetRegistered event");
+    let has_multiple_topics = events
+        .iter()
+        .filter(|(_, topics, _)| topic_matches(&env, &topics, "PetRegistered"))
+        .any(|(_, topics, _)| topics.len() >= 1);
+    assert!(has_multiple_topics, "PetRegistered event should have topic data");
+}
+
+#[test]
+fn test_pet_updated_event_emission() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let pet_id = register_test_pet(&env, &client, &owner);
+
+    client.update_pet_profile(
+        &pet_id,
+        &String::from_str(&env, "UpdatedName"),
+        &String::from_str(&env, "2019-06-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Labrador"),
+        &String::from_str(&env, "Black"),
+        &28u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let events = env.events().all();
+    let has_pet_updated = events
+        .iter()
+        .any(|(_, topics, _)| topic_matches(&env, &topics, "PetUpdated"));
+    assert!(has_pet_updated, "PetUpdated event should be emitted");
+}
+
+#[test]
+fn test_lost_pet_reported_event_emission() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let pet_id = register_test_pet(&env, &client, &owner);
+
+    let _alert_id = client.report_lost(
+        &pet_id,
+        &String::from_str(&env, "Central Park"),
+        &Some(100u64),
+    );
+
+    let events = env.events().all();
+    let has_lost_reported = events
+        .iter()
+        .any(|(_, topics, _)| topic_matches(&env, &topics, "LostPetReported"));
+    assert!(has_lost_reported, "LostPetReported event should be emitted");
+}
+
+#[test]
+fn test_event_indexing_by_topic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    register_test_pet(&env, &client, &owner);
+    register_test_pet(&env, &client, &owner); // pet_id 2
+
+    let events = env.events().all();
+    let pet_registered_count = events
+        .iter()
+        .filter(|(_, topics, _)| topic_matches(&env, &topics, "PetRegistered"))
+        .count();
+    assert_eq!(pet_registered_count, 2, "Should index 2 PetRegistered events");
+}
+
+#[test]
+fn test_access_granted_event_emission() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let grantee = Address::generate(&env);
+    let pet_id = register_test_pet(&env, &client, &owner);
+
+    client.grant_access(&pet_id, &grantee, &AccessLevel::Full, &None);
+
+    let events = env.events().all();
+    let has_access_granted = events
+        .iter()
+        .any(|(_, topics, _)| topic_matches(&env, &topics, "AccessGranted"));
+    assert!(has_access_granted, "AccessGranted event should be emitted");
+}


### PR DESCRIPTION
## Emit events for major contract actions (off-chain tracking)

### Summary
Add and standardize event emission for major contract actions so frontends/backends can react to on-chain changes in real time.

### Why
Events allow off-chain systems to track contract state without polling. Indexing by topic and `pet_id` supports real-time UIs, analytics, and audit logs.

### Changes

**New event structs**
- `RecordAddedEvent` – pet_id, record_id, vet_address, timestamp (topic: **RecordAdded**)
- `PetUpdatedEvent` – pet_id, updated_by, timestamp (topic: **PetUpdated**)
- `LostPetReportedEvent` – alert_id, pet_id, reported_by, timestamp (topic: **LostPetReported**)
Closes #127 
**Emission**
- **PetUpdated** in `update_pet_profile()` after a successful update
- **LostPetReported** in `report_lost()` after creating the alert
- **RecordAdded** in `add_medical_record()` (replaces **MedicalRecordAdded** for this flow)
- **TagLinked** topic normalized from `TAG_LINKED` to **TagLinked**, with `pet_id` as index key

**Existing events** (unchanged): PetRegistered, VaccinationAdded, AccessGranted, AccessRevoked, PetOwnershipTransferred.

**Docs**
- `stellar-contracts/EVENTS.md` – list of events, when they fire, payloads, and indexing notes

**Tests** (`test_events.rs`)
- Event emission: PetRegistered, PetUpdated, LostPetReported, AccessGranted
- Event data: single PetRegistered with correct topic
- Event indexing: filter/count by topic (e.g. 2 PetRegistered)

**Other**
- Resolved duplicate `WeightEntry`: Nutrition type renamed to `NutritionWeightEntry`, usages updated
- `test_grooming` left commented out (depends on unimplemented contract methods)

### Checklist
- [x] `env.events().publish()` used for major actions
- [x] Event topics and payloads defined and documented
- [x] EVENTS.md added
- [x] Tests: emission, data, indexing