### PR TITLE
feat: sliding window rate limiter (#614) + escrow dispute window (#613)

### DIFF
--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -14,7 +14,10 @@ pub use handlers::{AdminScoreHandlers, AuthenticatedUser, TwoFactorHandlers};
 pub use leaderboard::{
     FlaggedScoreStore, FlaggedScoreSubmission, ScoreSubmissionError, ScoreValidationConfig,
 };
-pub use rate_limiter::{InMemoryRateLimiter, RateLimitResult, RateLimiter, RedisRateLimiter};
+pub use rate_limiter::{
+    EndpointConfig, InMemoryRateLimiter, LiveRedisBackend, MockRedisBackend, RateLimitResult,
+    RateLimiter, RedisBackend, RedisRateLimiter, SlidingWindowRateLimiter,
+};
 pub use tracing_middleware::sanitize_json_body;
 pub use two_factor::{
     InMemoryStore, RecoveryResult, TotpConfig, TwoFactorAuth, TwoFactorData, TwoFactorSetup,

--- a/backend-2fa/src/rate_limiter.rs
+++ b/backend-2fa/src/rate_limiter.rs
@@ -14,21 +14,212 @@ pub enum RateLimitResult {
 }
 
 /// A pluggable rate limiter interface.
-///
-/// Implement this trait to back the limiter with Redis, a database, or
-/// any other store. The in-process [`InMemoryRateLimiter`] is provided
-/// for development and testing.
 pub trait RateLimiter: Send + Sync {
-    /// Record a failed attempt for `key` and return whether further
-    /// attempts are currently allowed.
     fn record_failure(&self, key: &str) -> RateLimitResult;
-
-    /// Clear the failure counter for `key` on a successful attempt.
     fn record_success(&self, key: &str);
 }
 
 // ---------------------------------------------------------------------------
-// In-memory implementation
+// Per-endpoint window configuration
+// ---------------------------------------------------------------------------
+
+/// Window size and request limit for a single endpoint.
+#[derive(Clone, Debug)]
+pub struct EndpointConfig {
+    pub window_secs: u64,
+    pub max_failures: u32,
+    pub lockout_secs: u64,
+}
+
+impl EndpointConfig {
+    pub fn new(window_secs: u64, max_failures: u32, lockout_secs: u64) -> Self {
+        Self { window_secs, max_failures, lockout_secs }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Redis backend abstraction (enables mock injection)
+// ---------------------------------------------------------------------------
+
+/// Minimal Redis operations needed by the sliding-window limiter.
+/// Implement this trait to swap in a mock for tests.
+pub trait RedisBackend: Send + Sync {
+    /// Returns the TTL of `key` in seconds, or -2 if the key does not exist.
+    fn ttl(&self, key: &str) -> i64;
+    /// Atomically: remove members with score in [0, cutoff_ms], add a new
+    /// member with score `now_ms`, return the cardinality, and refresh the TTL.
+    fn sliding_window_add(&self, key: &str, now_ms: u64, cutoff_ms: u64, member: &str, ttl_secs: u64) -> u64;
+    /// Set `key` with a TTL (seconds).
+    fn set_ex(&self, key: &str, value: &str, ttl_secs: u64);
+    /// Delete one or more keys.
+    fn del(&self, keys: &[&str]);
+}
+
+// ---------------------------------------------------------------------------
+// Live Redis backend
+// ---------------------------------------------------------------------------
+
+pub struct LiveRedisBackend {
+    client: redis::Client,
+}
+
+impl LiveRedisBackend {
+    pub fn new(redis_url: &str) -> Result<Self, redis::RedisError> {
+        Ok(Self { client: redis::Client::open(redis_url)? })
+    }
+}
+
+impl RedisBackend for LiveRedisBackend {
+    fn ttl(&self, key: &str) -> i64 {
+        let mut con = match self.client.get_connection() {
+            Ok(c) => c,
+            Err(_) => return -2,
+        };
+        con.ttl(key).unwrap_or(-2)
+    }
+
+    fn sliding_window_add(&self, key: &str, now_ms: u64, cutoff_ms: u64, member: &str, ttl_secs: u64) -> u64 {
+        let mut con = match self.client.get_connection() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[LiveRedisBackend] connection error: {e}");
+                return 0;
+            }
+        };
+        let result: redis::RedisResult<(u64,)> = (|| {
+            let mut pipe = redis::pipe();
+            pipe.cmd("ZREMRANGEBYSCORE").arg(key).arg(0u64).arg(cutoff_ms).ignore()
+                .cmd("ZADD").arg(key).arg(now_ms).arg(member).ignore()
+                .cmd("ZCARD").arg(key)
+                .cmd("EXPIRE").arg(key).arg(ttl_secs).ignore();
+            pipe.query(&mut con)
+        })();
+        match result {
+            Ok((card,)) => card,
+            Err(e) => {
+                eprintln!("[LiveRedisBackend] pipeline error: {e}");
+                0
+            }
+        }
+    }
+
+    fn set_ex(&self, key: &str, value: &str, ttl_secs: u64) {
+        if let Ok(mut con) = self.client.get_connection() {
+            let _: Result<(), _> = con.set_ex(key, value, ttl_secs);
+        }
+    }
+
+    fn del(&self, keys: &[&str]) {
+        if let Ok(mut con) = self.client.get_connection() {
+            let _: Result<(), _> = redis::cmd("DEL").arg(keys).query(&mut con);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock Redis backend (in-process, for tests)
+// ---------------------------------------------------------------------------
+
+struct MockEntry {
+    /// Sorted set: (score_ms, member)
+    zset: Vec<(u64, String)>,
+    /// Expiry in mock-clock milliseconds (None = no expiry)
+    expires_at_ms: Option<u64>,
+}
+
+/// In-process mock that faithfully implements the sorted-set sliding window.
+pub struct MockRedisBackend {
+    store: Mutex<HashMap<String, MockEntry>>,
+    /// Injected "current time" for deterministic tests.
+    now_ms: Mutex<u64>,
+}
+
+impl MockRedisBackend {
+    pub fn new() -> Self {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        Self {
+            store: Mutex::new(HashMap::new()),
+            now_ms: Mutex::new(now_ms),
+        }
+    }
+
+    /// Advance the mock clock by `ms` milliseconds (for deterministic tests).
+    pub fn advance_ms(&self, ms: u64) {
+        *self.now_ms.lock().unwrap() += ms;
+    }
+
+    fn current_ms(&self) -> u64 {
+        *self.now_ms.lock().unwrap()
+    }
+}
+
+impl Default for MockRedisBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RedisBackend for MockRedisBackend {
+    fn ttl(&self, key: &str) -> i64 {
+        let now_ms = self.current_ms();
+        let store = self.store.lock().unwrap();
+        match store.get(key) {
+            None => -2,
+            Some(entry) => match entry.expires_at_ms {
+                None => -1,
+                Some(exp_ms) => {
+                    if now_ms >= exp_ms { -2 }
+                    else { ((exp_ms - now_ms + 999) / 1_000) as i64 } // ceiling division → secs
+                }
+            },
+        }
+    }
+
+    fn sliding_window_add(&self, key: &str, _now_ms: u64, cutoff_ms: u64, member: &str, ttl_secs: u64) -> u64 {
+        let now_ms = self.current_ms();
+        let mut store = self.store.lock().unwrap();
+        let entry = store.entry(key.to_string()).or_insert(MockEntry {
+            zset: Vec::new(),
+            expires_at_ms: None,
+        });
+        // Evict if the key itself has expired
+        if let Some(exp) = entry.expires_at_ms {
+            if now_ms >= exp {
+                entry.zset.clear();
+                entry.expires_at_ms = None;
+            }
+        }
+        // ZREMRANGEBYSCORE: remove scores <= cutoff_ms
+        entry.zset.retain(|(score, _)| *score > cutoff_ms);
+        // ZADD
+        entry.zset.push((now_ms, member.to_string()));
+        // EXPIRE
+        entry.expires_at_ms = Some(now_ms + ttl_secs * 1_000);
+        entry.zset.len() as u64
+    }
+
+    fn set_ex(&self, key: &str, value: &str, ttl_secs: u64) {
+        let now_ms = self.current_ms();
+        let mut store = self.store.lock().unwrap();
+        store.insert(key.to_string(), MockEntry {
+            zset: vec![(0, value.to_string())],
+            expires_at_ms: Some(now_ms + ttl_secs * 1_000),
+        });
+    }
+
+    fn del(&self, keys: &[&str]) {
+        let mut store = self.store.lock().unwrap();
+        for k in keys {
+            store.remove(*k);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (unchanged)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug)]
@@ -39,11 +230,6 @@ struct AttemptRecord {
 }
 
 /// Thread-safe in-memory rate limiter using a sliding window + lockout.
-///
-/// Configuration:
-/// - `max_failures`  — max failed attempts before lockout (default 5)
-/// - `window`        — rolling window for counting failures (default 60 s)
-/// - `lockout`       — how long to block after hitting the limit (default 300 s)
 pub struct InMemoryRateLimiter {
     max_failures: u32,
     window: Duration,
@@ -63,7 +249,6 @@ impl InMemoryRateLimiter {
 }
 
 impl Default for InMemoryRateLimiter {
-    /// Sensible production defaults: 5 failures / 60 s → 300 s lockout.
     fn default() -> Self {
         Self::new(5, 60, 300)
     }
@@ -80,20 +265,17 @@ impl RateLimiter for InMemoryRateLimiter {
             locked_until: None,
         });
 
-        // Already locked out?
         if let Some(locked_until) = record.locked_until {
             if now < locked_until {
                 let retry_after_secs = (locked_until - now).as_secs().max(1);
                 return RateLimitResult::Blocked { retry_after_secs };
             } else {
-                // Lockout expired — reset
                 record.failures = 0;
                 record.window_start = now;
                 record.locked_until = None;
             }
         }
 
-        // Roll the window if it has elapsed
         if now.duration_since(record.window_start) >= self.window {
             record.failures = 0;
             record.window_start = now;
@@ -103,12 +285,9 @@ impl RateLimiter for InMemoryRateLimiter {
 
         if record.failures >= self.max_failures {
             record.locked_until = Some(now + self.lockout);
-            RateLimitResult::Blocked {
-                retry_after_secs: self.lockout.as_secs(),
-            }
+            RateLimitResult::Blocked { retry_after_secs: self.lockout.as_secs() }
         } else {
-            let remaining = self.max_failures - record.failures;
-            RateLimitResult::Allowed { remaining }
+            RateLimitResult::Allowed { remaining: self.max_failures - record.failures }
         }
     }
 
@@ -119,116 +298,122 @@ impl RateLimiter for InMemoryRateLimiter {
 }
 
 // ---------------------------------------------------------------------------
-// Redis-backed implementation
+// Redis-backed sliding window rate limiter (generic over backend)
 // ---------------------------------------------------------------------------
 
-/// Redis-backed rate limiter using the INCR + EXPIRE pattern.
+/// Redis-backed rate limiter using a sorted-set sliding window.
 ///
-/// State survives server restarts and is shared across multiple processes,
-/// making this suitable for production deployments.
+/// Accepts any [`RedisBackend`] — use [`LiveRedisBackend`] in production and
+/// [`MockRedisBackend`] in tests.  Per-endpoint configuration is supported via
+/// [`EndpointConfig`]: pass the endpoint name as part of the `key` (e.g.
+/// `"login:user:42"`) or supply separate limiters per endpoint.
 ///
-/// Key schema (for a given `key`):
-/// - `rate:{key}:failures` — integer counter, TTL = `window_secs`
-/// - `rate:{key}:lockout`  — exists while locked out, TTL = `lockout_secs`
+/// On any backend error the limiter **fails open** (returns `Allowed`) to
+/// avoid locking out users during an outage.
+pub struct SlidingWindowRateLimiter<B: RedisBackend> {
+    pub(crate) backend: B,
+    /// Default config, used when no per-endpoint override matches.
+    default: EndpointConfig,
+    /// Optional per-endpoint overrides keyed by endpoint prefix.
+    endpoints: HashMap<String, EndpointConfig>,
+}
+
+impl<B: RedisBackend> SlidingWindowRateLimiter<B> {
+    pub fn new(backend: B, default: EndpointConfig) -> Self {
+        Self { backend, default, endpoints: HashMap::new() }
+    }
+
+    /// Register a per-endpoint config.  The `endpoint` string is matched as a
+    /// prefix of the rate-limit key (e.g. `"login"` matches `"login:user:42"`).
+    pub fn with_endpoint(mut self, endpoint: impl Into<String>, config: EndpointConfig) -> Self {
+        self.endpoints.insert(endpoint.into(), config);
+        self
+    }
+
+    fn config_for(&self, key: &str) -> &EndpointConfig {
+        self.endpoints
+            .iter()
+            .find(|(prefix, _)| key.starts_with(prefix.as_str()))
+            .map(|(_, cfg)| cfg)
+            .unwrap_or(&self.default)
+    }
+
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
+    fn unique_member() -> String {
+        let d = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+        format!("{}:{}", d.as_millis(), d.subsec_nanos())
+    }
+}
+
+impl<B: RedisBackend> RateLimiter for SlidingWindowRateLimiter<B> {
+    fn record_failure(&self, key: &str) -> RateLimitResult {
+        let cfg = self.config_for(key);
+        let lockout_key = format!("rate:{key}:lockout");
+        let window_key = format!("rate:{key}:window");
+
+        let lockout_ttl = self.backend.ttl(&lockout_key);
+        if lockout_ttl > 0 {
+            return RateLimitResult::Blocked { retry_after_secs: lockout_ttl as u64 };
+        }
+
+        let now_ms = Self::now_ms();
+        let cutoff_ms = now_ms.saturating_sub(cfg.window_secs * 1_000);
+        let member = Self::unique_member();
+
+        let count = self.backend.sliding_window_add(&window_key, now_ms, cutoff_ms, &member, cfg.window_secs);
+
+        if count >= cfg.max_failures as u64 {
+            self.backend.set_ex(&lockout_key, "1", cfg.lockout_secs);
+            return RateLimitResult::Blocked { retry_after_secs: cfg.lockout_secs };
+        }
+
+        RateLimitResult::Allowed { remaining: cfg.max_failures - count as u32 }
+    }
+
+    fn record_success(&self, key: &str) {
+        let lockout_key = format!("rate:{key}:lockout");
+        let window_key = format!("rate:{key}:window");
+        self.backend.del(&[&lockout_key, &window_key]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy RedisRateLimiter (kept for backwards compatibility)
+// ---------------------------------------------------------------------------
+
+/// Redis-backed rate limiter using a sorted-set sliding window.
 ///
-/// On any Redis connectivity error the limiter **fails open** (returns
-/// `Allowed`) to avoid locking out users during an outage.
+/// Prefer [`SlidingWindowRateLimiter`] with [`LiveRedisBackend`] for new code.
 pub struct RedisRateLimiter {
-    client: redis::Client,
-    max_failures: u32,
-    window_secs: u64,
-    lockout_secs: u64,
+    inner: SlidingWindowRateLimiter<LiveRedisBackend>,
 }
 
 impl RedisRateLimiter {
-    /// Create a new `RedisRateLimiter`.
-    ///
-    /// `redis_url` must be a valid Redis URL such as `redis://127.0.0.1:6379`.
-    /// This validates the URL format but does not open a connection immediately.
     pub fn new(
         redis_url: &str,
         max_failures: u32,
         window_secs: u64,
         lockout_secs: u64,
     ) -> Result<Self, redis::RedisError> {
-        let client = redis::Client::open(redis_url)?;
-        Ok(Self {
-            client,
-            max_failures,
-            window_secs,
-            lockout_secs,
-        })
+        let backend = LiveRedisBackend::new(redis_url)?;
+        let cfg = EndpointConfig::new(window_secs, max_failures, lockout_secs);
+        Ok(Self { inner: SlidingWindowRateLimiter::new(backend, cfg) })
     }
 }
 
 impl RateLimiter for RedisRateLimiter {
     fn record_failure(&self, key: &str) -> RateLimitResult {
-        let mut con = match self.client.get_connection() {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("[RedisRateLimiter] connection error: {e}");
-                return RateLimitResult::Allowed {
-                    remaining: self.max_failures,
-                };
-            }
-        };
-
-        let lockout_key = format!("rate:{key}:lockout");
-        let failure_key = format!("rate:{key}:failures");
-
-        // Check active lockout.
-        let lockout_ttl: i64 = con.ttl(&lockout_key).unwrap_or(-2);
-        if lockout_ttl > 0 {
-            return RateLimitResult::Blocked {
-                retry_after_secs: lockout_ttl as u64,
-            };
-        }
-
-        // Increment failure counter.
-        let count: u64 = match con.incr(&failure_key, 1u64) {
-            Ok(n) => n,
-            Err(e) => {
-                eprintln!("[RedisRateLimiter] incr error: {e}");
-                return RateLimitResult::Allowed {
-                    remaining: self.max_failures,
-                };
-            }
-        };
-
-        // On first failure start the sliding window TTL.
-        if count == 1 {
-            let _: Result<(), _> = con.expire(&failure_key, self.window_secs as i64);
-        }
-
-        // Impose lockout when the threshold is reached.
-        if count >= self.max_failures as u64 {
-            let _: Result<(), _> = con.set_ex(&lockout_key, "1", self.lockout_secs);
-            return RateLimitResult::Blocked {
-                retry_after_secs: self.lockout_secs,
-            };
-        }
-
-        RateLimitResult::Allowed {
-            remaining: self.max_failures - count as u32,
-        }
+        self.inner.record_failure(key)
     }
-
     fn record_success(&self, key: &str) {
-        let mut con = match self.client.get_connection() {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("[RedisRateLimiter] connection error on success: {e}");
-                return;
-            }
-        };
-
-        let lockout_key = format!("rate:{key}:lockout");
-        let failure_key = format!("rate:{key}:failures");
-
-        // Delete both keys with a single DEL command (atomic, no-op for missing keys).
-        let _: Result<(), _> = redis::cmd("DEL")
-            .arg(&lockout_key)
-            .arg(&failure_key)
-            .query(&mut con);
+        self.inner.record_success(key)
     }
 }

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -1524,6 +1524,7 @@ mod integration_tests {
 #[cfg(test)]
 mod redis_rate_limiter_tests {
     use crate::rate_limiter::{RateLimitResult, RateLimiter, RedisRateLimiter};
+    use std::collections::HashMap;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     /// Returns a unique key per test invocation to prevent cross-test pollution.
@@ -1550,7 +1551,107 @@ mod redis_rate_limiter_tests {
     }
 
     // -----------------------------------------------------------------------
-    // Unconditional test — no Redis instance required
+    // Mock Redis client for sliding-window unit tests
+    // -----------------------------------------------------------------------
+
+    /// A minimal mock that records ZADD/ZREMRANGEBYSCORE/ZCARD/EXPIRE/DEL
+    /// calls so we can test the sliding-window logic without a real Redis.
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct MockRedisState {
+        /// sorted set: key → BTreeMap<score_ms, member_ms>
+        zsets: HashMap<String, BTreeMap<u64, u64>>,
+        /// string keys (lockout)
+        strings: HashMap<String, u64>, // value = TTL remaining (secs)
+    }
+
+    impl MockRedisState {
+        fn zremrangebyscore(&mut self, key: &str, min: u64, max: u64) {
+            if let Some(set) = self.zsets.get_mut(key) {
+                set.retain(|&score, _| score < min || score > max);
+            }
+        }
+
+        fn zadd(&mut self, key: &str, score: u64, member: u64) {
+            self.zsets
+                .entry(key.to_string())
+                .or_default()
+                .insert(score, member);
+        }
+
+        fn zcard(&self, key: &str) -> u64 {
+            self.zsets.get(key).map(|s| s.len() as u64).unwrap_or(0)
+        }
+
+        fn set_ex(&mut self, key: &str, ttl: u64) {
+            self.strings.insert(key.to_string(), ttl);
+        }
+
+        fn ttl(&self, key: &str) -> i64 {
+            match self.strings.get(key) {
+                Some(&t) if t > 0 => t as i64,
+                _ => -2,
+            }
+        }
+
+        fn del(&mut self, keys: &[&str]) {
+            for k in keys {
+                self.zsets.remove(*k);
+                self.strings.remove(*k);
+            }
+        }
+    }
+
+    /// Simulates the sliding-window logic of `RedisRateLimiter::record_failure`
+    /// using the mock state, so we can assert on the algorithm without Redis.
+    fn mock_record_failure(
+        state: &Arc<Mutex<MockRedisState>>,
+        key: &str,
+        now_ms: u64,
+        max_failures: u32,
+        window_secs: u64,
+        lockout_secs: u64,
+    ) -> RateLimitResult {
+        let mut s = state.lock().unwrap();
+
+        let lockout_key = format!("rate:{key}:lockout");
+        let window_key = format!("rate:{key}:window");
+
+        if s.ttl(&lockout_key) > 0 {
+            return RateLimitResult::Blocked {
+                retry_after_secs: s.ttl(&lockout_key) as u64,
+            };
+        }
+
+        let cutoff_ms = now_ms.saturating_sub(window_secs * 1_000);
+        s.zremrangebyscore(&window_key, 0, cutoff_ms);
+        s.zadd(&window_key, now_ms, now_ms);
+        let count = s.zcard(&window_key);
+
+        if count >= max_failures as u64 {
+            s.set_ex(&lockout_key, lockout_secs);
+            return RateLimitResult::Blocked {
+                retry_after_secs: lockout_secs,
+            };
+        }
+
+        RateLimitResult::Allowed {
+            remaining: max_failures - count as u32,
+        }
+    }
+
+    fn mock_record_success(state: &Arc<Mutex<MockRedisState>>, key: &str) {
+        let mut s = state.lock().unwrap();
+        s.del(&[
+            &format!("rate:{key}:lockout"),
+            &format!("rate:{key}:window"),
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Unconditional tests — no Redis instance required
     // -----------------------------------------------------------------------
 
     /// When Redis is unreachable the limiter must fail open (return Allowed)
@@ -1575,6 +1676,112 @@ mod redis_rate_limiter_tests {
     fn redis_rate_limiter_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<RedisRateLimiter>();
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock sliding-window unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mock_sliding_window_allows_below_limit() {
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        let now_ms = 1_000_000u64;
+        for i in 1u32..5 {
+            match mock_record_failure(&state, "user:a", now_ms + i as u64, 5, 60, 300) {
+                RateLimitResult::Allowed { remaining } => assert_eq!(remaining, 5 - i),
+                RateLimitResult::Blocked { .. } => panic!("should not block before limit"),
+            }
+        }
+    }
+
+    #[test]
+    fn mock_sliding_window_blocks_at_limit() {
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        let now_ms = 2_000_000u64;
+        for i in 0..3u64 {
+            mock_record_failure(&state, "user:b", now_ms + i, 3, 60, 300);
+        }
+        assert!(matches!(
+            mock_record_failure(&state, "user:b", now_ms + 3, 3, 60, 300),
+            RateLimitResult::Blocked { retry_after_secs: 300 }
+        ));
+    }
+
+    #[test]
+    fn mock_sliding_window_evicts_stale_entries() {
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        // 3 failures at t=0
+        for i in 0..3u64 {
+            mock_record_failure(&state, "user:c", i, 3, 60, 300);
+        }
+        // 61 seconds later — all three are outside the 60 s window
+        let later_ms = 61_000u64;
+        match mock_record_failure(&state, "user:c", later_ms, 3, 60, 300) {
+            RateLimitResult::Allowed { remaining } => assert_eq!(remaining, 2),
+            RateLimitResult::Blocked { .. } => panic!("stale entries should have been evicted"),
+        }
+    }
+
+    #[test]
+    fn mock_sliding_window_prevents_boundary_burst() {
+        // Fixed-window would reset at t=60 s, allowing a burst of max_failures
+        // right after. Sliding window must not allow that.
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        let max = 3u32;
+        let window_ms = 60_000u64;
+
+        // Fill the window just before the boundary (t = 59 s)
+        for i in 0..max as u64 {
+            mock_record_failure(&state, "user:d", 59_000 + i, max, 60, 300);
+        }
+        // At t = 60 s (boundary) the entries are still within the window
+        assert!(matches!(
+            mock_record_failure(&state, "user:d", window_ms, max, 60, 300),
+            RateLimitResult::Blocked { .. }
+        ));
+    }
+
+    #[test]
+    fn mock_sliding_window_success_resets_counter() {
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        let now_ms = 3_000_000u64;
+        mock_record_failure(&state, "user:e", now_ms, 3, 60, 300);
+        mock_record_failure(&state, "user:e", now_ms + 1, 3, 60, 300);
+        mock_record_success(&state, "user:e");
+        match mock_record_failure(&state, "user:e", now_ms + 2, 3, 60, 300) {
+            RateLimitResult::Allowed { remaining } => assert_eq!(remaining, 2),
+            RateLimitResult::Blocked { .. } => panic!("should not block after success reset"),
+        }
+    }
+
+    #[test]
+    fn mock_sliding_window_concurrent_requests_independent_keys() {
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        let now_ms = 4_000_000u64;
+        // Exhaust key "user:f"
+        for i in 0..3u64 {
+            mock_record_failure(&state, "user:f", now_ms + i, 3, 60, 300);
+        }
+        // "user:g" must be unaffected
+        assert!(matches!(
+            mock_record_failure(&state, "user:g", now_ms, 3, 60, 300),
+            RateLimitResult::Allowed { .. }
+        ));
+    }
+
+    #[test]
+    fn mock_sliding_window_retry_after_is_accurate() {
+        let state = Arc::new(Mutex::new(MockRedisState::default()));
+        let now_ms = 5_000_000u64;
+        for i in 0..3u64 {
+            mock_record_failure(&state, "user:h", now_ms + i, 3, 60, 120);
+        }
+        match mock_record_failure(&state, "user:h", now_ms + 3, 3, 60, 120) {
+            RateLimitResult::Blocked { retry_after_secs } => {
+                assert_eq!(retry_after_secs, 120, "retry_after must equal lockout_secs");
+            }
+            RateLimitResult::Allowed { .. } => panic!("should be blocked"),
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -2018,5 +2225,139 @@ mod redis_rate_limiter_tests {
             let flagged = admin.get_all_flagged();
             assert_eq!(flagged[0].attempted_score, max_score);
         }
+    }
+}
+
+// ============================================================================
+// MockRedisBackend + SlidingWindowRateLimiter tests (#614)
+// ============================================================================
+
+#[cfg(test)]
+mod mock_redis_tests {
+    use crate::rate_limiter::{
+        EndpointConfig, MockRedisBackend, RateLimitResult, RateLimiter, SlidingWindowRateLimiter,
+    };
+    use std::sync::Arc;
+
+    fn limiter(max: u32, window_secs: u64, lockout_secs: u64) -> SlidingWindowRateLimiter<MockRedisBackend> {
+        SlidingWindowRateLimiter::new(
+            MockRedisBackend::new(),
+            EndpointConfig::new(window_secs, max, lockout_secs),
+        )
+    }
+
+    // --- limit ---
+
+    #[test]
+    fn allows_requests_below_limit() {
+        let l = limiter(3, 60, 300);
+        for i in 1u32..3 {
+            assert_eq!(l.record_failure("u:a"), RateLimitResult::Allowed { remaining: 3 - i });
+        }
+    }
+
+    #[test]
+    fn blocks_at_limit_with_accurate_retry_after() {
+        let l = limiter(3, 60, 120);
+        for _ in 0..3 { l.record_failure("u:b"); }
+        assert_eq!(
+            l.record_failure("u:b"),
+            RateLimitResult::Blocked { retry_after_secs: 120 },
+        );
+    }
+
+    // --- reset ---
+
+    #[test]
+    fn success_resets_counter() {
+        let l = limiter(3, 60, 300);
+        l.record_failure("u:c");
+        l.record_failure("u:c");
+        l.record_success("u:c");
+        assert_eq!(l.record_failure("u:c"), RateLimitResult::Allowed { remaining: 2 });
+    }
+
+    #[test]
+    fn window_expiry_resets_counter() {
+        let l = limiter(3, 60, 300);
+        // 2 failures (below the lockout threshold)
+        l.record_failure("u:d");
+        l.record_failure("u:d");
+        // Advance clock past the 60-second window — entries are evicted on next call
+        l.backend_advance_ms(61_000);
+        // Window has expired; the two old entries are outside the cutoff, so Allowed with remaining=2
+        assert_eq!(l.record_failure("u:d"), RateLimitResult::Allowed { remaining: 2 });
+    }
+
+    // --- concurrent / independent keys ---
+
+    #[test]
+    fn different_keys_are_independent() {
+        let l = limiter(2, 60, 300);
+        l.record_failure("u:e");
+        l.record_failure("u:e");
+        assert!(matches!(l.record_failure("u:f"), RateLimitResult::Allowed { .. }));
+    }
+
+    #[test]
+    fn concurrent_threads_do_not_corrupt_state() {
+        use std::thread;
+        let l = Arc::new(limiter(100, 60, 300));
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let l = Arc::clone(&l);
+                thread::spawn(move || l.record_failure(&format!("u:thread:{i}")))
+            })
+            .collect();
+        for h in handles { h.join().expect("thread panicked"); }
+    }
+
+    // --- per-endpoint config ---
+
+    #[test]
+    fn per_endpoint_config_applies_correct_limits() {
+        let l = SlidingWindowRateLimiter::new(
+            MockRedisBackend::new(),
+            EndpointConfig::new(60, 10, 300), // default: 10 failures
+        )
+        .with_endpoint("login", EndpointConfig::new(60, 2, 60)); // login: 2 failures
+
+        // Exhaust the login endpoint
+        l.record_failure("login:user:1");
+        l.record_failure("login:user:1");
+        assert!(matches!(
+            l.record_failure("login:user:1"),
+            RateLimitResult::Blocked { .. }
+        ));
+
+        // A key that doesn't match "login" uses the default (10 failures)
+        for _ in 0..9 {
+            assert!(matches!(
+                l.record_failure("verify:user:1"),
+                RateLimitResult::Allowed { .. }
+            ));
+        }
+    }
+
+    // --- sliding window prevents boundary burst ---
+
+    #[test]
+    fn sliding_window_prevents_boundary_burst() {
+        let l = limiter(3, 60, 300);
+        // 3 failures just before the 60-second boundary
+        for _ in 0..3 { l.record_failure("u:g"); }
+        // Advance to exactly the boundary — entries are still within the window
+        l.backend_advance_ms(59_999);
+        assert!(matches!(l.record_failure("u:g"), RateLimitResult::Blocked { .. }));
+    }
+}
+
+// Helper: expose advance_ms on SlidingWindowRateLimiter<MockRedisBackend>
+// without polluting the public API.
+#[cfg(test)]
+impl crate::rate_limiter::SlidingWindowRateLimiter<crate::rate_limiter::MockRedisBackend> {
+    fn backend_advance_ms(&self, ms: u64) {
+        // Access the backend field directly (same crate, so pub(crate) is fine).
+        self.backend.advance_ms(ms);
     }
 }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
@@ -12,6 +12,10 @@ use soroban_sdk::{
 /// so it is independent of ledger sequence numbers.
 pub const TRANSFER_EXPIRY_SECONDS: u64 = 7 * 24 * 60 * 60; // 604 800 s
 
+/// Dispute window: after both parties sign, either party has 48 hours to raise
+/// a dispute before [`finalize_transfer`] may be called.
+pub const DISPUTE_WINDOW_SECONDS: u64 = 48 * 60 * 60; // 172 800 s
+
 #[cfg(test)]
 mod test;
 mod vet_registry;
@@ -43,6 +47,18 @@ pub struct PendingTransfer {
     pub initiated_at: u64,
 }
 
+/// A transfer that has been accepted by both parties and is now in the
+/// 48-hour dispute window before ownership is finalised.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowedTransfer {
+    pub pet_id: u64,
+    pub from: Address,
+    pub to: Address,
+    pub escrowed_at: u64,
+    pub disputed: bool,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OwnershipRecord {
@@ -59,6 +75,7 @@ pub struct OwnershipRecord {
 enum DataKey {
     Pet(u64),
     PendingTransfer(u64),
+    EscrowedTransfer(u64),
     OwnershipHistory(u64),
     OwnerPets(Address),
 }
@@ -68,8 +85,10 @@ enum DataKey {
 /// ======================================================
 
 const EVT_TRANSFER_INITIATED: Symbol = symbol_short!("xfer_init");
-const EVT_TRANSFER_ACCEPTED: Symbol = symbol_short!("xfer_ok");
 const EVT_TRANSFER_CANCELLED: Symbol = symbol_short!("xfer_cncl");
+const EVT_TRANSFER_ESCROWED: Symbol = symbol_short!("xfer_escr");
+const EVT_TRANSFER_FINALIZED: Symbol = symbol_short!("xfer_fin");
+const EVT_TRANSFER_DISPUTED: Symbol = symbol_short!("xfer_disp");
 
 /// ======================================================
 /// ERRORS
@@ -90,6 +109,9 @@ pub enum ContractError {
     StaleCancellation = 9,
     EmptyBatch = 10,
     BatchOwnerMismatch = 11,
+    NoEscrowedTransfer = 12,
+    DisputeWindowNotElapsed = 13,
+    TransferAlreadyDisputed = 14,
 }
 
 /// ======================================================
@@ -222,9 +244,13 @@ impl PetOwnershipContract {
     }
 
     /// ----------------------------------
-    /// ACCEPT TRANSFER
+    /// ACCEPT TRANSFER → ESCROW
     /// ----------------------------------
-
+    ///
+    /// The recipient accepts the transfer. Ownership does **not** change yet;
+    /// the transfer enters an [`EscrowedTransfer`] state and a 48-hour dispute
+    /// window begins. Call [`finalize_transfer`] after the window to complete
+    /// the ownership change, or [`raise_dispute`] to block finalization.
     pub fn accept_transfer(env: Env, pet_id: u64) {
         let transfer: PendingTransfer = env
             .storage()
@@ -234,13 +260,59 @@ impl PetOwnershipContract {
 
         transfer.to.require_auth();
 
-        let mut pet = get_pet(&env, pet_id);
-
+        let pet = get_pet(&env, pet_id);
         if pet.current_owner != transfer.from {
             panic_with_error!(env, ContractError::Unauthorized);
         }
 
+        let escrowed = EscrowedTransfer {
+            pet_id,
+            from: transfer.from.clone(),
+            to: transfer.to.clone(),
+            escrowed_at: env.ledger().timestamp(),
+            disputed: false,
+        };
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingTransfer(pet_id));
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowedTransfer(pet_id), &escrowed);
+
+        env.events().publish(
+            (EVT_TRANSFER_ESCROWED, pet_id),
+            (transfer.from, transfer.to),
+        );
+    }
+
+    /// ----------------------------------
+    /// FINALIZE TRANSFER
+    /// ----------------------------------
+    ///
+    /// Completes the ownership transfer after the 48-hour dispute window has
+    /// elapsed. Either party may call this. Panics if the window has not yet
+    /// elapsed or if the transfer has been disputed.
+    pub fn finalize_transfer(env: Env, pet_id: u64) {
+        let escrowed: EscrowedTransfer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowedTransfer(pet_id))
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::NoEscrowedTransfer));
+
+        if escrowed.disputed {
+            panic_with_error!(env, ContractError::TransferAlreadyDisputed);
+        }
+
         let now = env.ledger().timestamp();
+        if now.saturating_sub(escrowed.escrowed_at) < DISPUTE_WINDOW_SECONDS {
+            panic_with_error!(env, ContractError::DisputeWindowNotElapsed);
+        }
+
+        let mut pet = get_pet(&env, pet_id);
+        if pet.current_owner != escrowed.from {
+            panic_with_error!(env, ContractError::Unauthorized);
+        }
 
         // Update ownership history
         let mut history = get_history(&env, pet_id);
@@ -253,28 +325,67 @@ impl PetOwnershipContract {
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::MissingOwnershipRecord));
         prev.relinquished_at = Some(now);
         history.set(last, prev);
-
         history.push_back(OwnershipRecord {
-            owner: transfer.to.clone(),
+            owner: escrowed.to.clone(),
             acquired_at: now,
             relinquished_at: None,
         });
 
-        remove_pet_from_owner(&env, &transfer.from, pet_id);
-        add_pet_to_owner(&env, &transfer.to, pet_id);
-
-        pet.current_owner = transfer.to.clone();
+        remove_pet_from_owner(&env, &escrowed.from, pet_id);
+        add_pet_to_owner(&env, &escrowed.to, pet_id);
+        pet.current_owner = escrowed.to.clone();
 
         save_pet(&env, &pet);
         save_history(&env, pet_id, &history);
-
         env.storage()
             .persistent()
-            .remove(&DataKey::PendingTransfer(pet_id));
+            .remove(&DataKey::EscrowedTransfer(pet_id));
 
         env.events().publish(
-            (EVT_TRANSFER_ACCEPTED, pet_id),
-            (transfer.from, transfer.to),
+            (EVT_TRANSFER_FINALIZED, pet_id),
+            (escrowed.from, escrowed.to),
+        );
+    }
+
+    /// ----------------------------------
+    /// RAISE DISPUTE
+    /// ----------------------------------
+    ///
+    /// Either the sender or recipient may raise a dispute during the 48-hour
+    /// window. A disputed transfer cannot be finalized; it must be resolved
+    /// through the main contract's dispute module.
+    ///
+    /// `caller` must be either the `from` or `to` address of the escrowed transfer.
+    pub fn raise_dispute(env: Env, pet_id: u64, caller: Address) {
+        let mut escrowed: EscrowedTransfer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowedTransfer(pet_id))
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::NoEscrowedTransfer));
+
+        if escrowed.disputed {
+            panic_with_error!(env, ContractError::TransferAlreadyDisputed);
+        }
+
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(escrowed.escrowed_at) >= DISPUTE_WINDOW_SECONDS {
+            panic_with_error!(env, ContractError::DisputeWindowNotElapsed);
+        }
+
+        // Require auth from the caller and verify they are a party to the transfer.
+        caller.require_auth();
+        if caller != escrowed.from && caller != escrowed.to {
+            panic_with_error!(env, ContractError::Unauthorized);
+        }
+
+        escrowed.disputed = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::EscrowedTransfer(pet_id), &escrowed);
+
+        env.events().publish(
+            (EVT_TRANSFER_DISPUTED, pet_id),
+            (escrowed.from, escrowed.to),
         );
     }
 
@@ -442,5 +553,12 @@ impl PetOwnershipContract {
         env.storage()
             .persistent()
             .get(&DataKey::PendingTransfer(pet_id))
+    }
+
+    /// Returns the [`EscrowedTransfer`] for `pet_id`, or `None` if none exists.
+    pub fn get_escrowed_transfer(env: Env, pet_id: u64) -> Option<EscrowedTransfer> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EscrowedTransfer(pet_id))
     }
 }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -1,7 +1,8 @@
 use super::{
-    ContractError, DataKey, OwnershipRecord, PetOwnershipContract, PetOwnershipContractClient,
+    ContractError, DataKey, EscrowedTransfer, OwnershipRecord, PetOwnershipContract,
+    PetOwnershipContractClient, DISPUTE_WINDOW_SECONDS,
 };
-use soroban_sdk::{testutils::Address as _, Address, Env, Error, Vec};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, Error, Vec};
 
 fn setup() -> (Env, Address, Address, u64) {
     let env = Env::default();
@@ -52,7 +53,13 @@ fn get_owner_pets_updates_after_transfer_acceptance() {
     client.create_pet(&pet_id, &owner);
     client.create_pet(&2, &owner);
     client.initiate_transfer(&pet_id, &new_owner);
-    client.accept_transfer(&pet_id);
+    client.accept_transfer(&pet_id); // → Escrowed
+
+    // Advance past the 48-hour dispute window then finalize
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
+    client.finalize_transfer(&pet_id);
 
     let owner_pets = client.get_owner_pets(&owner);
     assert_eq!(owner_pets.len(), 1);
@@ -78,11 +85,12 @@ fn create_pet_does_not_duplicate_owner_pet_index() {
 }
 
 #[test]
-fn accept_transfer_errors_when_history_is_missing() {
+fn finalize_transfer_errors_when_history_is_missing() {
     let (env, owner, new_owner, pet_id) = setup();
     let contract_id = env.register_contract(None, PetOwnershipContract);
     let client = PetOwnershipContractClient::new(&env, &contract_id);
     create_pending_transfer(&client, pet_id, &owner, &new_owner);
+    client.accept_transfer(&pet_id); // → Escrowed
 
     env.as_contract(&contract_id, || {
         env.storage()
@@ -90,7 +98,11 @@ fn accept_transfer_errors_when_history_is_missing() {
             .remove(&DataKey::OwnershipHistory(pet_id));
     });
 
-    let result = client.try_accept_transfer(&pet_id);
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
+
+    let result = client.try_finalize_transfer(&pet_id);
     assert_eq!(
         result,
         Err(Ok(Error::from_contract_error(
@@ -100,11 +112,12 @@ fn accept_transfer_errors_when_history_is_missing() {
 }
 
 #[test]
-fn accept_transfer_errors_when_history_is_empty() {
+fn finalize_transfer_errors_when_history_is_empty() {
     let (env, owner, new_owner, pet_id) = setup();
     let contract_id = env.register_contract(None, PetOwnershipContract);
     let client = PetOwnershipContractClient::new(&env, &contract_id);
     create_pending_transfer(&client, pet_id, &owner, &new_owner);
+    client.accept_transfer(&pet_id); // → Escrowed
 
     let empty_history = Vec::<OwnershipRecord>::new(&env);
     env.as_contract(&contract_id, || {
@@ -113,7 +126,11 @@ fn accept_transfer_errors_when_history_is_empty() {
             .set(&DataKey::OwnershipHistory(pet_id), &empty_history);
     });
 
-    let result = client.try_accept_transfer(&pet_id);
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
+
+    let result = client.try_finalize_transfer(&pet_id);
     assert_eq!(
         result,
         Err(Ok(Error::from_contract_error(
@@ -288,4 +305,197 @@ fn batch_initiate_transfer_errors_when_a_pet_already_has_pending_transfer() {
     );
     // Atomicity: pet 2 must remain unaffected
     assert!(!client.has_pending_transfer(&2));
+}
+
+// ======================================================
+// Escrow + dispute window tests
+// ======================================================
+
+#[test]
+fn accept_transfer_enters_escrowed_state() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+
+    // Ownership must NOT have changed yet
+    assert_eq!(client.get_current_owner(&pet_id), owner);
+    // Pending transfer is gone; escrowed transfer exists
+    assert!(!client.has_pending_transfer(&pet_id));
+    let escrowed = client.get_escrowed_transfer(&pet_id).unwrap();
+    assert_eq!(escrowed.from, owner);
+    assert_eq!(escrowed.to, new_owner);
+    assert!(!escrowed.disputed);
+}
+
+#[test]
+fn finalize_transfer_before_window_is_rejected() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+
+    // Advance time but stay within the window
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS - 1;
+    });
+
+    let result = client.try_finalize_transfer(&pet_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::DisputeWindowNotElapsed as u32,
+        )))
+    );
+    // Ownership unchanged
+    assert_eq!(client.get_current_owner(&pet_id), owner);
+}
+
+#[test]
+fn finalize_transfer_after_window_transfers_ownership() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
+    client.finalize_transfer(&pet_id);
+
+    assert_eq!(client.get_current_owner(&pet_id), new_owner);
+    assert!(client.get_escrowed_transfer(&pet_id).is_none());
+}
+
+#[test]
+fn raise_dispute_blocks_finalization() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+    client.raise_dispute(&pet_id, &owner);
+
+    // Escrowed transfer is now marked disputed
+    let escrowed = client.get_escrowed_transfer(&pet_id).unwrap();
+    assert!(escrowed.disputed);
+
+    // Finalize must fail even after the window
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
+    let result = client.try_finalize_transfer(&pet_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::TransferAlreadyDisputed as u32,
+        )))
+    );
+    // Ownership unchanged
+    assert_eq!(client.get_current_owner(&pet_id), owner);
+}
+
+#[test]
+fn raise_dispute_after_window_is_rejected() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
+
+    let result = client.try_raise_dispute(&pet_id, &owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::DisputeWindowNotElapsed as u32,
+        )))
+    );
+}
+
+#[test]
+fn finalize_transfer_no_escrowed_transfer_errors() {
+    let (env, _, _, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    let result = client.try_finalize_transfer(&pet_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::NoEscrowedTransfer as u32,
+        )))
+    );
+}
+
+#[test]
+fn recipient_can_raise_dispute_during_window() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+    // Recipient (new_owner / `to`) raises the dispute
+    client.raise_dispute(&pet_id, &new_owner);
+
+    let escrowed = client.get_escrowed_transfer(&pet_id).unwrap();
+    assert!(escrowed.disputed);
+}
+
+#[test]
+fn unauthorized_party_cannot_raise_dispute() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+
+    let stranger = Address::generate(&env);
+    let result = client.try_raise_dispute(&pet_id, &stranger);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::Unauthorized as u32,
+        )))
+    );
+}
+
+#[test]
+fn double_dispute_is_rejected() {
+    let (env, owner, new_owner, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.initiate_transfer(&pet_id, &new_owner);
+    client.accept_transfer(&pet_id);
+    client.raise_dispute(&pet_id, &owner);
+
+    let result = client.try_raise_dispute(&pet_id, &new_owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::TransferAlreadyDisputed as u32,
+        )))
+    );
 }


### PR DESCRIPTION
## Summary

Closes #614 
closes #613 

### #614 — Redis Sliding Window Rate Limiter

Replaces the fixed-window `RedisRateLimiter` with a proper sliding window backed by a `RedisBackend` trait:

- **`RedisBackend` trait** — decouples the algorithm from the transport; `LiveRedisBackend` wraps the real Redis client, `MockRedisBackend` is a fully in-process mock with a controllable clock (`advance_ms`).
- **`SlidingWindowRateLimiter<B: RedisBackend>`** — generic sliding window using sorted sets; per-endpoint window/limit/lockout via `EndpointConfig` + `with_endpoint()`.
- **`RedisRateLimiter`** kept as a thin backwards-compatible wrapper.
- **8 new `mock_redis_tests`** — no Redis instance required: below-limit allows, accurate `retry_after`, success reset, window-expiry reset, independent keys, concurrent threads, per-endpoint config, boundary burst prevention.

### #613 — Escrow Dispute Window

- Fixed `raise_dispute` to accept a `caller: Address` parameter and verify the caller is either the `from` or `to` party (previously only `from` could dispute).
- Added missing `Ledger` trait import that caused compile errors.
- 4 new tests: recipient raises dispute, unauthorized party rejected, double dispute rejected, plus all existing acceptance-criteria tests pass.

