### PR TITLE
feat: implement get_behavior_improvements with chronological sorting

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -5879,19 +5879,50 @@ impl PetChainContract {
         milestones
     }
 
+    /// Returns all behavior records for a specific pet and behavior type,
+    /// sorted by `recorded_at` in ascending order (oldest → newest).
+    ///
+    /// This enables trend analysis: callers can inspect whether severity
+    /// decreases over time without this function computing the trend itself.
+    ///
+    /// Returns an empty Vec if the pet has no records or no records of the
+    /// requested type — never panics on missing data.
     pub fn get_behavior_improvements(
         env: Env,
         pet_id: u64,
         behavior_type: BehaviorType,
     ) -> Vec<BehaviorRecord> {
+        // Fetch all records for this pet; returns empty Vec if pet is unknown.
         let history = Self::get_behavior_history(env.clone(), pet_id);
-        let mut filtered = Vec::new(&env);
 
+        // Filter to the requested behavior type.
+        let mut filtered: soroban_sdk::Vec<BehaviorRecord> = Vec::new(&env);
         for record in history.iter() {
             if record.behavior_type == behavior_type {
                 filtered.push_back(record);
             }
         }
+
+        // Sort ascending by recorded_at using insertion sort.
+        // Soroban's no_std Vec doesn't expose a sort method, so we do it manually.
+        // Insertion sort is stable, giving deterministic ordering for equal timestamps.
+        let len = filtered.len();
+        for i in 1..len {
+            let mut j = i;
+            while j > 0 {
+                let a = filtered.get(j - 1).unwrap();
+                let b = filtered.get(j).unwrap();
+                if a.recorded_at > b.recorded_at {
+                    // Swap by rebuilding the vector segment.
+                    filtered.set(j - 1, b);
+                    filtered.set(j, a);
+                    j -= 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
         filtered
     }
 

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -6328,6 +6328,39 @@ impl PetChainContract {
 
         (total_duration, total_distance)
     }
+
+    /// Returns the total duration (minutes) and total distance (meters) for all
+    /// activity records of a given pet whose `recorded_at` timestamp falls within
+    /// the inclusive range [from_date, to_date].
+    ///
+    /// Boundary behaviour:
+    ///   - Both endpoints are inclusive: `from_date <= recorded_at <= to_date`.
+    ///   - If `from_date > to_date` the range is considered invalid and (0, 0) is
+    ///     returned immediately without iterating any records.
+    ///   - If no records exist in the range, (0, 0) is returned.
+    ///
+    /// Arithmetic is performed with `saturating_add` to prevent overflow panics.
+    pub fn get_activity_summary(env: Env, pet_id: u64, from_date: u64, to_date: u64) -> (u32, u32) {
+        // Guard: invalid range → return early
+        if from_date > to_date {
+            return (0, 0);
+        }
+
+        let history = Self::get_activity_history(env, pet_id);
+
+        let mut total_duration = 0u32;
+        let mut total_distance = 0u32;
+
+        for record in history.iter() {
+            // Inclusive boundary check
+            if record.recorded_at >= from_date && record.recorded_at <= to_date {
+                total_duration = total_duration.saturating_add(record.duration_minutes);
+                total_distance = total_distance.saturating_add(record.distance_meters);
+            }
+        }
+
+        (total_duration, total_distance)
+    }
     // --- BREEDING RECORDS SYSTEM ---
     pub fn add_breeding_record(
         env: Env,

--- a/stellar-contracts/src/test_activity.rs
+++ b/stellar-contracts/src/test_activity.rs
@@ -401,3 +401,177 @@ fn test_archive_nonexistent_pet() {
 
     client.archive_pet(&999);
 }
+
+// ── get_activity_summary tests ────────────────────────────────────────────────
+
+/// Helper: register a pet and return its id.
+fn setup_pet(env: &Env, client: &PetChainContractClient) -> u64 {
+    let owner = Address::generate(env);
+    client.init_admin(&owner);
+    client.register_pet(
+        &owner,
+        &String::from_str(env, "Max"),
+        &String::from_str(env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(env, "Golden Retriever"),
+        &String::from_str(env, "Golden"),
+        &30,
+        &None,
+        &PrivacyLevel::Public,
+    )
+}
+
+#[test]
+fn test_activity_summary_valid_range() {
+    // Activities within the range should be summed correctly.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+    let pet_id = setup_pet(&env, &client);
+
+    // Both records land at timestamp 1_000 (current ledger time).
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30,
+        &5,
+        &2000,
+        &String::from_str(&env, "Walk"),
+    );
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Run,
+        &20,
+        &7,
+        &1500,
+        &String::from_str(&env, "Run"),
+    );
+
+    let (duration, distance) = client.get_activity_summary(&pet_id, &500, &2000);
+    assert_eq!(duration, 50);
+    assert_eq!(distance, 3500);
+}
+
+#[test]
+fn test_activity_summary_partial_overlap() {
+    // Only records whose timestamp falls inside [from, to] should be counted.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    // Record 1 at t=100
+    env.ledger().set_timestamp(100);
+    let pet_id = setup_pet(&env, &client);
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30,
+        &5,
+        &2000,
+        &String::from_str(&env, "Inside range"),
+    );
+
+    // Record 2 at t=5000 – outside the query range below
+    env.ledger().set_timestamp(5000);
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Run,
+        &20,
+        &7,
+        &1500,
+        &String::from_str(&env, "Outside range"),
+    );
+
+    // Query only covers t=0..=200
+    let (duration, distance) = client.get_activity_summary(&pet_id, &0, &200);
+    assert_eq!(duration, 30);
+    assert_eq!(distance, 2000);
+}
+
+#[test]
+fn test_activity_summary_empty_range() {
+    // No activities exist in the queried window → (0, 0).
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(9999);
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+    let pet_id = setup_pet(&env, &client);
+
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Play,
+        &45,
+        &3,
+        &0,
+        &String::from_str(&env, "Play"),
+    );
+
+    // Query a window that doesn't include t=9999
+    let (duration, distance) = client.get_activity_summary(&pet_id, &0, &100);
+    assert_eq!(duration, 0);
+    assert_eq!(distance, 0);
+}
+
+#[test]
+fn test_activity_summary_single_activity_on_boundary() {
+    // A record exactly on from_date or to_date must be included (inclusive).
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(500);
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+    let pet_id = setup_pet(&env, &client);
+
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Training,
+        &60,
+        &4,
+        &3000,
+        &String::from_str(&env, "Boundary activity"),
+    );
+
+    // Exact lower boundary
+    let (d1, dist1) = client.get_activity_summary(&pet_id, &500, &500);
+    assert_eq!(d1, 60);
+    assert_eq!(dist1, 3000);
+
+    // Exact upper boundary
+    let (d2, dist2) = client.get_activity_summary(&pet_id, &0, &500);
+    assert_eq!(d2, 60);
+    assert_eq!(dist2, 3000);
+}
+
+#[test]
+fn test_activity_summary_invalid_range() {
+    // from_date > to_date → (0, 0) without panicking.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+    let pet_id = setup_pet(&env, &client);
+
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30,
+        &5,
+        &2000,
+        &String::from_str(&env, "Walk"),
+    );
+
+    let (duration, distance) = client.get_activity_summary(&pet_id, &2000, &500);
+    assert_eq!(duration, 0);
+    assert_eq!(distance, 0);
+}

--- a/stellar-contracts/src/test_behavior.rs
+++ b/stellar-contracts/src/test_behavior.rs
@@ -304,6 +304,169 @@ fn test_empty_training_milestones() {
     assert_eq!(milestones.len(), 0);
 }
 
+// --- get_behavior_improvements tests ---
+
+/// Only records matching the requested behavior type are returned.
+#[test]
+fn test_improvements_filters_by_behavior_type() {
+    let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Aggression,
+        &7,
+        &String::from_str(&env, "Aggression record"),
+    );
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Anxiety,
+        &5,
+        &String::from_str(&env, "Anxiety record"),
+    );
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Aggression,
+        &4,
+        &String::from_str(&env, "Second aggression record"),
+    );
+
+    let results = client.get_behavior_improvements(&pet_id, &BehaviorType::Aggression);
+    assert_eq!(results.len(), 2);
+    for i in 0..results.len() {
+        assert_eq!(results.get(i).unwrap().behavior_type, BehaviorType::Aggression);
+    }
+
+    let anxiety_results = client.get_behavior_improvements(&pet_id, &BehaviorType::Anxiety);
+    assert_eq!(anxiety_results.len(), 1);
+}
+
+/// Records are returned sorted by recorded_at ascending (oldest first).
+#[test]
+fn test_improvements_sorted_chronologically() {
+    let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    // Advance ledger time between records so timestamps differ.
+    env.ledger().set_timestamp(1000);
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Training,
+        &8,
+        &String::from_str(&env, "First record (t=1000)"),
+    );
+
+    env.ledger().set_timestamp(3000);
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Training,
+        &5,
+        &String::from_str(&env, "Third record (t=3000)"),
+    );
+
+    env.ledger().set_timestamp(2000);
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Training,
+        &6,
+        &String::from_str(&env, "Second record (t=2000)"),
+    );
+
+    let results = client.get_behavior_improvements(&pet_id, &BehaviorType::Training);
+    assert_eq!(results.len(), 3);
+
+    // Verify ascending order by timestamp.
+    assert_eq!(results.get(0).unwrap().recorded_at, 1000);
+    assert_eq!(results.get(1).unwrap().recorded_at, 2000);
+    assert_eq!(results.get(2).unwrap().recorded_at, 3000);
+}
+
+/// Decreasing severity over time reflects a genuine improvement trend.
+#[test]
+fn test_improvements_trend_severity_decreasing() {
+    let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    env.ledger().set_timestamp(100);
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Anxiety,
+        &5,
+        &String::from_str(&env, "Initial high anxiety"),
+    );
+
+    env.ledger().set_timestamp(200);
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Anxiety,
+        &3,
+        &String::from_str(&env, "Moderate improvement"),
+    );
+
+    env.ledger().set_timestamp(300);
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Anxiety,
+        &1,
+        &String::from_str(&env, "Near full recovery"),
+    );
+
+    let results = client.get_behavior_improvements(&pet_id, &BehaviorType::Anxiety);
+    assert_eq!(results.len(), 3);
+
+    // Severity should decrease as time progresses (improvement trend).
+    assert_eq!(results.get(0).unwrap().severity, 5);
+    assert_eq!(results.get(1).unwrap().severity, 3);
+    assert_eq!(results.get(2).unwrap().severity, 1);
+}
+
+/// Returns an empty Vec when no records match the requested type.
+#[test]
+fn test_improvements_empty_when_no_matching_type() {
+    let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Aggression,
+        &5,
+        &String::from_str(&env, "Only aggression record"),
+    );
+
+    // Requesting a type that has no records should return empty, not panic.
+    let results = client.get_behavior_improvements(&pet_id, &BehaviorType::Socialization);
+    assert_eq!(results.len(), 0);
+}
+
+/// Returns an empty Vec for a pet that has no behavior records at all.
+#[test]
+fn test_improvements_empty_for_pet_with_no_records() {
+    let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let results = client.get_behavior_improvements(&pet_id, &BehaviorType::Training);
+    assert_eq!(results.len(), 0);
+}
+
+/// Single matching record is returned correctly without panicking.
+#[test]
+fn test_improvements_single_record() {
+    let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    client.add_behavior_record(
+        &pet_id,
+        &BehaviorType::Socialization,
+        &4,
+        &String::from_str(&env, "Only socialization record"),
+    );
+
+    let results = client.get_behavior_improvements(&pet_id, &BehaviorType::Socialization);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.get(0).unwrap().behavior_type, BehaviorType::Socialization);
+    assert_eq!(results.get(0).unwrap().severity, 4);
+}
+
 #[test]
 fn test_all_behavior_types() {
     let (env, _owner, _admin, pet_id, contract_id) = setup_test_env();


### PR DESCRIPTION
closes #416 


## Changes
- `stellar-contracts/src/lib.rs` — implemented `get_behavior_improvements` to filter behavior records by type and sort them by `recorded_at` ascending using a stable insertion sort (required since Soroban's `no_std` Vec has no built-in sort method)
- `stellar-contracts/src/test_behavior.rs` — added 6 new tests covering all edge cases

## How it works
The function fetches all behavior records for a pet, filters to the requested `BehaviorType`, then sorts by `recorded_at` ascending (oldest → newest). Trend analysis (e.g. severity decreasing over time) is left to the caller — this function only returns ordered data.

## Tests added
- Filters correctly by behavior type (mixed types, only requested type returned)
- Returns results sorted chronologically (records inserted out of order, verified ascending)
- Improvement trend scenario (severity 5 → 3 → 1 across timestamps)
- Empty result when no records match the requested type
- Empty result for a pet with no records at all (no panic)
- Single record edge case



