### PR TITLE
feat: implement get_medications with pagination and active filter

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -5208,6 +5208,35 @@ impl PetChainContract {
         id
     }
 
+    pub fn get_medications(env: Env, pet_id: u64, offset: u64, limit: u32) -> Vec<Medication> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&MedicalKey::PetMedicationCount(pet_id))
+            .unwrap_or(0);
+
+        let mut result = Vec::new(&env);
+        let start_index = offset + 1; // indices are 1-based
+        let end_index = (offset + limit as u64).min(count);
+
+        for i in start_index..=end_index {
+            if let Some(med_id) = env
+                .storage()
+                .instance()
+                .get::<MedicalKey, u64>(&MedicalKey::PetMedicationIndex((pet_id, i)))
+            {
+                if let Some(med) = env
+                    .storage()
+                    .instance()
+                    .get::<MedicalKey, Medication>(&MedicalKey::GlobalMedication(med_id))
+                {
+                    result.push_back(med);
+                }
+            }
+        }
+        result
+    }
+
     pub fn get_active_medications(env: Env, pet_id: u64) -> Vec<Medication> {
         let count: u64 = env
             .storage()

--- a/stellar-contracts/src/test_nutrition.rs
+++ b/stellar-contracts/src/test_nutrition.rs
@@ -80,3 +80,159 @@ fn test_weight_entries_and_pet_update() {
     let profile = client.get_pet(&pet_id, &owner).unwrap();
     assert_eq!(profile.weight, 8u32);
 }
+
+#[test]
+fn test_get_medications_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+
+    client.init_admin(&admin);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Rex"),
+        &String::from_str(&env, "2019-05-10"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Labrador"),
+        &String::from_str(&env, "Black"),
+        &30u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    // Register and verify vet
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr. Smith"),
+        &String::from_str(&env, "LIC-001"),
+        &String::from_str(&env, "General"),
+    );
+    client.verify_vet(&admin, &vet);
+
+    // Add 3 medications
+    client.add_medication(
+        &pet_id,
+        &String::from_str(&env, "Amoxicillin"),
+        &String::from_str(&env, "250mg"),
+        &String::from_str(&env, "Twice daily"),
+        &1000u64,
+        &None,
+        &vet,
+    );
+    client.add_medication(
+        &pet_id,
+        &String::from_str(&env, "Prednisone"),
+        &String::from_str(&env, "10mg"),
+        &String::from_str(&env, "Once daily"),
+        &2000u64,
+        &None,
+        &vet,
+    );
+    client.add_medication(
+        &pet_id,
+        &String::from_str(&env, "Metronidazole"),
+        &String::from_str(&env, "500mg"),
+        &String::from_str(&env, "Three times daily"),
+        &3000u64,
+        &None,
+        &vet,
+    );
+
+    // Get all medications (offset=0, limit=10)
+    let all = client.get_medications(&pet_id, &0u64, &10u32);
+    assert_eq!(all.len(), 3);
+    assert_eq!(all.get(0).unwrap().name, String::from_str(&env, "Amoxicillin"));
+    assert_eq!(all.get(1).unwrap().name, String::from_str(&env, "Prednisone"));
+    assert_eq!(all.get(2).unwrap().name, String::from_str(&env, "Metronidazole"));
+
+    // Pagination: offset=1, limit=2 → should return 2nd and 3rd
+    let page = client.get_medications(&pet_id, &1u64, &2u32);
+    assert_eq!(page.len(), 2);
+    assert_eq!(page.get(0).unwrap().name, String::from_str(&env, "Prednisone"));
+    assert_eq!(page.get(1).unwrap().name, String::from_str(&env, "Metronidazole"));
+
+    // Offset beyond count → empty
+    let empty = client.get_medications(&pet_id, &10u64, &5u32);
+    assert_eq!(empty.len(), 0);
+}
+
+#[test]
+fn test_get_active_medications_filter() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+
+    client.init_admin(&admin);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Milo"),
+        &String::from_str(&env, "2020-07-15"),
+        &Gender::Male,
+        &Species::Cat,
+        &String::from_str(&env, "Persian"),
+        &String::from_str(&env, "White"),
+        &5u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr. Jones"),
+        &String::from_str(&env, "LIC-002"),
+        &String::from_str(&env, "Feline"),
+    );
+    client.verify_vet(&admin, &vet);
+
+    // Add two medications
+    let med1_id = client.add_medication(
+        &pet_id,
+        &String::from_str(&env, "Doxycycline"),
+        &String::from_str(&env, "100mg"),
+        &String::from_str(&env, "Once daily"),
+        &1000u64,
+        &None,
+        &vet,
+    );
+    client.add_medication(
+        &pet_id,
+        &String::from_str(&env, "Furosemide"),
+        &String::from_str(&env, "20mg"),
+        &String::from_str(&env, "Twice daily"),
+        &2000u64,
+        &None,
+        &vet,
+    );
+
+    // Both should be active initially
+    let active = client.get_active_medications(&pet_id);
+    assert_eq!(active.len(), 2);
+
+    // Mark first medication as completed (inactive)
+    client.mark_medication_completed(&med1_id);
+
+    // Now only one should be active
+    let active_after = client.get_active_medications(&pet_id);
+    assert_eq!(active_after.len(), 1);
+    assert_eq!(active_after.get(0).unwrap().name, String::from_str(&env, "Furosemide"));
+    assert!(active_after.get(0).unwrap().active);
+
+    // get_medications still returns all (including inactive)
+    let all = client.get_medications(&pet_id, &0u64, &10u32);
+    assert_eq!(all.len(), 2);
+}


### PR DESCRIPTION
- Add get_medications(env, pet_id, offset, limit) -> Vec<Medication> Retrieves paginated medication history for a pet using the existing PetMedicationIndex. Indices are 1-based; offset is 0-based so start_index = offset + 1.

- get_active_medications(env, pet_id) already existed and is unchanged. It filters medications where active == true.

- Add two tests in test_nutrition.rs:
  * test_get_medications_pagination: verifies full list retrieval, correct pagination window, and empty result beyond count.
  * test_get_active_medications_filter: verifies that marking a medication completed removes it from the active list while get_medications still returns all records.

Closes: feature/medication-history (200 pts)

## Description
Brief description of changes made.

## Related Issue
Fixes #[issue number]

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- [ ] Added new contract function(s)
- [ ] Modified existing function(s)
- [ ] Added/updated tests
- [ ] Updated documentation
- [ ] Added new data structures

## Testing
- [ ] All existing tests pass
- [ ] Added tests for new functionality
- [ ] Tested on local environment
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information or context about the PR. closes #398 