### PR TITLE
feat: add get_activity_record_by_id (#497) and get_consent_count (#495)

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -5789,6 +5789,13 @@ impl PetChainContract {
         history
     }
 
+    pub fn get_consent_count(env: Env, pet_id: u64) -> u64 {
+        env.storage()
+            .instance()
+            .get(&ConsentKey::PetConsentCount(pet_id))
+            .unwrap_or(0)
+    }
+
     pub fn get_active_consents(env: Env, pet_id: u64) -> Vec<Consent> {
         let history = Self::get_consent_history(env.clone(), pet_id);
         let mut active = Vec::new(&env);
@@ -7880,6 +7887,12 @@ impl PetChainContract {
             }
         }
         history
+    }
+
+    pub fn get_activity_record_by_id(env: Env, record_id: u64) -> Option<ActivityRecord> {
+        env.storage()
+            .instance()
+            .get::<ActivityKey, ActivityRecord>(&ActivityKey::ActivityRecord(record_id))
     }
 
     pub fn get_activity_stats(env: Env, pet_id: u64, days: u32) -> (u32, u32) {

--- a/stellar-contracts/src/test_activity.rs
+++ b/stellar-contracts/src/test_activity.rs
@@ -580,3 +580,60 @@ fn test_activity_summary_invalid_range() {
     assert_eq!(duration, 0);
     assert_eq!(distance, 0);
 }
+
+#[test]
+fn test_get_activity_record_by_id_returns_correct_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    client.init_admin(&owner);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Max"),
+        &String::from_str(&env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Golden Retriever"),
+        &String::from_str(&env, "Golden"),
+        &30,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let record_id = client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30,
+        &5,
+        &2000,
+        &String::from_str(&env, "Morning walk"),
+    );
+
+    let record = client.get_activity_record_by_id(&record_id).unwrap();
+    assert_eq!(record.id, record_id);
+    assert_eq!(record.pet_id, pet_id);
+    assert_eq!(record.activity_type, ActivityType::Walk);
+    assert_eq!(record.duration_minutes, 30);
+    assert_eq!(record.intensity, 5);
+    assert_eq!(record.distance_meters, 2000);
+}
+
+#[test]
+fn test_get_activity_record_by_id_returns_none_for_nonexistent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    client.init_admin(&owner);
+
+    let result = client.get_activity_record_by_id(&9999);
+    assert!(result.is_none());
+}

--- a/stellar-contracts/src/test_consent_pagination.rs
+++ b/stellar-contracts/src/test_consent_pagination.rs
@@ -199,3 +199,23 @@ fn test_get_active_consents_no_consents() {
     let active = client.get_active_consents(&pet_id);
     assert_eq!(active.len(), 0);
 }
+
+#[test]
+fn test_get_consent_count_returns_correct_count() {
+    let (env, client, pet_id, owner) = setup();
+    let grantee = Address::generate(&env);
+
+    assert_eq!(client.get_consent_count(&pet_id), 0);
+
+    client.grant_consent(&pet_id, &owner, &ConsentType::Research, &grantee);
+    assert_eq!(client.get_consent_count(&pet_id), 1);
+
+    client.grant_consent(&pet_id, &owner, &ConsentType::Insurance, &grantee);
+    assert_eq!(client.get_consent_count(&pet_id), 2);
+}
+
+#[test]
+fn test_get_consent_count_zero_for_no_consents() {
+    let (_env, client, pet_id, _owner) = setup();
+    assert_eq!(client.get_consent_count(&pet_id), 0);
+}


### PR DESCRIPTION
## Summary
Implements two new read functions requested in issues #497 and #495.

---

## Issue #497 — Add get_activity_record_by_id

### Problem
Activity records could be listed in bulk via get_activity_history, but there was no way to fetch a single record by its unique ID. This made it impossible for clients to efficiently retrieve one specific activity without loading the entire history.

### Solution
Added get_activity_record_by_id(env, record_id) -> Option<ActivityRecord> in stellar-contracts/src/lib.rs, inserted directly after get_activity_history.

The function performs a single storage lookup using the existing ActivityKey::ActivityRecord(record_id) key that is already written by add_activity_record. It returns Some(record) when the ID exists and None when it does not, matching Soroban's idiomatic Option pattern.

No new storage keys, no new data structures — purely a targeted read on already-persisted data.

### Tests added (test_activity.rs)
- test_get_activity_record_by_id_returns_correct_record: registers a pet, adds one activity, then asserts every field of the returned record matches what was written (id, pet_id, activity_type, duration_minutes, intensity, distance_meters).
- test_get_activity_record_by_id_returns_none_for_nonexistent: calls the function with record_id 9999 on a fresh contract and asserts the result is None.

### Acceptance criteria met
[x] Returns correct record by ID
[x] Returns None for non-existent ID
[x] Tests written

---

## Issue #495 — Add get_consent_count

### Problem
No function exposed the total number of consent records stored for a given pet. The pagination UI needs this value to calculate the total number of pages without fetching all records.

### Solution
Added get_consent_count(env, pet_id) -> u64 in stellar-contracts/src/lib.rs, inserted directly before get_active_consents.

The function reads ConsentKey::PetConsentCount(pet_id) from instance storage — the same counter that grant_consent increments and the pruning logic decrements — and returns 0 when no key is present. This is a single-read, zero-allocation operation that is safe to call at any time.

### Tests added (test_consent_pagination.rs)
- test_get_consent_count_returns_correct_count: starts at 0, grants two consents one at a time, and asserts the count increments correctly after each grant (0 → 1 → 2).
- test_get_consent_count_zero_for_no_consents: calls get_consent_count on a pet that has never had any consents and asserts the result is 0.

### Acceptance criteria met
[x] Returns correct count
[x] Returns 0 when no consents exist
[x] Tests written

---

Closes #497
Closes #495

# Pull Request

## Related Issue

Closes #[issue_id]

## Description of Changes

<!-- Provide a clear and concise description of what this PR does. -->
<!-- Explain the problem this PR solves and how it addresses it. -->

## Type of Change

<!-- Please check the relevant option(s) by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->
<!-- Include details of your testing environment. -->

- [ ] All existing tests pass (`cargo test`)
- [ ] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [ ] Manually verified expected behavior

### Test Environment

- Rust version:
- Stellar CLI version:
- OS:

## Checklist

<!-- Please check all that apply by replacing [ ] with [x]. -->

- [ ] My code follows the project's code style guidelines (`cargo fmt`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] No hardcoded secrets, keys, or credentials are included in this PR
- [ ] No plaintext encryption keys or sensitive data are exposed in the code
- [ ] Input validation is properly implemented for all public functions
- [ ] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

<!-- If this PR touches security-sensitive code, describe the security implications. -->
<!-- For encryption, access control, or authentication changes, detail your approach. -->

## Screenshots / Logs (if applicable)

<!-- Add any relevant screenshots, logs, or output to help illustrate the changes. -->

## Additional Notes

<!-- Add any other context or notes about the PR here. -->
