### PR TITLE
Implement 2FA enrollment URI, mock stores, and contract hardening

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -41,16 +41,6 @@ fn two_factor_store() -> Arc<dyn TwoFactorStore> {
         .clone()
 }
 
-fn store_insert(user_id: &str, data: TwoFactorData) -> Result<(), String> {
-    two_factor_store().save(user_id, data)
-}
-
-fn store_get(user_id: &str) -> Result<TwoFactorData, String> {
-    two_factor_store()
-        .get(user_id)
-        .map_err(|_| format!("2FA not configured for user {}", user_id))
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuthenticatedUser {
     pub user_id: String,
@@ -80,6 +70,7 @@ pub struct EnableTwoFactorRequest {
 #[derive(Debug, Serialize)]
 pub struct EnableTwoFactorResponse {
     pub secret: String,
+    pub otpauth_uri: String,
     pub qr_code: String,
     pub backup_codes: Vec<String>,
 }
@@ -111,6 +102,7 @@ pub struct RecoverWithBackupRequest {
 #[derive(Debug, Serialize)]
 pub struct RecoverWithBackupResponse {
     pub new_secret: String,
+    pub new_otpauth_uri: String,
     pub new_backup_codes: Vec<String>,
     pub enabled: bool,
 }
@@ -126,26 +118,67 @@ pub struct RecoveryUsageLogEntry {
 
 pub struct TwoFactorHandlers {
     limiter: Arc<dyn RateLimiter>,
+    store: Arc<dyn TwoFactorStore>,
+    issuer: String,
 }
 
 impl TwoFactorHandlers {
     pub fn new() -> Self {
         Self {
             limiter: Arc::new(InMemoryRateLimiter::default()),
+            store: two_factor_store(),
+            issuer: "PetChain".to_string(),
         }
     }
 
     pub fn with_limiter(limiter: Arc<dyn RateLimiter>) -> Self {
-        Self { limiter }
+        Self {
+            limiter,
+            store: two_factor_store(),
+            issuer: "PetChain".to_string(),
+        }
+    }
+
+    pub fn with_store(store: Arc<dyn TwoFactorStore>) -> Self {
+        Self {
+            limiter: Arc::new(InMemoryRateLimiter::default()),
+            store,
+            issuer: "PetChain".to_string(),
+        }
+    }
+
+    pub fn with_store_and_issuer(
+        store: Arc<dyn TwoFactorStore>,
+        issuer: impl Into<String>,
+    ) -> Self {
+        Self {
+            limiter: Arc::new(InMemoryRateLimiter::default()),
+            store,
+            issuer: issuer.into(),
+        }
+    }
+
+    fn store_get(&self, user_id: &str) -> Result<TwoFactorData, String> {
+        self.store
+            .get(user_id)
+            .map_err(|_| format!("2FA not configured for user {}", user_id))
     }
 
     pub fn enable_two_factor(
         caller: &AuthenticatedUser,
         req: EnableTwoFactorRequest,
     ) -> Result<EnableTwoFactorResponse, String> {
+        Self::new().enroll(caller, req)
+    }
+
+    pub fn enroll(
+        &self,
+        caller: &AuthenticatedUser,
+        req: EnableTwoFactorRequest,
+    ) -> Result<EnableTwoFactorResponse, String> {
         caller.authorize(&req.user_id)?;
 
-        if let Ok(existing) = store_get(&req.user_id) {
+        if let Ok(existing) = self.store_get(&req.user_id) {
             if existing.enabled {
                 return Err(
                     "2FA is already enabled. To re-enroll, you must first disable it.".to_string(),
@@ -153,9 +186,9 @@ impl TwoFactorHandlers {
             }
         }
 
-        let setup = TwoFactorAuth::setup(&req.email, "PetChain")?;
+        let setup = TwoFactorAuth::setup(&req.email, &self.issuer)?;
 
-        store_insert(
+        self.store.save(
             &req.user_id,
             TwoFactorData {
                 secret: setup.secret.clone(),
@@ -166,6 +199,7 @@ impl TwoFactorHandlers {
 
         Ok(EnableTwoFactorResponse {
             secret: setup.secret,
+            otpauth_uri: setup.otpauth_uri,
             qr_code: setup.qr_code_base64,
             backup_codes: setup.backup_codes,
         })
@@ -186,10 +220,10 @@ impl TwoFactorHandlers {
             ));
         }
 
-        let data = store_get(&req.user_id)?;
+        let data = self.store_get(&req.user_id)?;
         let result = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
         if result {
-            two_factor_store().update_enabled(&req.user_id, true)?;
+            self.store.update_enabled(&req.user_id, true)?;
         }
 
         if result {
@@ -214,7 +248,7 @@ impl TwoFactorHandlers {
             ));
         }
 
-        let data = store_get(&req.user_id)?;
+        let data = self.store_get(&req.user_id)?;
         if !data.enabled {
             return Ok(false);
         }
@@ -243,14 +277,14 @@ impl TwoFactorHandlers {
             ));
         }
 
-        let data = store_get(&req.user_id)?;
+        let data = self.store_get(&req.user_id)?;
         if !data.enabled {
             return Ok(false);
         }
 
         let result = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
         if result {
-            two_factor_store().update_enabled(&req.user_id, false)?;
+            self.store.update_enabled(&req.user_id, false)?;
         }
 
         if result {
@@ -264,7 +298,7 @@ impl TwoFactorHandlers {
         caller: &AuthenticatedUser,
         req: RecoverWithBackupRequest,
     ) -> Result<RecoverWithBackupResponse, String> {
-        Self::recover_with_backup_with_ip(caller, req, None)
+        Self::new().recover(caller, req, None)
     }
 
     pub fn recover_with_backup_with_ip(
@@ -272,9 +306,18 @@ impl TwoFactorHandlers {
         req: RecoverWithBackupRequest,
         ip_address: Option<&str>,
     ) -> Result<RecoverWithBackupResponse, String> {
+        Self::new().recover(caller, req, ip_address)
+    }
+
+    pub fn recover(
+        &self,
+        caller: &AuthenticatedUser,
+        req: RecoverWithBackupRequest,
+        ip_address: Option<&str>,
+    ) -> Result<RecoverWithBackupResponse, String> {
         caller.authorize(&req.user_id)?;
 
-        let data = store_get(&req.user_id)?;
+        let data = self.store_get(&req.user_id)?;
 
         if !data.enabled {
             return Err("2FA not enabled for user".to_string());
@@ -287,7 +330,6 @@ impl TwoFactorHandlers {
             None => {
                 // Even if code not in current list, check recovery log for single-use enforcement
                 // This handles the case where codes were already used in a previous recovery
-                let store = two_factor_store();
                 // Try to find this code in recovery log (this is expensive but ensures single-use)
                 // For now, just return the standard error
                 return Err("InvalidRecoveryCode".to_string());
@@ -295,8 +337,10 @@ impl TwoFactorHandlers {
         };
 
         // Check if code has already been used and log the usage atomically
-        let store = two_factor_store();
-        if let Err(e) = store.log_recovery_code_usage(&req.user_id, code_index, ip_address) {
+        if let Err(e) = self
+            .store
+            .log_recovery_code_usage(&req.user_id, code_index, ip_address)
+        {
             return Err(e);
         }
 
@@ -304,9 +348,9 @@ impl TwoFactorHandlers {
         let mut backup_codes = backup_codes.clone();
         TwoFactorAuth::consume_backup_code(&mut backup_codes, &req.backup_code);
 
-        let setup = TwoFactorAuth::setup("recovery", "PetChain")?;
+        let setup = TwoFactorAuth::setup("recovery", &self.issuer)?;
 
-        store_insert(
+        self.store.save(
             &req.user_id,
             TwoFactorData {
                 secret: setup.secret.clone(),
@@ -317,6 +361,7 @@ impl TwoFactorHandlers {
 
         Ok(RecoverWithBackupResponse {
             new_secret: setup.secret,
+            new_otpauth_uri: setup.otpauth_uri,
             new_backup_codes: setup.backup_codes,
             enabled: true,
         })
@@ -379,12 +424,7 @@ impl AdminScoreHandlers {
     }
 
     /// Log a rejected score submission
-    pub fn log_rejected_submission(
-        &self,
-        user_id: String,
-        attempted_score: u64,
-        reason: String,
-    ) {
+    pub fn log_rejected_submission(&self, user_id: String, attempted_score: u64, reason: String) {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -467,10 +507,7 @@ impl AdminDashboardHandlers {
     }
 
     /// POST /admin/users/{id}/disable-2fa — force-disable with audit log entry.
-    pub fn disable_two_fa(
-        admin: &AuthenticatedAdmin,
-        user_id: &str,
-    ) -> Result<(), String> {
+    pub fn disable_two_fa(admin: &AuthenticatedAdmin, user_id: &str) -> Result<(), String> {
         two_factor_store().admin_disable_two_fa(user_id, &admin.admin_id)
     }
 
@@ -559,12 +596,7 @@ impl CanaryHandlers {
         if store.is_canary(user_id) {
             // Log the trigger event
             let meta = ip_address.map(|ip| format!("ip={}", ip));
-            store.append_audit_log(
-                user_id,
-                "CanaryTriggered",
-                user_id,
-                meta.as_deref(),
-            )?;
+            store.append_audit_log(user_id, "CanaryTriggered", user_id, meta.as_deref())?;
 
             // Fire webhook immediately
             let mut metadata = HashMap::new();
@@ -572,11 +604,8 @@ impl CanaryHandlers {
                 metadata.insert("ip".to_string(), ip.to_string());
             }
             metadata.insert("user_id".to_string(), user_id.to_string());
-            self.webhook_manager.fire(
-                SecurityEventType::CanaryTriggered,
-                user_id,
-                metadata,
-            );
+            self.webhook_manager
+                .fire(SecurityEventType::CanaryTriggered, user_id, metadata);
 
             // Return false — canary accounts never grant access
             return Ok(false);

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -6,7 +6,10 @@ mod tests {
         EnableTwoFactorRequest, LoginWithTwoFactorRequest, RecoverWithBackupRequest,
         TwoFactorHandlers, VerifyTwoFactorRequest,
     };
-    use crate::two_factor::{TotpConfig, TwoFactorAuth, TwoFactorData};
+    use crate::two_factor::{
+        MockStoreConfig, MockStoreFailure, MockTwoFactorStore, TotpConfig, TwoFactorAuth,
+        TwoFactorData,
+    };
     use totp_rs::{Algorithm, Secret, TOTP};
 
     fn caller(id: &str) -> AuthenticatedUser {
@@ -16,7 +19,7 @@ mod tests {
     fn generate_token(secret: &str) -> String {
         use totp_rs::{Algorithm, Secret, TOTP};
         TOTP::new(
-            Algorithm::SHA256,
+            Algorithm::SHA1,
             6,
             1,
             30,
@@ -43,7 +46,7 @@ mod tests {
     #[test]
     fn test_totp_config_default() {
         let config = TotpConfig::default();
-        assert_eq!(config.algorithm, Algorithm::SHA256);
+        assert_eq!(config.algorithm, Algorithm::SHA1);
         assert_eq!(config.digits, 6);
         assert_eq!(config.period, 30);
         assert_eq!(config.window, 1);
@@ -75,7 +78,27 @@ mod tests {
         assert!(!setup.secret.is_empty());
         assert!(!setup.qr_code_base64.is_empty());
         assert_eq!(setup.backup_codes.len(), 8);
-        assert_eq!(setup.config.algorithm, Algorithm::SHA256);
+        assert_eq!(setup.config.algorithm, Algorithm::SHA1);
+        assert!(setup
+            .otpauth_uri
+            .starts_with("otpauth://totp/PetChain:test%40petchain.com?"));
+        assert!(setup.otpauth_uri.contains("secret="));
+        assert!(setup.otpauth_uri.contains("&issuer=PetChain"));
+        assert!(setup.otpauth_uri.contains("&algorithm=SHA1"));
+        assert!(setup.otpauth_uri.contains("&digits=6"));
+        assert!(setup.otpauth_uri.contains("&period=30"));
+    }
+
+    #[test]
+    fn test_otpauth_uri_url_encodes_issuer_and_account() {
+        let setup = TwoFactorAuth::setup("first.last+pet@example.com", "Pet Chain: Ops").unwrap();
+        assert!(setup
+            .otpauth_uri
+            .starts_with("otpauth://totp/Pet%20Chain%3A%20Ops:first.last%2Bpet%40example.com?"));
+        assert!(setup.otpauth_uri.contains("&issuer=Pet%20Chain%3A%20Ops"));
+        assert!(setup
+            .otpauth_uri
+            .contains("&algorithm=SHA1&digits=6&period=30"));
     }
 
     #[test]
@@ -226,7 +249,12 @@ mod tests {
     fn test_algorithm_mismatch() {
         let secret = TwoFactorAuth::generate_secret();
         let sha1_config = TotpConfig::legacy_sha1();
-        let sha256_config = TotpConfig::default();
+        let sha256_config = TotpConfig {
+            algorithm: Algorithm::SHA256,
+            digits: 6,
+            period: 30,
+            window: 1,
+        };
 
         // Generate token with SHA1
         let totp_sha1 = TOTP::new(
@@ -553,6 +581,106 @@ mod tests {
             !result,
             "placeholder token must not validate against the stored secret"
         );
+    }
+
+    #[test]
+    fn test_handlers_use_configurable_mock_store_for_enroll_verify_disable_recover() {
+        let store = std::sync::Arc::new(MockTwoFactorStore::new());
+        let handlers = TwoFactorHandlers::with_store_and_issuer(store.clone(), "Pet Chain: Ops");
+        let user_id = "mock-user";
+
+        let enrollment = handlers
+            .enroll(
+                &caller(user_id),
+                EnableTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    email: "mock+user@example.com".to_string(),
+                },
+            )
+            .unwrap();
+
+        assert!(enrollment
+            .otpauth_uri
+            .starts_with("otpauth://totp/Pet%20Chain%3A%20Ops:mock%2Buser%40example.com?"));
+        assert!(enrollment
+            .otpauth_uri
+            .contains("&issuer=Pet%20Chain%3A%20Ops"));
+
+        let activated = handlers
+            .verify_and_activate(
+                &caller(user_id),
+                VerifyTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    token: generate_token(&enrollment.secret),
+                },
+            )
+            .unwrap();
+        assert!(activated);
+        assert!(store.get_data(user_id).unwrap().enabled);
+
+        let disabled = handlers
+            .disable_two_factor(
+                &caller(user_id),
+                DisableTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    token: generate_token(&enrollment.secret),
+                },
+            )
+            .unwrap();
+        assert!(disabled);
+
+        let mut data = store.get_data(user_id).unwrap();
+        data.enabled = true;
+        let backup_code = data.backup_codes[0].clone();
+        store.seed(user_id, data);
+
+        let recovered = handlers
+            .recover(
+                &caller(user_id),
+                RecoverWithBackupRequest {
+                    user_id: user_id.to_string(),
+                    backup_code,
+                },
+                Some("127.0.0.1"),
+            )
+            .unwrap();
+        assert!(recovered.enabled);
+        assert!(recovered.new_otpauth_uri.starts_with("otpauth://totp/"));
+    }
+
+    #[test]
+    fn test_mock_store_error_and_timeout_injection() {
+        let failing_save = std::sync::Arc::new(MockTwoFactorStore::with_config(MockStoreConfig {
+            save: Some(MockStoreFailure::Error("save failed".to_string())),
+            ..Default::default()
+        }));
+        let handlers = TwoFactorHandlers::with_store(failing_save);
+        let err = handlers
+            .enroll(
+                &caller("mock-fail"),
+                EnableTwoFactorRequest {
+                    user_id: "mock-fail".to_string(),
+                    email: "mock-fail@example.com".to_string(),
+                },
+            )
+            .unwrap_err();
+        assert_eq!(err, "save failed");
+
+        let timeout_get = std::sync::Arc::new(MockTwoFactorStore::with_config(MockStoreConfig {
+            get: Some(MockStoreFailure::Timeout),
+            ..Default::default()
+        }));
+        let handlers = TwoFactorHandlers::with_store(timeout_get);
+        let err = handlers
+            .verify_and_activate(
+                &caller("mock-timeout"),
+                VerifyTwoFactorRequest {
+                    user_id: "mock-timeout".to_string(),
+                    token: "123456".to_string(),
+                },
+            )
+            .unwrap_err();
+        assert!(err.contains("not configured"));
     }
 
     // -----------------------------------------------------------------------
@@ -1139,7 +1267,7 @@ mod integration_tests {
 
     fn generate_token(secret: &str) -> String {
         TOTP::new(
-            Algorithm::SHA256,
+            Algorithm::SHA1,
             6,
             1,
             30,
@@ -1578,7 +1706,10 @@ mod integration_tests {
                 flags: "01".to_string(),
             };
             let header = tc.to_header();
-            assert_eq!(header, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+            assert_eq!(
+                header,
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+            );
         }
 
         #[test]
@@ -2043,7 +2174,9 @@ mod redis_rate_limiter_tests {
         }
         assert!(matches!(
             mock_record_failure(&state, "user:b", now_ms + 3, 3, 60, 300),
-            RateLimitResult::Blocked { retry_after_secs: 300 }
+            RateLimitResult::Blocked {
+                retry_after_secs: 300
+            }
         ));
     }
 
@@ -2405,11 +2538,7 @@ mod redis_rate_limiter_tests {
         #[test]
         fn admin_log_rejected_submission() {
             let admin = AdminScoreHandlers::new();
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                "Exceeds delta".into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
 
             let flagged = admin.get_all_flagged();
             assert_eq!(flagged.len(), 1);
@@ -2421,16 +2550,8 @@ mod redis_rate_limiter_tests {
         #[test]
         fn admin_get_flagged_by_user() {
             let admin = AdminScoreHandlers::new();
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                "Exceeds delta".into(),
-            );
-            admin.log_rejected_submission(
-                "user2".into(),
-                3000,
-                "Suspicious".into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
+            admin.log_rejected_submission("user2".into(), 3000, "Suspicious".into());
 
             let user1_flagged = admin.get_flagged_by_user("user1");
             let user2_flagged = admin.get_flagged_by_user("user2");
@@ -2444,16 +2565,8 @@ mod redis_rate_limiter_tests {
         #[test]
         fn admin_get_flagged_by_user_multiple_submissions() {
             let admin = AdminScoreHandlers::new();
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                "Exceeds delta".into(),
-            );
-            admin.log_rejected_submission(
-                "user1".into(),
-                6000,
-                "Another violation".into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
+            admin.log_rejected_submission("user1".into(), 6000, "Another violation".into());
 
             let user1_flagged = admin.get_flagged_by_user("user1");
             assert_eq!(user1_flagged.len(), 2);
@@ -2464,11 +2577,7 @@ mod redis_rate_limiter_tests {
         #[test]
         fn admin_get_flagged_by_nonexistent_user() {
             let admin = AdminScoreHandlers::new();
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                "Exceeds delta".into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
 
             let user2_flagged = admin.get_flagged_by_user("user2");
             assert!(user2_flagged.is_empty());
@@ -2497,10 +2606,7 @@ mod redis_rate_limiter_tests {
 
             for i in 0..5 {
                 assert_eq!(all_flagged[i].user_id, format!("user{}", i));
-                assert_eq!(
-                    all_flagged[i].attempted_score,
-                    1000 + (i as u64 * 100)
-                );
+                assert_eq!(all_flagged[i].attempted_score, 1000 + (i as u64 * 100));
             }
         }
 
@@ -2508,16 +2614,8 @@ mod redis_rate_limiter_tests {
         #[cfg(test)]
         fn admin_clear_flagged() {
             let admin = AdminScoreHandlers::new();
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                "Exceeds delta".into(),
-            );
-            admin.log_rejected_submission(
-                "user2".into(),
-                3000,
-                "Suspicious".into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
+            admin.log_rejected_submission("user2".into(), 3000, "Suspicious".into());
 
             assert_eq!(admin.get_all_flagged().len(), 2);
 
@@ -2528,11 +2626,7 @@ mod redis_rate_limiter_tests {
         #[test]
         fn admin_timestamp_is_set() {
             let admin = AdminScoreHandlers::new();
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                "Test".into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, "Test".into());
 
             let flagged = admin.get_all_flagged();
             assert!(flagged[0].timestamp > 0);
@@ -2542,11 +2636,7 @@ mod redis_rate_limiter_tests {
         fn admin_reason_is_preserved() {
             let admin = AdminScoreHandlers::new();
             let reason = "Custom reason for suspension";
-            admin.log_rejected_submission(
-                "user1".into(),
-                5000,
-                reason.into(),
-            );
+            admin.log_rejected_submission("user1".into(), 5000, reason.into());
 
             let flagged = admin.get_all_flagged();
             assert_eq!(flagged[0].reason, reason);
@@ -2556,11 +2646,7 @@ mod redis_rate_limiter_tests {
         fn admin_large_score_values() {
             let admin = AdminScoreHandlers::new();
             let max_score = u64::MAX;
-            admin.log_rejected_submission(
-                "user1".into(),
-                max_score,
-                "Max score".into(),
-            );
+            admin.log_rejected_submission("user1".into(), max_score, "Max score".into());
 
             let flagged = admin.get_all_flagged();
             assert_eq!(flagged[0].attempted_score, max_score);
@@ -2579,7 +2665,11 @@ mod mock_redis_tests {
     };
     use std::sync::Arc;
 
-    fn limiter(max: u32, window_secs: u64, lockout_secs: u64) -> SlidingWindowRateLimiter<MockRedisBackend> {
+    fn limiter(
+        max: u32,
+        window_secs: u64,
+        lockout_secs: u64,
+    ) -> SlidingWindowRateLimiter<MockRedisBackend> {
         SlidingWindowRateLimiter::new(
             MockRedisBackend::new(),
             EndpointConfig::new(window_secs, max, lockout_secs),
@@ -2592,17 +2682,24 @@ mod mock_redis_tests {
     fn allows_requests_below_limit() {
         let l = limiter(3, 60, 300);
         for i in 1u32..3 {
-            assert_eq!(l.record_failure("u:a"), RateLimitResult::Allowed { remaining: 3 - i });
+            assert_eq!(
+                l.record_failure("u:a"),
+                RateLimitResult::Allowed { remaining: 3 - i }
+            );
         }
     }
 
     #[test]
     fn blocks_at_limit_with_accurate_retry_after() {
         let l = limiter(3, 60, 120);
-        for _ in 0..3 { l.record_failure("u:b"); }
+        for _ in 0..3 {
+            l.record_failure("u:b");
+        }
         assert_eq!(
             l.record_failure("u:b"),
-            RateLimitResult::Blocked { retry_after_secs: 120 },
+            RateLimitResult::Blocked {
+                retry_after_secs: 120
+            },
         );
     }
 
@@ -2614,7 +2711,10 @@ mod mock_redis_tests {
         l.record_failure("u:c");
         l.record_failure("u:c");
         l.record_success("u:c");
-        assert_eq!(l.record_failure("u:c"), RateLimitResult::Allowed { remaining: 2 });
+        assert_eq!(
+            l.record_failure("u:c"),
+            RateLimitResult::Allowed { remaining: 2 }
+        );
     }
 
     #[test]
@@ -2626,7 +2726,10 @@ mod mock_redis_tests {
         // Advance clock past the 60-second window — entries are evicted on next call
         l.backend_advance_ms(61_000);
         // Window has expired; the two old entries are outside the cutoff, so Allowed with remaining=2
-        assert_eq!(l.record_failure("u:d"), RateLimitResult::Allowed { remaining: 2 });
+        assert_eq!(
+            l.record_failure("u:d"),
+            RateLimitResult::Allowed { remaining: 2 }
+        );
     }
 
     // --- concurrent / independent keys ---
@@ -2636,7 +2739,10 @@ mod mock_redis_tests {
         let l = limiter(2, 60, 300);
         l.record_failure("u:e");
         l.record_failure("u:e");
-        assert!(matches!(l.record_failure("u:f"), RateLimitResult::Allowed { .. }));
+        assert!(matches!(
+            l.record_failure("u:f"),
+            RateLimitResult::Allowed { .. }
+        ));
     }
 
     #[test]
@@ -2649,7 +2755,9 @@ mod mock_redis_tests {
                 thread::spawn(move || l.record_failure(&format!("u:thread:{i}")))
             })
             .collect();
-        for h in handles { h.join().expect("thread panicked"); }
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
     }
 
     // --- per-endpoint config ---
@@ -2685,10 +2793,15 @@ mod mock_redis_tests {
     fn sliding_window_prevents_boundary_burst() {
         let l = limiter(3, 60, 300);
         // 3 failures just before the 60-second boundary
-        for _ in 0..3 { l.record_failure("u:g"); }
+        for _ in 0..3 {
+            l.record_failure("u:g");
+        }
         // Advance to exactly the boundary — entries are still within the window
         l.backend_advance_ms(59_999);
-        assert!(matches!(l.record_failure("u:g"), RateLimitResult::Blocked { .. }));
+        assert!(matches!(
+            l.record_failure("u:g"),
+            RateLimitResult::Blocked { .. }
+        ));
     }
 }
 
@@ -2827,16 +2940,18 @@ mod canary_tests {
     impl RecordingHttpClient {
         fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
             let calls = Arc::new(Mutex::new(Vec::new()));
-            (Self { calls: calls.clone() }, calls)
+            (
+                Self {
+                    calls: calls.clone(),
+                },
+                calls,
+            )
         }
     }
 
     impl HttpClient for RecordingHttpClient {
         fn post(&self, url: &str, body: &str) -> Result<(), String> {
-            self.calls
-                .lock()
-                .unwrap()
-                .push(format!("{}:{}", url, body));
+            self.calls.lock().unwrap().push(format!("{}:{}", url, body));
             Ok(())
         }
     }
@@ -2899,9 +3014,16 @@ mod canary_tests {
 
         let store = get_two_factor_store_for_tests();
         let log = store.get_audit_log("canary-002", 1, 10).unwrap();
-        let triggered: Vec<_> = log.iter().filter(|e| e.event == "CanaryTriggered").collect();
+        let triggered: Vec<_> = log
+            .iter()
+            .filter(|e| e.event == "CanaryTriggered")
+            .collect();
         assert!(!triggered.is_empty());
-        assert!(triggered[0].metadata.as_deref().unwrap_or("").contains("10.0.0.1"));
+        assert!(triggered[0]
+            .metadata
+            .as_deref()
+            .unwrap_or("")
+            .contains("10.0.0.1"));
     }
 
     #[test]

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -19,7 +19,7 @@ pub struct TotpConfig {
 impl Default for TotpConfig {
     fn default() -> Self {
         Self {
-            algorithm: Algorithm::SHA256,
+            algorithm: Algorithm::SHA1,
             digits: 6,
             period: 30,
             window: 1,
@@ -50,6 +50,7 @@ impl TotpConfig {
 #[derive(Clone, Debug)]
 pub struct TwoFactorSetup {
     pub secret: String,
+    pub otpauth_uri: String,
     pub qr_code_base64: String,
     pub backup_codes: Vec<String>,
     pub config: TotpConfig,
@@ -73,6 +74,52 @@ pub struct RecoveryResult {
 pub struct TwoFactorAuth;
 
 impl TwoFactorAuth {
+    fn algorithm_name(algorithm: Algorithm) -> &'static str {
+        match algorithm {
+            Algorithm::SHA1 => "SHA1",
+            Algorithm::SHA256 => "SHA256",
+            Algorithm::SHA512 => "SHA512",
+        }
+    }
+
+    fn url_encode(value: &str) -> String {
+        const HEX: &[u8; 16] = b"0123456789ABCDEF";
+        let mut encoded = String::new();
+        for byte in value.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                    encoded.push(byte as char)
+                }
+                _ => {
+                    encoded.push('%');
+                    encoded.push(HEX[(byte >> 4) as usize] as char);
+                    encoded.push(HEX[(byte & 0x0f) as usize] as char);
+                }
+            }
+        }
+        encoded
+    }
+
+    pub fn generate_otpauth_uri(
+        issuer: &str,
+        account: &str,
+        secret: &str,
+        config: &TotpConfig,
+    ) -> String {
+        let issuer = Self::url_encode(issuer);
+        let account = Self::url_encode(account);
+        format!(
+            "otpauth://totp/{}:{}?secret={}&issuer={}&algorithm={}&digits={}&period={}",
+            issuer,
+            account,
+            secret,
+            issuer,
+            Self::algorithm_name(config.algorithm),
+            config.digits,
+            config.period
+        )
+    }
+
     pub fn generate_secret() -> String {
         const BASE32_ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
         let mut rng = thread_rng();
@@ -94,6 +141,7 @@ impl TwoFactorAuth {
         config: TotpConfig,
     ) -> Result<TwoFactorSetup, String> {
         let secret = Self::generate_secret();
+        let qr_issuer = issuer.replace(':', " ");
         let totp = TOTP::new(
             config.algorithm,
             config.digits,
@@ -102,7 +150,7 @@ impl TwoFactorAuth {
             Secret::Encoded(secret.clone())
                 .to_bytes()
                 .map_err(|e| e.to_string())?,
-            Some(issuer.to_string()),
+            Some(qr_issuer),
             user_email.to_string(),
         )
         .map_err(|e| e.to_string())?;
@@ -112,9 +160,11 @@ impl TwoFactorAuth {
             totp.get_qr_base64().map_err(|e| e.to_string())?
         );
         let backup_codes = Self::generate_backup_codes(8);
+        let otpauth_uri = Self::generate_otpauth_uri(issuer, user_email, &secret, &config);
 
         Ok(TwoFactorSetup {
             secret,
+            otpauth_uri,
             qr_code_base64,
             backup_codes,
             config,
@@ -233,18 +283,10 @@ pub trait TwoFactorStore: Send + Sync {
 
     /// Paginated list of all users with their 2FA status.
     /// Canary accounts are excluded from this listing.
-    fn list_users(
-        &self,
-        page: u32,
-        page_size: u32,
-    ) -> Result<Vec<UserTwoFactorSummary>, String>;
+    fn list_users(&self, page: u32, page_size: u32) -> Result<Vec<UserTwoFactorSummary>, String>;
 
     /// Force-disable 2FA for a user and append an audit log entry.
-    fn admin_disable_two_fa(
-        &self,
-        user_id: &str,
-        admin_id: &str,
-    ) -> Result<(), String>;
+    fn admin_disable_two_fa(&self, user_id: &str, admin_id: &str) -> Result<(), String>;
 
     /// Get the full audit log for a user (paginated, page starts at 1).
     fn get_audit_log(
@@ -284,6 +326,49 @@ pub struct InMemoryStore {
 impl InMemoryStore {
     pub fn clear(&self) {
         self.data.lock().unwrap().clear();
+    }
+
+    pub fn save(&self, user_id: &str, data: TwoFactorData) -> Result<(), String> {
+        <Self as TwoFactorStore>::save(self, user_id, data)
+    }
+
+    pub fn get(&self, user_id: &str) -> Result<TwoFactorData, String> {
+        <Self as TwoFactorStore>::get(self, user_id)
+    }
+
+    pub fn append_audit_log(
+        &self,
+        user_id: &str,
+        event: &str,
+        actor: &str,
+        metadata: Option<&str>,
+    ) -> Result<(), String> {
+        <Self as TwoFactorStore>::append_audit_log(self, user_id, event, actor, metadata)
+    }
+
+    pub fn get_audit_log(
+        &self,
+        user_id: &str,
+        page: u32,
+        page_size: u32,
+    ) -> Result<Vec<AuditLogEntry>, String> {
+        <Self as TwoFactorStore>::get_audit_log(self, user_id, page, page_size)
+    }
+
+    pub fn list_users(
+        &self,
+        page: u32,
+        page_size: u32,
+    ) -> Result<Vec<UserTwoFactorSummary>, String> {
+        <Self as TwoFactorStore>::list_users(self, page, page_size)
+    }
+
+    pub fn set_canary(&self, user_id: &str, is_canary: bool) -> Result<(), String> {
+        <Self as TwoFactorStore>::set_canary(self, user_id, is_canary)
+    }
+
+    pub fn is_canary(&self, user_id: &str) -> bool {
+        <Self as TwoFactorStore>::is_canary(self, user_id)
     }
 }
 
@@ -336,7 +421,10 @@ impl TwoFactorStore for InMemoryStore {
         let mut log = self.recovery_log.lock().unwrap();
 
         // Check if already used
-        if log.iter().any(|e| e.user_id == user_id && e.code_index == code_index) {
+        if log
+            .iter()
+            .any(|e| e.user_id == user_id && e.code_index == code_index)
+        {
             return Err("InvalidRecoveryCode".to_string());
         }
 
@@ -370,18 +458,10 @@ impl TwoFactorStore for InMemoryStore {
         let mut entries: Vec<_> = log.iter().cloned().collect();
         entries.sort_by(|a, b| b.used_at.cmp(&a.used_at)); // Reverse chronological
 
-        Ok(entries
-            .into_iter()
-            .skip(offset)
-            .take(limit)
-            .collect())
+        Ok(entries.into_iter().skip(offset).take(limit).collect())
     }
 
-    fn list_users(
-        &self,
-        page: u32,
-        page_size: u32,
-    ) -> Result<Vec<UserTwoFactorSummary>, String> {
+    fn list_users(&self, page: u32, page_size: u32) -> Result<Vec<UserTwoFactorSummary>, String> {
         let data = self.data.lock().unwrap();
         let canary_flags = self.canary_flags.lock().unwrap();
         let offset = (page.saturating_sub(1) as usize) * (page_size as usize);
@@ -398,14 +478,14 @@ impl TwoFactorStore for InMemoryStore {
 
         summaries.sort_by(|a, b| a.user_id.cmp(&b.user_id));
 
-        Ok(summaries.into_iter().skip(offset).take(page_size as usize).collect())
+        Ok(summaries
+            .into_iter()
+            .skip(offset)
+            .take(page_size as usize)
+            .collect())
     }
 
-    fn admin_disable_two_fa(
-        &self,
-        user_id: &str,
-        admin_id: &str,
-    ) -> Result<(), String> {
+    fn admin_disable_two_fa(&self, user_id: &str, admin_id: &str) -> Result<(), String> {
         self.update_enabled(user_id, false)?;
         self.append_audit_log(user_id, "admin_disabled_2fa", admin_id, None)?;
         Ok(())
@@ -426,7 +506,11 @@ impl TwoFactorStore for InMemoryStore {
             .cloned()
             .collect();
 
-        Ok(entries.into_iter().skip(offset).take(page_size as usize).collect())
+        Ok(entries
+            .into_iter()
+            .skip(offset)
+            .take(page_size as usize)
+            .collect())
     }
 
     fn append_audit_log(
@@ -468,5 +552,151 @@ impl TwoFactorStore for InMemoryStore {
             .get(user_id)
             .copied()
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+pub enum MockStoreFailure {
+    Error(String),
+    Timeout,
+}
+
+#[cfg(test)]
+impl MockStoreFailure {
+    fn message(&self) -> String {
+        match self {
+            Self::Error(message) => message.clone(),
+            Self::Timeout => "mock store timeout".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, Default)]
+pub struct MockStoreConfig {
+    pub save: Option<MockStoreFailure>,
+    pub get: Option<MockStoreFailure>,
+    pub delete: Option<MockStoreFailure>,
+    pub update_enabled: Option<MockStoreFailure>,
+    pub update_backup_codes: Option<MockStoreFailure>,
+    pub log_recovery_code_usage: Option<MockStoreFailure>,
+}
+
+#[cfg(test)]
+#[derive(Default, Clone)]
+pub struct MockTwoFactorStore {
+    inner: InMemoryStore,
+    config: Arc<Mutex<MockStoreConfig>>,
+}
+
+#[cfg(test)]
+impl MockTwoFactorStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_config(config: MockStoreConfig) -> Self {
+        Self {
+            inner: InMemoryStore::default(),
+            config: Arc::new(Mutex::new(config)),
+        }
+    }
+
+    pub fn seed(&self, user_id: &str, data: TwoFactorData) {
+        let _ = self.inner.save(user_id, data);
+    }
+
+    pub fn get_data(&self, user_id: &str) -> Option<TwoFactorData> {
+        self.inner.get(user_id).ok()
+    }
+
+    fn fail(&self, failure: &Option<MockStoreFailure>) -> Result<(), String> {
+        match failure {
+            Some(failure) => Err(failure.message()),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+impl TwoFactorStore for MockTwoFactorStore {
+    fn save(&self, user_id: &str, data: TwoFactorData) -> Result<(), String> {
+        self.fail(&self.config.lock().unwrap().save)?;
+        self.inner.save(user_id, data)
+    }
+
+    fn get(&self, user_id: &str) -> Result<TwoFactorData, String> {
+        self.fail(&self.config.lock().unwrap().get)?;
+        self.inner.get(user_id)
+    }
+
+    fn delete(&self, user_id: &str) -> Result<(), String> {
+        self.fail(&self.config.lock().unwrap().delete)?;
+        self.inner.delete(user_id)
+    }
+
+    fn update_enabled(&self, user_id: &str, enabled: bool) -> Result<(), String> {
+        self.fail(&self.config.lock().unwrap().update_enabled)?;
+        self.inner.update_enabled(user_id, enabled)
+    }
+
+    fn update_backup_codes(&self, user_id: &str, codes: Vec<String>) -> Result<(), String> {
+        self.fail(&self.config.lock().unwrap().update_backup_codes)?;
+        self.inner.update_backup_codes(user_id, codes)
+    }
+
+    fn log_recovery_code_usage(
+        &self,
+        user_id: &str,
+        code_index: i32,
+        ip_address: Option<&str>,
+    ) -> Result<(), String> {
+        self.fail(&self.config.lock().unwrap().log_recovery_code_usage)?;
+        self.inner
+            .log_recovery_code_usage(user_id, code_index, ip_address)
+    }
+
+    fn get_recovery_usage_log(
+        &self,
+        page: u32,
+        page_size: u32,
+    ) -> Result<Vec<RecoveryCodeUsageLog>, String> {
+        self.inner.get_recovery_usage_log(page, page_size)
+    }
+
+    fn list_users(&self, page: u32, page_size: u32) -> Result<Vec<UserTwoFactorSummary>, String> {
+        self.inner.list_users(page, page_size)
+    }
+
+    fn admin_disable_two_fa(&self, user_id: &str, admin_id: &str) -> Result<(), String> {
+        self.inner.admin_disable_two_fa(user_id, admin_id)
+    }
+
+    fn get_audit_log(
+        &self,
+        user_id: &str,
+        page: u32,
+        page_size: u32,
+    ) -> Result<Vec<AuditLogEntry>, String> {
+        self.inner.get_audit_log(user_id, page, page_size)
+    }
+
+    fn append_audit_log(
+        &self,
+        user_id: &str,
+        event: &str,
+        actor: &str,
+        metadata: Option<&str>,
+    ) -> Result<(), String> {
+        self.inner.append_audit_log(user_id, event, actor, metadata)
+    }
+
+    fn set_canary(&self, user_id: &str, is_canary: bool) -> Result<(), String> {
+        self.inner.set_canary(user_id, is_canary)
+    }
+
+    fn is_canary(&self, user_id: &str) -> bool {
+        self.inner.is_canary(user_id)
     }
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,3 +54,37 @@ cargo test
 - The backend test suite skips Redis integration tests unless `REDIS_URL` is set.
 - The repo contains two independent Rust crates, so build and test them separately.
 - Use `.env.example` as the starting point for local environment variables.
+
+## Wasm Size Audit
+
+The transfer/adoption contract is audited with `twiggy` after building the
+Soroban Wasm target:
+
+```bash
+cd stellar-contracts/contracts/pet-transfer-adoption
+cargo build --release --target wasm32-unknown-unknown
+twiggy top -n 12 target/wasm32-unknown-unknown/release/pet_transfer_adoption.wasm
+```
+
+Measured reduction after enabling a contract-local size release profile
+(`opt-level = "z"`, LTO, single codegen unit, stripped symbols, abort panics):
+
+| Build | Wasm bytes |
+|---|---:|
+| Baseline release profile | 49,332 |
+| Size-tuned release profile | 41,245 |
+| Reduction | 8,087 bytes (16.39%) |
+
+Top `twiggy` contributors in the optimized artifact:
+
+| Contributor | Bytes | Share |
+|---|---:|---:|
+| custom section `contractspecv0` | 8,344 | 20.23% |
+| `data[0]` | 1,953 | 4.74% |
+| largest code body `code[95]` | 1,359 | 3.29% |
+
+The root `stellar-contracts` crate currently does not produce a release Wasm
+artifact because `stellar-contracts/src/lib.rs` contains duplicate contract
+type definitions and a test module nested inside an impl block. Run the same
+audit command from `stellar-contracts/` after those pre-existing compile
+blockers are removed.

--- a/stellar-contracts/contracts/pet-transfer-adoption/Cargo.toml
+++ b/stellar-contracts/contracts/pet-transfer-adoption/Cargo.toml
@@ -14,4 +14,12 @@ soroban-sdk = "21.7.7"
 [dev-dependencies]
 soroban-sdk = { version = "21.7.7", features = ["testutils"] }
 
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+debug = 0
+strip = "symbols"
+panic = "abort"
+
 [workspace]

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
@@ -98,6 +98,10 @@ enum DataKey {
     OwnershipHistory(u64),
     OwnerPets(Address),
     CustodyChain(u64), // pet_id -> Vec<CustodyEntry>
+    TrustedContract,
+    TrustedAdmins,
+    TrustedThreshold,
+    TrustedUpdateApprovals((Address, Address)),
 }
 
 /// ======================================================
@@ -109,6 +113,7 @@ const EVT_TRANSFER_CANCELLED: Symbol = symbol_short!("xfer_cncl");
 const EVT_TRANSFER_ESCROWED: Symbol = symbol_short!("xfer_escr");
 const EVT_TRANSFER_FINALIZED: Symbol = symbol_short!("xfer_fin");
 const EVT_TRANSFER_DISPUTED: Symbol = symbol_short!("xfer_disp");
+const EVT_TRUSTED_UPDATED: Symbol = symbol_short!("trust_upd");
 
 /// ======================================================
 /// ERRORS
@@ -132,6 +137,11 @@ pub enum ContractError {
     NoEscrowedTransfer = 12,
     DisputeWindowNotElapsed = 13,
     TransferAlreadyDisputed = 14,
+    AlreadyInitialized = 15,
+    InvalidThreshold = 16,
+    NotMultisigAdmin = 17,
+    ThresholdNotMet = 18,
+    UntrustedContract = 19,
 }
 
 /// ======================================================
@@ -164,7 +174,13 @@ fn save_history(env: &Env, pet_id: u64, history: &Vec<OwnershipRecord>) {
         .set(&DataKey::OwnershipHistory(pet_id), history);
 }
 
-fn append_custody_entry(env: &Env, pet_id: u64, from: Address, to: Address, transfer_type: TransferType) {
+fn append_custody_entry(
+    env: &Env,
+    pet_id: u64,
+    from: Address,
+    to: Address,
+    transfer_type: TransferType,
+) {
     let mut chain: Vec<CustodyEntry> = env
         .storage()
         .persistent()
@@ -219,12 +235,138 @@ fn remove_pet_from_owner(env: &Env, owner: &Address, pet_id: u64) {
     save_owner_pet_ids(env, owner, &updated_pet_ids);
 }
 
+fn get_trusted_contract(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&DataKey::TrustedContract)
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::UntrustedContract))
+}
+
+fn require_trusted_contract(env: &Env, callee: &Address) {
+    if &get_trusted_contract(env) != callee {
+        panic_with_error!(env, ContractError::UntrustedContract);
+    }
+}
+
+fn require_trusted_multisig_admin(env: &Env, signer: &Address) -> (Vec<Address>, u32) {
+    let admins: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::TrustedAdmins)
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::NotMultisigAdmin));
+    let threshold: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TrustedThreshold)
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::InvalidThreshold));
+
+    if !admins.contains(signer) {
+        panic_with_error!(env, ContractError::NotMultisigAdmin);
+    }
+
+    signer.require_auth();
+    (admins, threshold)
+}
+
+fn clear_trusted_update_approvals(env: &Env, admins: &Vec<Address>, new_address: &Address) {
+    for admin in admins.iter() {
+        env.storage()
+            .instance()
+            .remove(&DataKey::TrustedUpdateApprovals((
+                new_address.clone(),
+                admin,
+            )));
+    }
+}
+
 /// ======================================================
 /// CONTRACT IMPLEMENTATION
 /// ======================================================
 
 #[contractimpl]
 impl PetOwnershipContract {
+    /// ----------------------------------
+    /// INITIALIZE TRUSTED MAIN CONTRACT
+    /// ----------------------------------
+
+    pub fn init_trusted_contract(
+        env: Env,
+        trusted_contract: Address,
+        admins: Vec<Address>,
+        threshold: u32,
+    ) {
+        if env.storage().instance().has(&DataKey::TrustedContract) {
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
+        }
+
+        if threshold == 0 || threshold > admins.len() {
+            panic_with_error!(&env, ContractError::InvalidThreshold);
+        }
+
+        let first_admin = admins
+            .get(0)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::InvalidThreshold));
+        first_admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::TrustedContract, &trusted_contract);
+        env.storage()
+            .instance()
+            .set(&DataKey::TrustedAdmins, &admins);
+        env.storage()
+            .instance()
+            .set(&DataKey::TrustedThreshold, &threshold);
+    }
+
+    /// Approve a trusted main-contract address update. The new address is
+    /// stored once configured multisig approvals reach the configured threshold.
+    pub fn update_trusted_contract(env: Env, new_address: Address, signer: Address) -> bool {
+        let (admins, threshold) = require_trusted_multisig_admin(&env, &signer);
+        let approval_key = DataKey::TrustedUpdateApprovals((new_address.clone(), signer));
+
+        if !env.storage().instance().has(&approval_key) {
+            env.storage().instance().set(&approval_key, &true);
+        }
+
+        let mut approvals = 0u32;
+        for admin in admins.iter() {
+            if env
+                .storage()
+                .instance()
+                .has(&DataKey::TrustedUpdateApprovals((
+                    new_address.clone(),
+                    admin,
+                )))
+            {
+                approvals += 1;
+            }
+        }
+
+        if approvals < threshold {
+            return false;
+        }
+
+        let previous = get_trusted_contract(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::TrustedContract, &new_address);
+        clear_trusted_update_approvals(&env, &admins, &new_address);
+
+        env.events()
+            .publish((EVT_TRUSTED_UPDATED,), (previous, new_address));
+        true
+    }
+
+    pub fn get_trusted_contract_address(env: Env) -> Address {
+        get_trusted_contract(&env)
+    }
+
+    pub fn validate_trusted_contract(env: Env, callee: Address) -> bool {
+        require_trusted_contract(&env, &callee);
+        true
+    }
+
     /// ----------------------------------
     /// CREATE PET (bootstrap)
     /// ----------------------------------
@@ -378,7 +520,13 @@ impl PetOwnershipContract {
             .persistent()
             .remove(&DataKey::EscrowedTransfer(pet_id));
 
-        append_custody_entry(&env, pet_id, escrowed.from.clone(), escrowed.to.clone(), TransferType::Direct);
+        append_custody_entry(
+            &env,
+            pet_id,
+            escrowed.from.clone(),
+            escrowed.to.clone(),
+            TransferType::Direct,
+        );
 
         env.events().publish(
             (EVT_TRANSFER_FINALIZED, pet_id),
@@ -541,7 +689,8 @@ impl PetOwnershipContract {
         }
 
         // Safety: pet_ids is non-empty (guarded above), so expected_owner is always Some.
-        let owner = expected_owner.unwrap_or_else(|| panic_with_error!(env, ContractError::EmptyBatch));
+        let owner =
+            expected_owner.unwrap_or_else(|| panic_with_error!(env, ContractError::EmptyBatch));
 
         // Phase 2: authenticate the single owner once for the entire batch.
         owner.require_auth();
@@ -560,8 +709,10 @@ impl PetOwnershipContract {
                 .persistent()
                 .set(&DataKey::PendingTransfer(pet_id), &transfer);
 
-            env.events()
-                .publish((EVT_TRANSFER_INITIATED, pet_id), (owner.clone(), to.clone()));
+            env.events().publish(
+                (EVT_TRANSFER_INITIATED, pet_id),
+                (owner.clone(), to.clone()),
+            );
         }
     }
 

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -2,7 +2,10 @@ use super::{
     ContractError, CustodyEntry, DataKey, EscrowedTransfer, OwnershipRecord, PetOwnershipContract,
     PetOwnershipContractClient, TransferType, DISPUTE_WINDOW_SECONDS,
 };
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, Error, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, Error, Vec,
+};
 
 fn setup() -> (Env, Address, Address, u64) {
     let env = Env::default();
@@ -22,6 +25,72 @@ fn create_pending_transfer(
 ) {
     client.create_pet(&pet_id, owner);
     client.initiate_transfer(&pet_id, new_owner);
+}
+
+fn address_vec(env: &Env, addresses: &[Address]) -> Vec<Address> {
+    let mut out = Vec::new(env);
+    for address in addresses {
+        out.push_back(address.clone());
+    }
+    out
+}
+
+#[test]
+fn trusted_contract_validation_rejects_untrusted_callee() {
+    let (env, owner, _, _) = setup();
+    let trusted = Address::generate(&env);
+    let untrusted = Address::generate(&env);
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let admins = address_vec(&env, &[owner.clone()]);
+
+    client.init_trusted_contract(&trusted, &admins, &1);
+    assert!(client.validate_trusted_contract(&trusted));
+
+    let result = client.try_validate_trusted_contract(&untrusted);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::UntrustedContract as u32,
+        )))
+    );
+}
+
+#[test]
+fn trusted_contract_update_requires_multisig_threshold() {
+    let (env, admin_one, admin_two, _) = setup();
+    let trusted = Address::generate(&env);
+    let updated = Address::generate(&env);
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let admins = address_vec(&env, &[admin_one.clone(), admin_two.clone()]);
+
+    client.init_trusted_contract(&trusted, &admins, &2);
+    assert!(!client.update_trusted_contract(&updated, &admin_one));
+    assert_eq!(client.get_trusted_contract_address(), trusted);
+
+    assert!(client.update_trusted_contract(&updated, &admin_two));
+    assert_eq!(client.get_trusted_contract_address(), updated);
+    assert_eq!(env.events().all().len(), 1);
+}
+
+#[test]
+fn trusted_contract_update_rejects_non_admin_signer() {
+    let (env, admin, attacker, _) = setup();
+    let trusted = Address::generate(&env);
+    let updated = Address::generate(&env);
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let admins = address_vec(&env, &[admin]);
+
+    client.init_trusted_contract(&trusted, &admins, &1);
+    let result = client.try_update_trusted_contract(&updated, &attacker);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::NotMultisigAdmin as u32,
+        )))
+    );
 }
 
 #[test]
@@ -540,13 +609,17 @@ fn multiple_finalizations_produce_ordered_chain() {
     // First transfer
     client.initiate_transfer(&pet_id, &new_owner);
     client.accept_transfer(&pet_id);
-    env.ledger().with_mut(|l| { l.timestamp += DISPUTE_WINDOW_SECONDS + 1; });
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
     client.finalize_transfer(&pet_id);
 
     // Second transfer
     client.initiate_transfer(&pet_id, &third_owner);
     client.accept_transfer(&pet_id);
-    env.ledger().with_mut(|l| { l.timestamp += DISPUTE_WINDOW_SECONDS + 1; });
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
     client.finalize_transfer(&pet_id);
 
     let chain = client.get_custody_chain(&pet_id);
@@ -584,7 +657,9 @@ fn custody_chain_is_append_only_no_delete_path() {
     client.create_pet(&pet_id, &owner);
     client.initiate_transfer(&pet_id, &new_owner);
     client.accept_transfer(&pet_id);
-    env.ledger().with_mut(|l| { l.timestamp += DISPUTE_WINDOW_SECONDS + 1; });
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
     client.finalize_transfer(&pet_id);
 
     // Chain has one entry; no contract function can remove it
@@ -595,7 +670,9 @@ fn custody_chain_is_append_only_no_delete_path() {
     let third_owner = Address::generate(&env);
     client.initiate_transfer(&pet_id, &third_owner);
     client.accept_transfer(&pet_id);
-    env.ledger().with_mut(|l| { l.timestamp += DISPUTE_WINDOW_SECONDS + 1; });
+    env.ledger().with_mut(|l| {
+        l.timestamp += DISPUTE_WINDOW_SECONDS + 1;
+    });
     client.finalize_transfer(&pet_id);
 
     let chain = client.get_custody_chain(&pet_id);


### PR DESCRIPTION
Closes #628
Closes #639
Closes #643
Closes #646

Summary:
- Added otpauth:// URI generation with encoded issuer/account values and returned it with 2FA enrollment and recovery setup responses.
- Added injectable TwoFactorStore support plus a configurable MockTwoFactorStore for handler tests covering enroll, verify, disable, recover, and mock error/timeout injection.
- Added trusted main-contract address storage and multisig-gated trusted address updates to the transfer/adoption contract, with validation and update event coverage.
- Added a contract-local size-tuned release profile and documented the twiggy size audit showing 49,332 bytes to 41,245 bytes, a 16.39% reduction.

Validation:
- cargo test test_otpauth_uri_url_encodes_issuer_and_account (backend-2fa)
- cargo test test_handlers_use_configurable_mock_store_for_enroll_verify_disable_recover (backend-2fa)
- cargo test test_mock_store_error_and_timeout_injection (backend-2fa)
- cargo test (stellar-contracts/contracts/pet-transfer-adoption)
- cargo build --release --target wasm32-unknown-unknown (stellar-contracts/contracts/pet-transfer-adoption)
- twiggy top -n 12 target/wasm32-unknown-unknown/release/pet_transfer_adoption.wasm

Known existing blockers:
- Full backend cargo test still has unrelated existing failures in db::tests::select_secret_provider_aws and leaderboard validation tests.
- Root stellar-contracts release build is blocked by existing duplicate contract types and a nested gas_profile_tests module in stellar-contracts/src/lib.rs; the buildable transfer/adoption contract was audited and reduced.