### PR TITLE
feat: get all active vets

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -609,6 +609,8 @@ pub enum DataKey {
     // Vet verification keys
     Vet(Address),
     VetLicense(String),
+    VetCount,
+    VetIndex(u64),
     Admin,
 
     // Contract Upgrade keys
@@ -2240,7 +2242,59 @@ impl PetChainContract {
             .instance()
             .set(&DataKey::VetLicense(license_number), &vet_address);
 
+        let vet_count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VetCount)
+            .unwrap_or(0)
+            + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::VetCount, &vet_count);
+        env.storage()
+            .instance()
+            .set(&DataKey::VetIndex(vet_count), &vet_address);
+
         true
+    }
+
+    pub fn get_verified_vets(env: Env, offset: u64, limit: u32) -> Vec<Vet> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::VetCount)
+            .unwrap_or(0);
+        let mut result = Vec::new(&env);
+        if count == 0 || limit == 0 {
+            return result;
+        }
+        let mut skipped = 0u64;
+        for i in 1..=count {
+            if let Some(addr) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Address>(&DataKey::VetIndex(i))
+            {
+                if let Some(vet) = env
+                    .storage()
+                    .instance()
+                    .get::<DataKey, Vet>(&DataKey::Vet(addr))
+                {
+                    if !vet.verified {
+                        continue;
+                    }
+                    if skipped < offset {
+                        skipped += 1;
+                        continue;
+                    }
+                    result.push_back(vet);
+                    if result.len() >= limit {
+                        break;
+                    }
+                }
+            }
+        }
+        result
     }
 
     pub fn verify_vet(env: Env, admin: Address, vet_address: Address) -> bool {

--- a/stellar-contracts/src/test_access_control.rs
+++ b/stellar-contracts/src/test_access_control.rs
@@ -939,3 +939,87 @@ fn test_get_vaccination_history_pagination_limit_zero() {
     let history = client.get_vaccination_history(&pet_id, &0u64, &0u32);
     assert_eq!(history.len(), 0);
 }
+
+#[test]
+fn test_get_verified_vets_only_returns_verified() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.init_admin(&admin);
+
+    let vet1 = Address::generate(&env);
+    let vet2 = Address::generate(&env);
+
+    client.register_vet(
+        &vet1,
+        &String::from_str(&env, "Dr. Alice"),
+        &String::from_str(&env, "LIC-001"),
+        &String::from_str(&env, "Surgery"),
+    );
+    client.register_vet(
+        &vet2,
+        &String::from_str(&env, "Dr. Bob"),
+        &String::from_str(&env, "LIC-002"),
+        &String::from_str(&env, "Dentistry"),
+    );
+
+    // Only verify vet1
+    client.verify_vet(&admin, &vet1);
+
+    let vets = client.get_verified_vets(&0u64, &10u32);
+    assert_eq!(vets.len(), 1);
+    assert_eq!(vets.get(0).unwrap().address, vet1);
+}
+
+#[test]
+fn test_get_verified_vets_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.init_admin(&admin);
+
+    let licenses = ["LIC-P1", "LIC-P2", "LIC-P3"];
+    for lic in licenses.iter() {
+        let vet = Address::generate(&env);
+        client.register_vet(
+            &vet,
+            &String::from_str(&env, "Dr. Vet"),
+            &String::from_str(&env, lic),
+            &String::from_str(&env, "General"),
+        );
+        client.verify_vet(&admin, &vet);
+    }
+
+    // Page 1: offset=0, limit=2
+    let page1 = client.get_verified_vets(&0u64, &2u32);
+    assert_eq!(page1.len(), 2);
+
+    // Page 2: offset=2, limit=2
+    let page2 = client.get_verified_vets(&2u64, &2u32);
+    assert_eq!(page2.len(), 1);
+}
+
+#[test]
+fn test_get_verified_vets_empty_when_none_verified() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let vet = Address::generate(&env);
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr. Unverified"),
+        &String::from_str(&env, "LIC-UNVER"),
+        &String::from_str(&env, "General"),
+    );
+
+    let vets = client.get_verified_vets(&0u64, &10u32);
+    assert_eq!(vets.len(), 0);
+}


### PR DESCRIPTION
 ## What was implemented:
  
  - Two new storage keys (VetCount, VetIndex(u64)) to maintain an indexed list of registered vets
  - register_vet now increments the count and stores the vet's address by index
  - get_verified_vets(offset, limit) iterates the index, filters to only verified vets, and returns a paginated Vec<Vet>
  
  Tests added:
  
  - Only verified vets are returned (unverified are excluded)
  - Pagination works correctly across pages
  - Returns empty when no vets are verified
closes #394 