### PR TITLE
feat: add get_diet_plan_count function for pagination support

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -3180,6 +3180,16 @@ impl PetChainContract {
         current
     }
 
+    /// Returns the total number of diet plans recorded for a given pet.
+    /// Returns 0 if the pet does not exist or has no diet plans.
+    /// Useful for pagination UI to determine total pages.
+    pub fn get_diet_plan_count(env: Env, pet_id: u64) -> u64 {
+        env.storage()
+            .instance()
+            .get(&NutritionKey::PetDietCount(pet_id))
+            .unwrap_or(0)
+    }
+
     pub fn add_weight_entry(env: Env, pet_id: u64, weight: u32) -> bool {
         let mut pet: Pet = env
             .storage()

--- a/stellar-contracts/src/test_nutrition.rs
+++ b/stellar-contracts/src/test_nutrition.rs
@@ -311,3 +311,57 @@ fn test_discontinue_medication() {
     assert!(!med.active);
     assert_eq!(med.end_date, Some(end_date));
 }
+
+#[test]
+fn test_get_diet_plan_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Buddy"),
+        &String::from_str(&env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Golden Retriever"),
+        &String::from_str(&env, "Golden"),
+        &25u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    // Initially zero
+    assert_eq!(client.get_diet_plan_count(&pet_id), 0);
+
+    let restrictions = Vec::new(&env);
+    let allergies = Vec::new(&env);
+
+    // Add first diet plan
+    client.set_diet_plan(
+        &pet_id,
+        &String::from_str(&env, "Dry Kibble"),
+        &String::from_str(&env, "200g"),
+        &String::from_str(&env, "Twice daily"),
+        &restrictions,
+        &allergies,
+    );
+    assert_eq!(client.get_diet_plan_count(&pet_id), 1);
+
+    // Add second diet plan
+    client.set_diet_plan(
+        &pet_id,
+        &String::from_str(&env, "Wet Food"),
+        &String::from_str(&env, "150g"),
+        &String::from_str(&env, "Three times daily"),
+        &restrictions,
+        &allergies,
+    );
+    assert_eq!(client.get_diet_plan_count(&pet_id), 2);
+
+    // Count for a non-existent pet returns 0
+    assert_eq!(client.get_diet_plan_count(&9999u64), 0);
+}


### PR DESCRIPTION
Adds `get_diet_plan_count(env, pet_id) -> u64` to `PetChainContract`, returning the total number of diet plans recorded for a given pet. This is required by the pagination UI to calculate total pages when displaying a pet's diet history. closes #499 