### PR TITLE
feat: add get_current_diet_plan convenience function

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -2660,6 +2660,21 @@ impl PetChainContract {
         history
     }
 
+    pub fn get_current_diet_plan(env: Env, pet_id: u64) -> Option<DietPlan> {
+        let history = Self::get_diet_history(env, pet_id);
+        let mut current: Option<DietPlan> = None;
+        for plan in history.iter() {
+            let replace = match current {
+                None => true,
+                Some(ref c) => plan.created_at > c.created_at,
+            };
+            if replace {
+                current = Some(plan);
+            }
+        }
+        current
+    }
+
     pub fn add_weight_entry(env: Env, pet_id: u64, weight: u32) -> bool {
         let mut pet: Pet = env
             .storage()

--- a/stellar-contracts/src/test_nutrition.rs
+++ b/stellar-contracts/src/test_nutrition.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String, Vec};
 
 #[test]
 fn test_set_and_get_diet_plan() {
@@ -79,4 +79,80 @@ fn test_weight_entries_and_pet_update() {
 
     let profile = client.get_pet(&pet_id, &owner).unwrap();
     assert_eq!(profile.weight, 8u32);
+}
+
+#[test]
+fn test_get_current_diet_plan() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Max"),
+        &String::from_str(&env, "2019-05-10"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Labrador"),
+        &String::from_str(&env, "Black"),
+        &30u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let restrictions = Vec::new(&env);
+    let allergies = Vec::new(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.set_diet_plan(
+        &pet_id,
+        &String::from_str(&env, "Dry Kibble"),
+        &String::from_str(&env, "200g"),
+        &String::from_str(&env, "Twice daily"),
+        &restrictions,
+        &allergies,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 2000);
+    client.set_diet_plan(
+        &pet_id,
+        &String::from_str(&env, "Wet Food"),
+        &String::from_str(&env, "300g"),
+        &String::from_str(&env, "Three times daily"),
+        &restrictions,
+        &allergies,
+    );
+
+    let current = client.get_current_diet_plan(&pet_id).unwrap();
+    assert_eq!(current.food_type, String::from_str(&env, "Wet Food"));
+    assert_eq!(current.created_at, 2000);
+}
+
+#[test]
+fn test_get_current_diet_plan_no_plans() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Rex"),
+        &String::from_str(&env, "2022-01-15"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Poodle"),
+        &String::from_str(&env, "White"),
+        &10u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let result = client.get_current_diet_plan(&pet_id);
+    assert!(result.is_none());
 }


### PR DESCRIPTION
Implements a public get_current_diet_plan(env, pet_id) -> Option<DietPlan> that returns the most recently created diet plan for a pet by comparing created_at timestamps. Returns None when no plans exist.

Closes #419

## Description
Brief description of changes made.

## Related Issue
Fixes #[issue number]

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- [ ] Added new contract function(s)
- [ ] Modified existing function(s)
- [ ] Added/updated tests
- [ ] Updated documentation
- [ ] Added new data structures

## Testing
- [ ] All existing tests pass
- [ ] Added tests for new functionality
- [ ] Tested on local environment
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information or context about the PR.