### PR TITLE
feat: add get_admins and get_admin_threshold public functions

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -1339,6 +1339,32 @@ impl PetChainContract {
             .set(&SystemKey::AdminThreshold, &threshold);
     }
 
+    pub fn get_admins(env: Env) -> Vec<Address> {
+        if let Some(admin) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::Admin)
+        {
+            let mut admins = Vec::new(&env);
+            admins.push_back(admin);
+            return admins;
+        }
+        env.storage()
+            .instance()
+            .get(&SystemKey::Admins)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_admin_threshold(env: Env) -> u32 {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return 1u32;
+        }
+        env.storage()
+            .instance()
+            .get(&SystemKey::AdminThreshold)
+            .unwrap_or(1u32)
+    }
+
     fn update_vet_stats(
         env: &Env,
         vet: &Address,

--- a/stellar-contracts/src/test_admin_initialization.rs
+++ b/stellar-contracts/src/test_admin_initialization.rs
@@ -181,3 +181,50 @@ fn test_multisig_admin_methods_work_after_initialization() {
     // Approving with the other admin should work
     client.approve_proposal(&admin2, &proposal_id);
 }
+
+#[test]
+fn test_get_admins_single_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.init_admin(&admin);
+
+    let admins = client.get_admins();
+    assert_eq!(admins.len(), 1);
+    assert_eq!(admins.get(0).unwrap(), admin);
+    assert_eq!(client.get_admin_threshold(), 1u32);
+}
+
+#[test]
+fn test_get_admins_multisig() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let mut admins_vec = soroban_sdk::Vec::new(&env);
+    admins_vec.push_back(admin1.clone());
+    admins_vec.push_back(admin2.clone());
+
+    client.init_multisig(&admin1, &admins_vec, &2u32);
+
+    let admins = client.get_admins();
+    assert_eq!(admins.len(), 2);
+    assert_eq!(client.get_admin_threshold(), 2u32);
+}
+
+#[test]
+fn test_get_admins_no_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admins = client.get_admins();
+    assert_eq!(admins.len(), 0);
+}


### PR DESCRIPTION
Implements get_admins(env) -> Vec<Address> which returns the full admin list, handling both legacy single-admin (DataKey::Admin) and multisig (SystemKey::Admins) configurations. Implements get_admin_threshold(env) -> u32 which returns 1 for single-admin mode and the stored threshold for multisig. Both return safe defaults when no admin is configured.

Closes #429

## Description
Brief description of changes made.

## Related Issue
Fixes #[issue number]

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- [ ] Added new contract function(s)
- [ ] Modified existing function(s)
- [ ] Added/updated tests
- [ ] Updated documentation
- [ ] Added new data structures

## Testing
- [ ] All existing tests pass
- [ ] Added tests for new functionality
- [ ] Tested on local environment
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information or context about the PR.