### PR TITLE
 test: add expired, duplicate, and non-admin coverage to upgrade proposal tests

### DIFF
--- a/stellar-contracts/src/test_upgrade_proposal.rs
+++ b/stellar-contracts/src/test_upgrade_proposal.rs
@@ -244,3 +244,80 @@ fn test_version_readable_publicly() {
     assert_eq!(version.minor, 1);
     assert_eq!(version.patch, 5);
 }
+
+// --- Missing coverage: expired proposals, duplicate approval, non-admin ---
+
+#[test]
+#[should_panic]
+fn test_approve_expired_proposal_panics() {
+    let env = Env::default();
+    let (client, admin1, admin2) = setup(&env);
+
+    // expires_in = 100 seconds
+    let action = ProposalAction::UpgradeContract(BytesN::from_array(&env, &[0u8; 32]));
+    let proposal_id = client.propose_action(&admin1, &action, &100);
+
+    // Advance time past expiry
+    env.ledger().with_mut(|l| l.timestamp = 200);
+
+    // admin2 tries to approve an expired proposal — must panic
+    client.approve_proposal(&admin2, &proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_execute_expired_proposal_panics() {
+    let env = Env::default();
+    let (client, admin1, admin2) = setup(&env);
+
+    let action = ProposalAction::UpgradeContract(BytesN::from_array(&env, &[0u8; 32]));
+    let proposal_id = client.propose_action(&admin1, &action, &100);
+
+    // Approve before expiry
+    client.approve_proposal(&admin2, &proposal_id);
+
+    // Advance time past expiry before executing
+    env.ledger().with_mut(|l| l.timestamp = 200);
+
+    // Execute after expiry — must panic
+    client.execute_proposal(&proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_duplicate_approval_panics() {
+    let env = Env::default();
+    let (client, admin1, admin2) = setup(&env);
+
+    let action = ProposalAction::UpgradeContract(BytesN::from_array(&env, &[0u8; 32]));
+    let proposal_id = client.propose_action(&admin1, &action, &3600);
+
+    // admin2 approves once
+    client.approve_proposal(&admin2, &proposal_id);
+    // admin2 approves again — must panic
+    client.approve_proposal(&admin2, &proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_propose_action() {
+    let env = Env::default();
+    let (client, _admin1, _admin2) = setup(&env);
+
+    let non_admin = Address::generate(&env);
+    let action = ProposalAction::UpgradeContract(BytesN::from_array(&env, &[0u8; 32]));
+    client.propose_action(&non_admin, &action, &3600);
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_approve_proposal() {
+    let env = Env::default();
+    let (client, admin1, _admin2) = setup(&env);
+
+    let action = ProposalAction::UpgradeContract(BytesN::from_array(&env, &[0u8; 32]));
+    let proposal_id = client.propose_action(&admin1, &action, &3600);
+
+    let non_admin = Address::generate(&env);
+    client.approve_proposal(&non_admin, &proposal_id);
+}


### PR DESCRIPTION
closes #428
  
  PR description:
  
  Summary
  
  Adds 5 missing test cases to test_upgrade_proposal.rs to achieve full coverage of the upgrade proposal lifecycle.
  
  Changes
  
  - test_approve_expired_proposal_panics — verifies approve_proposal panics when the proposal has expired
  - test_execute_expired_proposal_panics — verifies execute_proposal panics when called after expiry, even if already approved
  - test_duplicate_approval_panics — verifies a second approval from the same admin panics (AdminAlreadyApproved)
  - test_non_admin_cannot_propose_action — verifies a non-admin address cannot create a proposal
  - test_non_admin_cannot_approve_proposal — verifies a non-admin address cannot approve an existing proposal
  
  Testing
  
  All tests use #[should_panic] and env.ledger().with_mut(|l| l.timestamp = ...) consistent with the existing test patterns in the file.
  
  ──────────────────────────────────