### PR TITLE
feat: add get_grooming_record function to retrieve record by ID

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -6514,6 +6514,12 @@ impl PetChainContract {
         }
         total
     }
+
+    pub fn get_grooming_record(env: Env, record_id: u64) -> Option<GroomingRecord> {
+        env.storage()
+            .instance()
+            .get(&GroomingKey::GroomingRecord(record_id))
+    }
 }
 
 // --- OVERFLOW-SAFE COUNTER HELPER ---

--- a/stellar-contracts/src/test_grooming.rs
+++ b/stellar-contracts/src/test_grooming.rs
@@ -238,3 +238,58 @@ fn test_empty_grooming_history() {
     let expenses = client.get_grooming_expenses(&pet_id);
     assert_eq!(expenses, 0);
 }
+
+#[test]
+fn test_get_grooming_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    client.init_admin(&admin);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Buddy"),
+        &String::from_str(&env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Golden Retriever"),
+        &String::from_str(&env, "Golden"),
+        &30,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let record_id = client.add_grooming_record(
+        &pet_id,
+        &String::from_str(&env, "Full Grooming"),
+        &String::from_str(&env, "Pet Spa"),
+        &env.ledger().timestamp(),
+        &(env.ledger().timestamp() + 2592000),
+        &5000,
+        &String::from_str(&env, "Haircut and bath"),
+    );
+
+    let record = client.get_grooming_record(&record_id).unwrap();
+    assert_eq!(record.id, record_id);
+    assert_eq!(record.pet_id, pet_id);
+    assert_eq!(record.cost, 5000);
+    assert_eq!(record.service_type, String::from_str(&env, "Full Grooming"));
+}
+
+#[test]
+fn test_get_grooming_record_nonexistent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let result = client.get_grooming_record(&999u64);
+    assert!(result.is_none());
+}


### PR DESCRIPTION
Implements get_grooming_record(env, record_id) -> Option<GroomingRecord> for direct lookup of a grooming record by its ID. Returns None for a non-existent record_id, complementing the existing get_grooming_history.

Closes #420

## Description
Brief description of changes made.

## Related Issue
Fixes #[issue number]

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- [ ] Added new contract function(s)
- [ ] Modified existing function(s)
- [ ] Added/updated tests
- [ ] Updated documentation
- [ ] Added new data structures

## Testing
- [ ] All existing tests pass
- [ ] Added tests for new functionality
- [ ] Tested on local environment
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information or context about the PR.