### PR TITLE
[389] Add Pagination to get_medical_records

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,17 @@ The PetChain smart contract manages pet registration, medical records, and owner
 
 ### Pet Management
 
+#### `get_pet_medical_records`
+Retrieves a paginated slice of medical records for a pet.
+
+**Parameters:**
+- `env: Env` - Contract environment
+- `pet_id: u64` - Pet identifier
+- `offset: u64` - Zero-based starting index into the pet's medical record history
+- `limit: u32` - Maximum number of records to return
+
+**Returns:** `Vec<MedicalRecord>` - Up to `limit` records starting at `offset`
+
 #### `register_pet`
 Registers a new pet on the blockchain.
 

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -69,6 +69,8 @@ mod test_insurance_claims;
 #[cfg(test)]
 mod test_insurance_comprehensive;
 #[cfg(test)]
+mod test_medical_records_pagination;
+#[cfg(test)]
 mod test_multisig_transfer;
 #[cfg(test)]
 mod test_nutrition;
@@ -3652,14 +3654,31 @@ impl PetChainContract {
         record
     }
 
-    pub fn get_pet_medical_records(env: Env, pet_id: u64) -> Vec<MedicalRecord> {
+    pub fn get_pet_medical_records(
+        env: Env,
+        pet_id: u64,
+        offset: u64,
+        limit: u32,
+    ) -> Vec<MedicalRecord> {
         let count = env
             .storage()
             .instance()
             .get::<MedicalKey, u64>(&MedicalKey::PetMedicalRecordCount(pet_id))
             .unwrap_or(0);
         let mut records = Vec::new(&env);
-        for i in 1..=count {
+        if count == 0 || limit == 0 || offset >= count {
+            return records;
+        }
+
+        let start_index = offset.saturating_add(1);
+        let requested_end = offset.saturating_add(limit as u64);
+        let end_index = if requested_end > count {
+            count
+        } else {
+            requested_end
+        };
+
+        for i in start_index..=end_index {
             if let Some(rid) = env
                 .storage()
                 .instance()

--- a/stellar-contracts/src/test_medical_records_pagination.rs
+++ b/stellar-contracts/src/test_medical_records_pagination.rs
@@ -1,0 +1,103 @@
+#[cfg(test)]
+mod test_medical_records_pagination {
+    use crate::{Gender, PetChainContract, PetChainContractClient, PrivacyLevel, Species};
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn setup() -> (
+        Env,
+        PetChainContractClient<'static>,
+        Address,
+        Address,
+        Address,
+        u64,
+    ) {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+        client.init_admin(&admin);
+
+        let owner = Address::generate(&env);
+        let vet = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Labrador"),
+            &String::from_str(&env, "Brown"),
+            &25u32,
+            &None,
+            &PrivacyLevel::Public,
+        );
+
+        client.register_vet(
+            &vet,
+            &String::from_str(&env, "Dr. Smith"),
+            &String::from_str(&env, "LIC-001"),
+            &String::from_str(&env, "General"),
+        );
+        client.verify_vet(&admin, &vet);
+
+        (env, client, admin, owner, vet, pet_id)
+    }
+
+    fn add_record(
+        client: &PetChainContractClient,
+        env: &Env,
+        pet_id: u64,
+        vet: &Address,
+        diagnosis: &str,
+    ) {
+        client.add_medical_record(
+            &pet_id,
+            vet,
+            &String::from_str(env, diagnosis),
+            &String::from_str(env, "Treatment"),
+            &soroban_sdk::Vec::new(env),
+            &String::from_str(env, "Notes"),
+        );
+    }
+
+    #[test]
+    fn returns_first_page_with_limit() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+        add_record(&client, &env, pet_id, &vet, "A");
+        add_record(&client, &env, pet_id, &vet, "B");
+        add_record(&client, &env, pet_id, &vet, "C");
+
+        let page = client.get_pet_medical_records(&pet_id, &0u64, &2u32);
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().diagnosis, String::from_str(&env, "A"));
+        assert_eq!(page.get(1).unwrap().diagnosis, String::from_str(&env, "B"));
+    }
+
+    #[test]
+    fn returns_middle_page_with_offset() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+        add_record(&client, &env, pet_id, &vet, "A");
+        add_record(&client, &env, pet_id, &vet, "B");
+        add_record(&client, &env, pet_id, &vet, "C");
+        add_record(&client, &env, pet_id, &vet, "D");
+
+        let page = client.get_pet_medical_records(&pet_id, &1u64, &2u32);
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().diagnosis, String::from_str(&env, "B"));
+        assert_eq!(page.get(1).unwrap().diagnosis, String::from_str(&env, "C"));
+    }
+
+    #[test]
+    fn returns_empty_when_offset_out_of_range_or_limit_zero() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+        add_record(&client, &env, pet_id, &vet, "Only");
+
+        let out_of_range = client.get_pet_medical_records(&pet_id, &5u64, &2u32);
+        assert_eq!(out_of_range.len(), 0);
+
+        let zero_limit = client.get_pet_medical_records(&pet_id, &0u64, &0u32);
+        assert_eq!(zero_limit.len(), 0);
+    }
+}

--- a/stellar-contracts/src/test_search_medical_records.rs
+++ b/stellar-contracts/src/test_search_medical_records.rs
@@ -245,4 +245,28 @@ mod test_search_medical_records {
         assert_eq!(flu_results.len(), 5);
         assert_eq!(allergy_results.len(), 5);
     }
+
+    // ---- pagination ----
+
+    #[test]
+    fn test_get_pet_medical_records_pagination_window() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+        add_record(&client, &env, pet_id, &vet, "A");
+        add_record(&client, &env, pet_id, &vet, "B");
+        add_record(&client, &env, pet_id, &vet, "C");
+
+        let page = client.get_pet_medical_records(&pet_id, &1u64, &2u32);
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().diagnosis, String::from_str(&env, "B"));
+        assert_eq!(page.get(1).unwrap().diagnosis, String::from_str(&env, "C"));
+    }
+
+    #[test]
+    fn test_get_pet_medical_records_pagination_out_of_bounds() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+        add_record(&client, &env, pet_id, &vet, "Only");
+
+        assert_eq!(client.get_pet_medical_records(&pet_id, &5u64, &2u32).len(), 0);
+        assert_eq!(client.get_pet_medical_records(&pet_id, &0u64, &0u32).len(), 0);
+    }
 }


### PR DESCRIPTION
Closes #389

## What changed
- updated `get_pet_medical_records` to accept `offset` and `limit`
- implemented bounded slice retrieval over indexed medical records
- added pagination tests for first page, middle page, and out-of-range/zero-limit behavior
- updated `API.md` with the paginated method contract

## Validation
- `cargo test` (in `stellar-contracts`) passes: 114 passed, 0 failed

Made with [Cursor](https://cursor.com)