### PR TITLE
[439] Complete test_get_pet_access_control.rs Test Suite

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -65,8 +65,6 @@ mod test_behavior;
 // #[cfg(test)]
 // mod test_disputes;  // Has compilation errors - missing DisputeStatus
 #[cfg(test)]
-mod test_consent_pagination;
-#[cfg(test)]
 mod test_emergency_contacts;
 #[cfg(test)]
 mod test_emergency_override;
@@ -1641,9 +1639,18 @@ impl PetChainContract {
             .instance()
             .get::<DataKey, Pet>(&DataKey::Pet(id))
         {
-            let _caller = caller;            // For now, we decrypt if Public, or we assume this function decrypts for the client to see.
-            // Real privacy requires off-chain key management.
-            // We will proceed with decryption to return the Profile.
+            // Enforce access control based on privacy level.
+            let allowed = match pet.privacy_level {
+                PrivacyLevel::Public => true,
+                PrivacyLevel::Restricted => {
+                    let access = Self::check_access(env.clone(), id, caller.clone());
+                    !matches!(access, AccessLevel::None)
+                }
+                PrivacyLevel::Private => pet.owner == caller,
+            };
+            if !allowed {
+                return None;
+            }
 
             let key = Self::get_encryption_key(&env);
 

--- a/stellar-contracts/src/test_get_pet_access_control.rs
+++ b/stellar-contracts/src/test_get_pet_access_control.rs
@@ -10,7 +10,7 @@ mod test_get_pet_access_control {
     use crate::{
         AccessLevel, Gender, PetChainContract, PetChainContractClient, PrivacyLevel, Species,
     };
-    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
 
     // ---- helpers ----
 
@@ -145,13 +145,35 @@ mod test_get_pet_access_control {
         let grantee = Address::generate(&env);
         let pet_id = register(&client, &env, &owner, PrivacyLevel::Restricted);
 
-        // Grant that expired in the past (timestamp 1 = far in the past).
-        client.grant_access(&pet_id, &grantee, &AccessLevel::Full, &Some(1u64));
+        // Grant with expiry at timestamp 100.
+        let expires_at: u64 = 100;
+        client.grant_access(&pet_id, &grantee, &AccessLevel::Full, &Some(expires_at));
+
+        // Advance ledger past the expiry so the grant is expired.
+        env.ledger().with_mut(|l| l.timestamp = expires_at + 1);
 
         let result = client.get_pet(&pet_id, &grantee);
         assert!(
             result.is_none(),
             "expired grant must not allow access to a Restricted pet"
+        );
+    }
+
+    #[test]
+    fn test_restricted_pet_revoked_grant_cannot_read() {
+        let (env, client) = setup();
+        let owner = Address::generate(&env);
+        let grantee = Address::generate(&env);
+        let pet_id = register(&client, &env, &owner, PrivacyLevel::Restricted);
+
+        // Grant and then immediately revoke access.
+        client.grant_access(&pet_id, &grantee, &AccessLevel::Full, &None);
+        client.revoke_access(&pet_id, &grantee);
+
+        let result = client.get_pet(&pet_id, &grantee);
+        assert!(
+            result.is_none(),
+            "revoked grant must not allow access to a Restricted pet"
         );
     }
 


### PR DESCRIPTION
Closes #439

## Summary

Completes the 	est_get_pet_access_control.rs test suite by:

1. **Enforcing access control in get_pet** — The function previously ignored the caller parameter and always returned the pet. It now enforces privacy-level rules:
   - Public: accessible to any caller
   - Restricted: accessible only to the owner or a caller with an active, non-expired grant
   - Private: accessible only to the owner (grants cannot override this)

2. **Adding revoked-grant test** — 	est_restricted_pet_revoked_grant_cannot_read verifies that a grant revoked via evoke_access no longer allows read access.

3. **Fixing expired-grant test** — Updated 	est_restricted_pet_expired_grant_cannot_read to advance the ledger timestamp past the grant expiry using env.ledger().with_mut(|l| l.timestamp = expires_at + 1), matching the pattern used in the existing 	est_access_control.rs suite.

4. **Fixed duplicate module declaration** — Removed an erroneous duplicate mod test_consent_pagination that caused compilation errors.

## Test Results

All 13 tests pass:
- owner access (Public / Restricted / Private)
- stranger access (Public ✓, Restricted ✗, Private ✗)
- granted access: Basic and Full on Restricted
- expired grant on Restricted ✗
- revoked grant on Restricted ✗
- Full grant on Private ✗
- non-existent pet → None