### PR TITLE
Treatment count fixes

### DIFF
--- a/backend-2fa/schema.sql
+++ b/backend-2fa/schema.sql
@@ -56,3 +56,13 @@ CREATE TABLE canary_accounts (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (tenant_id, user_id)
 );
+
+-- Persistent 2FA lockout state. Redis stores the hot failure counter, but this
+-- table is the source of truth for full account lockout after 10 failures.
+CREATE TABLE two_fa_lockouts (
+    user_id VARCHAR(255) PRIMARY KEY,
+    failed_attempts INT NOT NULL DEFAULT 0,
+    locked BOOLEAN NOT NULL DEFAULT FALSE,
+    locked_at TIMESTAMP NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -1,4 +1,7 @@
-use crate::two_factor::{AuditLogEntry, RecoveryCodeUsageLog, TwoFactorData, TwoFactorStore, UserTwoFactorSummary};
+use crate::two_factor::{
+    AuditLogEntry, RecoveryCodeUsageLog, TwoFactorData, TwoFactorLockoutState, TwoFactorStore,
+    UserTwoFactorSummary,
+};
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::sync::Arc;
 use std::time::Duration;
@@ -486,6 +489,79 @@ impl TwoFactorStore for PostgresTwoFactorStore {
         )
         .map(|c| c > 0)
         .unwrap_or(false)
+    }
+
+    fn get_lockout_state(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            failed_attempts: i32,
+            locked: bool,
+            locked_at: Option<i64>,
+            updated_at: i64,
+        }
+
+        let row = self.block_on(
+            sqlx::query_as::<_, Row>(
+                r#"
+                SELECT failed_attempts, locked,
+                       EXTRACT(EPOCH FROM locked_at)::bigint AS locked_at,
+                       EXTRACT(EPOCH FROM updated_at)::bigint AS updated_at
+                FROM two_fa_lockouts
+                WHERE user_id = $1
+                "#,
+            )
+            .bind(user_id)
+            .fetch_optional(&self.pool),
+        )?;
+
+        Ok(row
+            .map(|r| TwoFactorLockoutState {
+                failed_attempts: r.failed_attempts.max(0) as u32,
+                locked: r.locked,
+                locked_at: r.locked_at.map(|ts| ts as u64),
+                updated_at: r.updated_at as u64,
+            })
+            .unwrap_or_default())
+    }
+
+    fn record_failed_two_fa_attempt(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+        self.block_on(
+            sqlx::query(
+                r#"
+                INSERT INTO two_fa_lockouts (user_id, failed_attempts, locked, locked_at, updated_at)
+                VALUES ($1, 1, FALSE, NULL, CURRENT_TIMESTAMP)
+                ON CONFLICT (user_id)
+                DO UPDATE SET
+                    failed_attempts = two_fa_lockouts.failed_attempts + 1,
+                    locked = (two_fa_lockouts.failed_attempts + 1) >= 10,
+                    locked_at = CASE
+                        WHEN (two_fa_lockouts.failed_attempts + 1) >= 10
+                             AND two_fa_lockouts.locked_at IS NULL
+                        THEN CURRENT_TIMESTAMP
+                        ELSE two_fa_lockouts.locked_at
+                    END,
+                    updated_at = CURRENT_TIMESTAMP
+                "#,
+            )
+            .bind(user_id)
+            .execute(&self.pool),
+        )?;
+        self.get_lockout_state(user_id)
+    }
+
+    fn reset_two_fa_failures(&self, user_id: &str) -> Result<(), String> {
+        self.block_on(
+            sqlx::query("DELETE FROM two_fa_lockouts WHERE user_id = $1")
+                .bind(user_id)
+                .execute(&self.pool),
+        )?;
+        Ok(())
+    }
+
+    fn unlock_two_fa_account(&self, user_id: &str, actor: &str) -> Result<(), String> {
+        self.reset_two_fa_failures(user_id)?;
+        self.append_audit_log(user_id, "two_fa_account_unlocked", actor, None)?;
+        Ok(())
     }
 }
 

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -1,7 +1,9 @@
 #[cfg(not(test))]
 use crate::db::PostgresTwoFactorStore;
 use crate::leaderboard::{FlaggedScoreStore, FlaggedScoreSubmission};
-use crate::rate_limiter::{InMemoryRateLimiter, RateLimitResult, RateLimiter, UserQuotaStore};
+use crate::rate_limiter::{
+    progressive_delay_secs, InMemoryRateLimiter, RateLimitResult, RateLimiter, UserQuotaStore,
+};
 use crate::two_factor::{
     AuditLogEntry, InMemoryStore, TwoFactorAuth, TwoFactorData, TwoFactorStore,
     UserTwoFactorSummary, TenantConfig, TenantRegistry, TenantScopedStore,
@@ -164,6 +166,28 @@ impl TwoFactorHandlers {
             .map_err(|_| format!("2FA not configured for user {}", user_id))
     }
 
+    fn ensure_not_locked(&self, user_id: &str) -> Result<(), String> {
+        let state = self.store.get_lockout_state(user_id)?;
+        if state.locked {
+            return Err("2FA account locked after 10 failed attempts. Use admin unlock or a recovery code.".to_string());
+        }
+        Ok(())
+    }
+
+    fn record_failed_verification(&self, user_id: &str) -> Result<(), String> {
+        let state = self.store.record_failed_two_fa_attempt(user_id)?;
+        if state.locked {
+            return Err("2FA account locked after 10 failed attempts. Use admin unlock or a recovery code.".to_string());
+        }
+        if let Some(delay) = progressive_delay_secs(state.failed_attempts) {
+            return Err(format!(
+                "Invalid 2FA token. Retry after {} seconds.",
+                delay
+            ));
+        }
+        Err("Invalid 2FA token.".to_string())
+    }
+
     pub fn enable_two_factor(
         caller: &AuthenticatedUser,
         req: EnableTwoFactorRequest,
@@ -212,25 +236,19 @@ impl TwoFactorHandlers {
     ) -> Result<bool, String> {
         caller.authorize(&req.user_id)?;
 
-        let key = format!("verify:{}", req.user_id);
-        if let RateLimitResult::Blocked { retry_after_secs } = self.limiter.record_failure(&key) {
-            return Err(format!(
-                "Too many failed attempts. Retry after {} seconds.",
-                retry_after_secs
-            ));
-        }
+        self.ensure_not_locked(&req.user_id)?;
 
         let data = self.store_get(&req.user_id)?;
         let result = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
         if result {
             self.store.update_enabled(&req.user_id, true)?;
+            self.store.reset_two_fa_failures(&req.user_id)?;
+            self.limiter.record_success(&format!("verify:{}", req.user_id));
+            return Ok(true);
         }
 
-        if result {
-            self.limiter.record_success(&key);
-        }
-
-        Ok(result)
+        self.record_failed_verification(&req.user_id)?;
+        Ok(false)
     }
 
     pub fn verify_login_token(
@@ -240,13 +258,7 @@ impl TwoFactorHandlers {
     ) -> Result<bool, String> {
         caller.authorize(&req.user_id)?;
 
-        let key = format!("login:{}", req.user_id);
-        if let RateLimitResult::Blocked { retry_after_secs } = self.limiter.record_failure(&key) {
-            return Err(format!(
-                "Too many failed attempts. Retry after {} seconds.",
-                retry_after_secs
-            ));
-        }
+        self.ensure_not_locked(&req.user_id)?;
 
         let data = self.store_get(&req.user_id)?;
         if !data.enabled {
@@ -256,10 +268,13 @@ impl TwoFactorHandlers {
         let is_valid = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
 
         if is_valid {
-            self.limiter.record_success(&key);
+            self.store.reset_two_fa_failures(&req.user_id)?;
+            self.limiter.record_success(&format!("login:{}", req.user_id));
+            return Ok(true);
         }
 
-        Ok(is_valid)
+        self.record_failed_verification(&req.user_id)?;
+        Ok(false)
     }
 
     pub fn disable_two_factor(
@@ -269,13 +284,7 @@ impl TwoFactorHandlers {
     ) -> Result<bool, String> {
         caller.authorize(&req.user_id)?;
 
-        let key = format!("disable:{}", req.user_id);
-        if let RateLimitResult::Blocked { retry_after_secs } = self.limiter.record_failure(&key) {
-            return Err(format!(
-                "Too many failed attempts. Retry after {} seconds.",
-                retry_after_secs
-            ));
-        }
+        self.ensure_not_locked(&req.user_id)?;
 
         let data = self.store_get(&req.user_id)?;
         if !data.enabled {
@@ -285,13 +294,13 @@ impl TwoFactorHandlers {
         let result = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
         if result {
             self.store.update_enabled(&req.user_id, false)?;
+            self.store.reset_two_fa_failures(&req.user_id)?;
+            self.limiter.record_success(&format!("disable:{}", req.user_id));
+            return Ok(true);
         }
 
-        if result {
-            self.limiter.record_success(&key);
-        }
-
-        Ok(result)
+        self.record_failed_verification(&req.user_id)?;
+        Ok(false)
     }
 
     pub fn recover_with_backup(
@@ -358,6 +367,8 @@ impl TwoFactorHandlers {
                 enabled: true,
             },
         )?;
+        self.store
+            .unlock_two_fa_account(&req.user_id, "recovery_code")?;
 
         Ok(RecoverWithBackupResponse {
             new_secret: setup.secret,
@@ -559,6 +570,11 @@ impl AdminDashboardHandlers {
     /// POST /admin/users/{id}/disable-2fa — force-disable with audit log entry.
     pub fn disable_two_fa(admin: &AuthenticatedAdmin, user_id: &str) -> Result<(), String> {
         two_factor_store().admin_disable_two_fa(user_id, &admin.admin_id)
+    }
+
+    /// POST /admin/users/{id}/unlock-2fa — clear persistent lockout state.
+    pub fn unlock_two_fa(admin: &AuthenticatedAdmin, user_id: &str) -> Result<(), String> {
+        two_factor_store().unlock_two_fa_account(user_id, &admin.admin_id)
     }
 
     /// GET /admin/users/{id}/audit-log — full 2FA event history (paginated).

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -24,7 +24,7 @@ pub use leaderboard::{
 pub use rate_limiter::{
     DistributedRateLimiter, EndpointConfig, InMemoryRateLimiter, LiveRedisBackend,
     MockRedisBackend, RateLimitResult, RateLimiter, RedisBackend, RedisRateLimiter,
-    SlidingWindowRateLimiter,
+    RedisTwoFactorFailureCounter, SlidingWindowRateLimiter, progressive_delay_secs,
 };
 pub use metrics::{
     metrics, record_rate_limit_hit, record_recovery_code_use, record_totp_verification,
@@ -33,7 +33,7 @@ pub use metrics::{
 pub use tracing_middleware::sanitize_json_body;
 pub use two_factor::{
     AuditLogEntry, InMemoryStore, RecoveryResult, TotpConfig, TwoFactorAuth, TwoFactorData,
-    TwoFactorSetup, TwoFactorStore, UserTwoFactorSummary,
+    TwoFactorLockoutState, TwoFactorSetup, TwoFactorStore, UserTwoFactorSummary,
     TenantConfig, TenantRegistry, TenantScopedStore,
 };
 pub use webhooks::{

--- a/backend-2fa/src/rate_limiter.rs
+++ b/backend-2fa/src/rate_limiter.rs
@@ -53,6 +53,62 @@ pub trait RedisBackend: Send + Sync {
     fn set_ex(&self, key: &str, value: &str, ttl_secs: u64);
     /// Delete one or more keys.
     fn del(&self, keys: &[&str]);
+    /// Increment a string counter and set TTL on first write.
+    fn incr_with_ttl(&self, key: &str, ttl_secs: u64) -> u64 {
+        let _ = (key, ttl_secs);
+        0
+    }
+    /// Read a string counter.
+    fn get_u64(&self, key: &str) -> Option<u64> {
+        let _ = key;
+        None
+    }
+}
+
+pub fn progressive_delay_secs(attempt: u32) -> Option<u64> {
+    if attempt == 0 || attempt >= 10 {
+        None
+    } else {
+        Some(1u64 << (attempt - 1).min(8))
+    }
+}
+
+pub struct RedisTwoFactorFailureCounter<B: RedisBackend> {
+    backend: B,
+    key_prefix: String,
+    ttl_secs: u64,
+}
+
+impl<B: RedisBackend> RedisTwoFactorFailureCounter<B> {
+    pub fn new(backend: B, key_prefix: impl Into<String>, ttl_secs: u64) -> Self {
+        Self {
+            backend,
+            key_prefix: key_prefix.into(),
+            ttl_secs,
+        }
+    }
+
+    fn key(&self, user_id: &str) -> String {
+        format!("{}2fa:failures:{}", self.key_prefix, user_id)
+    }
+
+    pub fn record_failure(&self, user_id: &str) -> u32 {
+        self.backend
+            .incr_with_ttl(&self.key(user_id), self.ttl_secs)
+            .min(u32::MAX as u64) as u32
+    }
+
+    pub fn get_failures(&self, user_id: &str) -> u32 {
+        self.backend
+            .get_u64(&self.key(user_id))
+            .unwrap_or(0)
+            .min(u32::MAX as u64) as u32
+    }
+
+    pub fn reset(&self, user_id: &str) {
+        let key = self.key(user_id);
+        self.backend.del(&[&key]);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +170,23 @@ impl RedisBackend for LiveRedisBackend {
             let _: Result<(), _> = redis::cmd("DEL").arg(keys).query(&mut con);
         }
     }
+
+    fn incr_with_ttl(&self, key: &str, ttl_secs: u64) -> u64 {
+        let mut con = match self.client.get_connection() {
+            Ok(c) => c,
+            Err(_) => return 0,
+        };
+        let count: u64 = redis::cmd("INCR").arg(key).query(&mut con).unwrap_or(0);
+        if count == 1 {
+            let _: Result<(), _> = redis::cmd("EXPIRE").arg(key).arg(ttl_secs).query(&mut con);
+        }
+        count
+    }
+
+    fn get_u64(&self, key: &str) -> Option<u64> {
+        let mut con = self.client.get_connection().ok()?;
+        redis::cmd("GET").arg(key).query(&mut con).ok()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +198,7 @@ struct MockEntry {
     zset: Vec<(u64, String)>,
     /// Expiry in mock-clock milliseconds (None = no expiry)
     expires_at_ms: Option<u64>,
+    value: Option<u64>,
 }
 
 /// In-process mock that faithfully implements the sorted-set sliding window.
@@ -184,6 +258,7 @@ impl RedisBackend for MockRedisBackend {
         let entry = store.entry(key.to_string()).or_insert(MockEntry {
             zset: Vec::new(),
             expires_at_ms: None,
+            value: None,
         });
         // Evict if the key itself has expired
         if let Some(exp) = entry.expires_at_ms {
@@ -207,6 +282,7 @@ impl RedisBackend for MockRedisBackend {
         store.insert(key.to_string(), MockEntry {
             zset: vec![(0, value.to_string())],
             expires_at_ms: Some(now_ms + ttl_secs * 1_000),
+            value: None,
         });
     }
 
@@ -214,6 +290,34 @@ impl RedisBackend for MockRedisBackend {
         let mut store = self.store.lock().unwrap();
         for k in keys {
             store.remove(*k);
+        }
+    }
+
+    fn incr_with_ttl(&self, key: &str, ttl_secs: u64) -> u64 {
+        let now_ms = self.current_ms();
+        let mut store = self.store.lock().unwrap();
+        let entry = store.entry(key.to_string()).or_insert(MockEntry {
+            zset: Vec::new(),
+            expires_at_ms: Some(now_ms + ttl_secs * 1_000),
+            value: Some(0),
+        });
+        if entry.expires_at_ms.map(|exp| now_ms >= exp).unwrap_or(false) {
+            entry.value = Some(0);
+        }
+        let value = entry.value.unwrap_or(0).saturating_add(1);
+        entry.value = Some(value);
+        entry.expires_at_ms = Some(now_ms + ttl_secs * 1_000);
+        value
+    }
+
+    fn get_u64(&self, key: &str) -> Option<u64> {
+        let now_ms = self.current_ms();
+        let store = self.store.lock().unwrap();
+        let entry = store.get(key)?;
+        if entry.expires_at_ms.map(|exp| now_ms >= exp).unwrap_or(false) {
+            None
+        } else {
+            entry.value
         }
     }
 }

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -3218,3 +3218,138 @@ mod distributed_rate_limiter_tests {
         assert!(blocked >= 5, "expected at least 5 blocked, got {blocked}");
     }
 }
+
+mod progressive_two_factor_lockout_tests {
+    use crate::handlers::{
+        AuthenticatedAdmin, AuthenticatedUser, EnableTwoFactorRequest, LoginWithTwoFactorRequest,
+        TwoFactorHandlers,
+    };
+    use crate::rate_limiter::{
+        progressive_delay_secs, MockRedisBackend, RedisTwoFactorFailureCounter,
+    };
+    use crate::two_factor::{InMemoryStore, TwoFactorStore};
+    use std::sync::Arc;
+    use totp_rs::{Algorithm, Secret, TOTP};
+
+    fn generate_token(secret: &str) -> String {
+        TOTP::new(
+            Algorithm::SHA1,
+            6,
+            1,
+            30,
+            Secret::Encoded(secret.to_string()).to_bytes().unwrap(),
+            None,
+            String::new(),
+        )
+        .unwrap()
+        .generate_current()
+        .unwrap()
+    }
+
+    #[test]
+    fn delay_doubles_through_attempt_nine() {
+        let expected = [1, 2, 4, 8, 16, 32, 64, 128, 256];
+        for (attempt, delay) in (1u32..=9).zip(expected) {
+            assert_eq!(progressive_delay_secs(attempt), Some(delay));
+        }
+        assert_eq!(progressive_delay_secs(10), None);
+    }
+
+    #[test]
+    fn redis_failure_counter_tracks_attempts() {
+        let counter = RedisTwoFactorFailureCounter::new(MockRedisBackend::new(), "test:", 300);
+        assert_eq!(counter.record_failure("user-1"), 1);
+        assert_eq!(counter.record_failure("user-1"), 2);
+        assert_eq!(counter.get_failures("user-1"), 2);
+        counter.reset("user-1");
+        assert_eq!(counter.get_failures("user-1"), 0);
+    }
+
+    #[test]
+    fn persistent_store_locks_after_ten_failures() {
+        let store = InMemoryStore::default();
+        for attempt in 1..=9 {
+            let state = store.record_failed_two_fa_attempt("user-lock").unwrap();
+            assert_eq!(state.failed_attempts, attempt);
+            assert!(!state.locked);
+        }
+
+        let state = store.record_failed_two_fa_attempt("user-lock").unwrap();
+        assert_eq!(state.failed_attempts, 10);
+        assert!(state.locked);
+        assert!(state.locked_at.is_some());
+    }
+
+    #[test]
+    fn admin_unlock_clears_lockout_state() {
+        let store = InMemoryStore::default();
+        for _ in 0..10 {
+            store.record_failed_two_fa_attempt("user-admin-unlock").unwrap();
+        }
+        assert!(store.get_lockout_state("user-admin-unlock").unwrap().locked);
+
+        store
+            .unlock_two_fa_account("user-admin-unlock", "admin-1")
+            .unwrap();
+
+        let state = store.get_lockout_state("user-admin-unlock").unwrap();
+        assert_eq!(state.failed_attempts, 0);
+        assert!(!state.locked);
+    }
+
+    #[test]
+    fn handler_locks_after_ten_invalid_tokens_and_admin_unlocks() {
+        let store = Arc::new(InMemoryStore::default());
+        let handlers = TwoFactorHandlers::with_store(store.clone());
+        let user_id = "handler-lockout-user";
+        let caller = AuthenticatedUser::new(user_id);
+        let enrollment = handlers
+            .enroll(
+                &caller,
+                EnableTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    email: "lockout@example.com".to_string(),
+                },
+            )
+            .unwrap();
+        store.update_enabled(user_id, true).unwrap();
+
+        for _ in 0..9 {
+            let err = handlers
+                .verify_login_token(
+                    &caller,
+                    LoginWithTwoFactorRequest {
+                        user_id: user_id.to_string(),
+                        token: "000000".to_string(),
+                    },
+                )
+                .unwrap_err();
+            assert!(err.contains("Retry after"));
+        }
+
+        let locked = handlers
+            .verify_login_token(
+                &caller,
+                LoginWithTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    token: "000000".to_string(),
+                },
+            )
+            .unwrap_err();
+        assert!(locked.contains("locked after 10"));
+
+        store
+            .unlock_two_fa_account(user_id, &AuthenticatedAdmin::new("admin").admin_id)
+            .unwrap();
+        let token = generate_token(&enrollment.secret);
+        assert!(handlers
+            .verify_login_token(
+                &caller,
+                LoginWithTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    token,
+                },
+            )
+            .unwrap());
+    }
+}

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -255,6 +255,14 @@ pub struct AuditLogEntry {
     pub metadata: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct TwoFactorLockoutState {
+    pub failed_attempts: u32,
+    pub locked: bool,
+    pub locked_at: Option<u64>,
+    pub updated_at: u64,
+}
+
 /// Persistence abstraction for 2FA state (kept for compatibility)
 pub trait TwoFactorStore: Send + Sync {
     fn save(&self, user_id: &str, data: TwoFactorData) -> Result<(), String>;
@@ -312,6 +320,18 @@ pub trait TwoFactorStore: Send + Sync {
 
     /// Check whether a user account is a canary.
     fn is_canary(&self, user_id: &str) -> bool;
+
+    /// Persistent lockout state, used after Redis restarts.
+    fn get_lockout_state(&self, user_id: &str) -> Result<TwoFactorLockoutState, String>;
+
+    /// Increment failed 2FA attempts and persist lockout after the tenth failure.
+    fn record_failed_two_fa_attempt(&self, user_id: &str) -> Result<TwoFactorLockoutState, String>;
+
+    /// Reset failed attempts after a successful TOTP verification or recovery.
+    fn reset_two_fa_failures(&self, user_id: &str) -> Result<(), String>;
+
+    /// Admin/recovery unlock for fully locked accounts.
+    fn unlock_two_fa_account(&self, user_id: &str, actor: &str) -> Result<(), String>;
 }
 
 /// In-memory implementation of TwoFactorStore for testing
@@ -321,6 +341,7 @@ pub struct InMemoryStore {
     recovery_log: Arc<Mutex<Vec<RecoveryCodeUsageLog>>>,
     audit_log: Arc<Mutex<Vec<AuditLogEntry>>>,
     canary_flags: Arc<Mutex<HashMap<String, bool>>>,
+    lockouts: Arc<Mutex<HashMap<String, TwoFactorLockoutState>>>,
 }
 
 impl InMemoryStore {
@@ -553,6 +574,43 @@ impl TwoFactorStore for InMemoryStore {
             .copied()
             .unwrap_or(false)
     }
+
+    fn get_lockout_state(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+        Ok(self
+            .lockouts
+            .lock()
+            .unwrap()
+            .get(user_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn record_failed_two_fa_attempt(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+        let mut lockouts = self.lockouts.lock().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let state = lockouts.entry(user_id.to_string()).or_default();
+        state.failed_attempts = state.failed_attempts.saturating_add(1);
+        state.updated_at = now;
+        if state.failed_attempts >= 10 {
+            state.locked = true;
+            state.locked_at = Some(now);
+        }
+        Ok(state.clone())
+    }
+
+    fn reset_two_fa_failures(&self, user_id: &str) -> Result<(), String> {
+        self.lockouts.lock().unwrap().remove(user_id);
+        Ok(())
+    }
+
+    fn unlock_two_fa_account(&self, user_id: &str, actor: &str) -> Result<(), String> {
+        self.reset_two_fa_failures(user_id)?;
+        self.append_audit_log(user_id, "two_fa_account_unlocked", actor, None)?;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -652,6 +710,25 @@ impl TenantScopedStore {
 
     pub fn is_canary(&self, user_id: &str) -> bool {
         self.inner.is_canary(&self.key(user_id))
+    }
+
+    pub fn get_lockout_state(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+        self.inner.get_lockout_state(&self.key(user_id))
+    }
+
+    pub fn record_failed_two_fa_attempt(
+        &self,
+        user_id: &str,
+    ) -> Result<TwoFactorLockoutState, String> {
+        self.inner.record_failed_two_fa_attempt(&self.key(user_id))
+    }
+
+    pub fn reset_two_fa_failures(&self, user_id: &str) -> Result<(), String> {
+        self.inner.reset_two_fa_failures(&self.key(user_id))
+    }
+
+    pub fn unlock_two_fa_account(&self, user_id: &str, actor: &str) -> Result<(), String> {
+        self.inner.unlock_two_fa_account(&self.key(user_id), actor)
     }
 
     /// TOTP issuer name for this tenant (used when generating QR codes).

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -188,6 +188,8 @@ mod test_upgrade_proposal;
 mod test_vaccination_expiry;
 #[cfg(test)]
 mod test_medical_record_soft_delete;
+#[cfg(test)]
+mod test_event_subscriptions;
 
 use soroban_sdk::xdr::{FromXdr, ToXdr};
 use soroban_sdk::{
@@ -202,6 +204,7 @@ const MAX_SEARCH_TOKENS_PER_RECORD: u32 = 16;
 const MAX_SEARCH_NOTES_LEN: u32 = 512;
 const MAX_LINEAGE_DEPTH: u32 = 16;
 const MAX_LOG_ENTRIES: u32 = 1_000;
+const MAX_ACTIVE_SUBSCRIPTIONS_PER_ADDRESS: u32 = 10;
 
 // --- INPUT VALIDATION MIDDLEWARE ---
 
@@ -972,6 +975,37 @@ pub enum TreatmentKey {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EventType {
+    PetRegistered,
+    TreatmentAdded,
+    MedicalRecordAdded,
+    VaccinationAdded,
+    AccessGranted,
+    AccessRevoked,
+    InsuranceClaimSubmitted,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventSubscription {
+    pub id: u64,
+    pub subscriber: Address,
+    pub event_types: Vec<EventType>,
+    pub pet_ids: Vec<u64>,
+    pub expires_at: u64,
+    pub created_at: u64,
+}
+
+#[contracttype]
+pub enum SubscriptionKey {
+    Subscription(u64),
+    SubscriptionCount,
+    SubscriberSubscriptionCount(Address),
+    SubscriberSubscriptionIndex((Address, u64)),
+}
+
+#[contracttype]
 pub enum TagKey {
     // Tag Linking System keys
     Tag(soroban_sdk::BytesN<32>), // tag_id -> PetTag (reverse lookup for QR scan)
@@ -1716,6 +1750,7 @@ pub struct TreatmentAddedEvent {
     pub vet_address: Address,
     pub treatment_type: TreatmentType,
     pub timestamp: u64,
+    pub subscription_ids: Vec<u64>,
 }
 
 // --- EVENTS ---
@@ -1885,6 +1920,7 @@ pub struct PetRegisteredEvent {
     pub name: String,
     pub species: Species,
     pub timestamp: u64,
+    pub subscription_ids: Vec<u64>,
 }
 
 #[contracttype]
@@ -1897,6 +1933,7 @@ pub struct VaccinationAddedEvent {
     pub vaccine_type: VaccineType,
     pub next_due_date: u64,
     pub timestamp: u64,
+    pub subscription_ids: Vec<u64>,
 }
 
 #[contracttype]
@@ -1939,6 +1976,7 @@ pub struct MedicalRecordAddedEvent {
     pub pet_id: u64,
     pub updated_by: Address,
     pub timestamp: u64,
+    pub subscription_ids: Vec<u64>,
 }
 
 #[contracttype]
@@ -1990,6 +2028,136 @@ pub struct PetChainContract;
 #[contractimpl]
 impl PetChainContract {
     // --- CONTRACT STATISTICS ---
+
+    pub fn register_subscription(
+        env: Env,
+        subscriber: Address,
+        event_types: Vec<EventType>,
+        pet_ids: Vec<u64>,
+        ttl: u64,
+    ) -> u64 {
+        subscriber.require_auth();
+
+        if event_types.len() == 0 || pet_ids.len() == 0 || ttl == 0 {
+            panic_with_error!(&env, ContractError::InvalidInput);
+        }
+
+        let now = env.ledger().timestamp();
+        let existing_count: u64 = env
+            .storage()
+            .instance()
+            .get(&SubscriptionKey::SubscriberSubscriptionCount(subscriber.clone()))
+            .unwrap_or(0);
+        let mut active_count = 0u32;
+        for i in 1..=existing_count {
+            let Some(subscription_id) = env
+                .storage()
+                .instance()
+                .get::<SubscriptionKey, u64>(&SubscriptionKey::SubscriberSubscriptionIndex((
+                    subscriber.clone(),
+                    i,
+                )))
+            else {
+                continue;
+            };
+            if let Some(subscription) = env
+                .storage()
+                .instance()
+                .get::<SubscriptionKey, EventSubscription>(&SubscriptionKey::Subscription(
+                    subscription_id,
+                ))
+            {
+                if subscription.expires_at > now {
+                    active_count += 1;
+                }
+            }
+        }
+
+        if active_count >= MAX_ACTIVE_SUBSCRIPTIONS_PER_ADDRESS {
+            panic_with_error!(&env, ContractError::TooManyItems);
+        }
+
+        let current_id: u64 = env
+            .storage()
+            .instance()
+            .get(&SubscriptionKey::SubscriptionCount)
+            .unwrap_or(0);
+        let subscription_id = safe_increment(current_id);
+        let expires_at = now.saturating_add(ttl);
+        let subscription = EventSubscription {
+            id: subscription_id,
+            subscriber: subscriber.clone(),
+            event_types,
+            pet_ids,
+            expires_at,
+            created_at: now,
+        };
+
+        env.storage()
+            .instance()
+            .set(&SubscriptionKey::Subscription(subscription_id), &subscription);
+        env.storage()
+            .instance()
+            .set(&SubscriptionKey::SubscriptionCount, &subscription_id);
+
+        let new_subscriber_count = safe_increment(existing_count);
+        env.storage().instance().set(
+            &SubscriptionKey::SubscriberSubscriptionCount(subscriber.clone()),
+            &new_subscriber_count,
+        );
+        env.storage().instance().set(
+            &SubscriptionKey::SubscriberSubscriptionIndex((subscriber, new_subscriber_count)),
+            &subscription_id,
+        );
+
+        subscription_id
+    }
+
+    pub fn get_subscription(env: Env, subscription_id: u64) -> Option<EventSubscription> {
+        env.storage()
+            .instance()
+            .get(&SubscriptionKey::Subscription(subscription_id))
+    }
+
+    pub fn get_matching_subscription_ids(
+        env: Env,
+        event_type: EventType,
+        pet_id: u64,
+    ) -> Vec<u64> {
+        Self::matching_subscription_ids(&env, event_type, pet_id)
+    }
+
+    fn matching_subscription_ids(env: &Env, event_type: EventType, pet_id: u64) -> Vec<u64> {
+        let now = env.ledger().timestamp();
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&SubscriptionKey::SubscriptionCount)
+            .unwrap_or(0);
+        let mut matches = Vec::new(env);
+
+        for subscription_id in 1..=count {
+            let Some(subscription) = env
+                .storage()
+                .instance()
+                .get::<SubscriptionKey, EventSubscription>(&SubscriptionKey::Subscription(
+                    subscription_id,
+                ))
+            else {
+                continue;
+            };
+
+            if subscription.expires_at <= now {
+                continue;
+            }
+            if subscription.event_types.contains(&event_type) && subscription.pet_ids.contains(&pet_id)
+            {
+                matches.push_back(subscription.id);
+            }
+        }
+
+        matches
+    }
 
     /// Returns the total number of pets ever registered in the contract.
     pub fn get_total_pets(env: Env) -> u64 {
@@ -2762,6 +2930,11 @@ impl PetChainContract {
                 name: String::from_str(&env, "PROTECTED"), // Masking name in event for safety
                 species,
                 timestamp,
+                subscription_ids: Self::matching_subscription_ids(
+                    &env,
+                    EventType::PetRegistered,
+                    pet_id,
+                ),
             },
         );
 
@@ -4047,6 +4220,11 @@ impl PetChainContract {
                 vaccine_type,
                 next_due_date,
                 timestamp: now,
+                subscription_ids: Self::matching_subscription_ids(
+                    &env,
+                    EventType::VaccinationAdded,
+                    pet_id,
+                ),
             },
         );
 
@@ -6725,9 +6903,15 @@ impl PetChainContract {
         env.events().publish(
             (String::from_str(&env, "MedicalRecordAdded"), pet_id),
             MedicalRecordAddedEvent {
+                version: EVENT_SCHEMA_VERSION,
                 pet_id,
                 updated_by: vet_address.clone(),
                 timestamp: now,
+                subscription_ids: Self::matching_subscription_ids(
+                    &env,
+                    EventType::MedicalRecordAdded,
+                    pet_id,
+                ),
             },
         );
         PetChainContract::log_access(
@@ -11106,6 +11290,11 @@ impl PetChainContract {
                 vet_address,
                 treatment_type,
                 timestamp: now,
+                subscription_ids: Self::matching_subscription_ids(
+                    &env,
+                    EventType::TreatmentAdded,
+                    pet_id,
+                ),
             },
         );
 

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -760,9 +760,12 @@ pub struct ClinicInfo {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Specialization {
-    pub name: String,
-    pub certified_date: u64,
+pub enum Specialization {
+    GeneralPractice,
+    Surgery,
+    Dermatology,
+    Oncology,
+    Dentistry,
 }
 
 #[contracttype]
@@ -901,6 +904,7 @@ pub enum DataKey {
     /// `verify_vet_license()`. Presence of this key is the authoritative
     /// signal used by `grant_access` to allow vet access grants.
     VetLicenseVerified(Address), // vet_address -> verified license_id (String)
+    VetSpecializations(Address), // vet_address -> Vec<Specialization>, admin verified
 
     // Contract Upgrade keys
     ContractVersion,
@@ -3780,6 +3784,70 @@ impl PetChainContract {
         PetChainContract::_verify_vet_internal(&env, vet_address)
     }
 
+    pub fn register_vet_specializations(
+        env: Env,
+        admin: Address,
+        vet_address: Address,
+        specializations: Vec<Specialization>,
+    ) -> bool {
+        PetChainContract::require_admin_auth(&env, &admin);
+
+        let vet = env
+            .storage()
+            .instance()
+            .get::<DataKey, Vet>(&DataKey::Vet(vet_address.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::VetNotFound));
+
+        if !vet.verified {
+            panic_with_error!(&env, ContractError::VeterinarianNotVerified);
+        }
+
+        if specializations.len() == 0 || specializations.len() > 5 {
+            panic_with_error!(&env, ContractError::InvalidInput);
+        }
+
+        let mut verified = Vec::new(&env);
+        for specialization in specializations.iter() {
+            if !verified.contains(&specialization) {
+                verified.push_back(specialization);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::VetSpecializations(vet_address), &verified);
+        true
+    }
+
+    pub fn get_vet_specializations(env: Env, vet_address: Address) -> Vec<Specialization> {
+        env.storage()
+            .instance()
+            .get(&DataKey::VetSpecializations(vet_address))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    fn vet_has_specialization(
+        env: &Env,
+        vet_address: &Address,
+        specialization: Specialization,
+    ) -> bool {
+        env.storage()
+            .instance()
+            .get::<DataKey, Vec<Specialization>>(&DataKey::VetSpecializations(vet_address.clone()))
+            .map(|specializations| specializations.contains(&specialization))
+            .unwrap_or(false)
+    }
+
+    fn require_vet_specialization(
+        env: &Env,
+        vet_address: &Address,
+        specialization: Specialization,
+    ) {
+        if !Self::vet_has_specialization(env, vet_address, specialization) {
+            panic_with_error!(env, ContractError::Unauthorized);
+        }
+    }
+
     fn _verify_vet_internal(env: &Env, vet_address: Address) -> bool {
         if let Some(mut vet) = env
             .storage()
@@ -6575,6 +6643,9 @@ impl PetChainContract {
         // Verify vet is verified
         if !PetChainContract::is_verified_vet(env.clone(), vet_address.clone()) {
             panic!("Veterinarian not verified");
+        }
+        if treatment == String::from_str(&env, "Surgery") {
+            Self::require_vet_specialization(&env, &vet_address, Specialization::Surgery);
         }
 
         // Verify pet exists
@@ -10965,6 +11036,10 @@ impl PetChainContract {
 
         if !PetChainContract::is_verified_vet(env.clone(), vet_address.clone()) {
             panic!("Veterinarian not verified");
+        }
+
+        if treatment_type == TreatmentType::Surgery {
+            Self::require_vet_specialization(&env, &vet_address, Specialization::Surgery);
         }
 
         let _pet: Pet = env

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -11043,6 +11043,13 @@ impl PetChainContract {
             .get::<TreatmentKey, Treatment>(&TreatmentKey::Treatment(treatment_id))
     }
 
+    pub fn get_treatment_count(env: Env, pet_id: u64) -> u64 {
+        env.storage()
+            .instance()
+            .get(&TreatmentKey::PetTreatmentCount(pet_id))
+            .unwrap_or(0)
+    }
+
     pub fn get_treatment_history(env: Env, pet_id: u64, offset: u64, limit: u32) -> Vec<Treatment> {
         if env
             .storage()

--- a/stellar-contracts/src/test_access_control.rs
+++ b/stellar-contracts/src/test_access_control.rs
@@ -1920,3 +1920,106 @@ fn test_export_access_log_admin_can_export() {
     let logs = client.export_access_log(&admin, &pet_id, &0u64, &1000u64, &1u32);
     assert!(!logs.is_empty());
 }
+
+fn setup_verified_vet_for_specialization() -> (
+    Env,
+    PetChainContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    u64,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+    client.init_admin(&admin);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Nova"),
+        &String::from_str(&env, "2021-01-01"),
+        &Gender::Female,
+        &Species::Dog,
+        &String::from_str(&env, "Mixed"),
+        &String::from_str(&env, "Brown"),
+        &18u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr Morgan"),
+        &String::from_str(&env, "SPEC-VET-1"),
+        &String::from_str(&env, "General"),
+    );
+    assert!(client.verify_vet(&admin, &vet));
+
+    (env, client, admin, owner, vet, pet_id)
+}
+
+#[test]
+fn test_admin_verified_specialization_query_returns_values() {
+    let (env, client, admin, _owner, vet, _pet_id) = setup_verified_vet_for_specialization();
+    let mut specializations = Vec::new(&env);
+    specializations.push_back(Specialization::GeneralPractice);
+    specializations.push_back(Specialization::Surgery);
+
+    assert!(client.register_vet_specializations(&admin, &vet, &specializations));
+
+    let stored = client.get_vet_specializations(&vet);
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap(), Specialization::GeneralPractice);
+    assert_eq!(stored.get(1).unwrap(), Specialization::Surgery);
+}
+
+#[test]
+#[should_panic]
+fn test_specialization_registration_requires_admin() {
+    let (env, client, _admin, owner, vet, _pet_id) = setup_verified_vet_for_specialization();
+    let mut specializations = Vec::new(&env);
+    specializations.push_back(Specialization::Dermatology);
+
+    client.register_vet_specializations(&owner, &vet, &specializations);
+}
+
+#[test]
+#[should_panic]
+fn test_surgery_treatment_rejected_for_unqualified_vet() {
+    let (env, client, _admin, _owner, vet, pet_id) = setup_verified_vet_for_specialization();
+
+    client.add_treatment(
+        &pet_id,
+        &vet,
+        &TreatmentType::Surgery,
+        &env.ledger().timestamp(),
+        &String::from_str(&env, "Surgery notes"),
+        &None,
+        &String::from_str(&env, "Pending"),
+    );
+}
+
+#[test]
+fn test_surgery_treatment_allowed_for_surgery_vet() {
+    let (env, client, admin, _owner, vet, pet_id) = setup_verified_vet_for_specialization();
+    let mut specializations = Vec::new(&env);
+    specializations.push_back(Specialization::Surgery);
+    client.register_vet_specializations(&admin, &vet, &specializations);
+
+    let treatment_id = client.add_treatment(
+        &pet_id,
+        &vet,
+        &TreatmentType::Surgery,
+        &env.ledger().timestamp(),
+        &String::from_str(&env, "Surgery notes"),
+        &None,
+        &String::from_str(&env, "Successful"),
+    );
+
+    assert_eq!(treatment_id, 1);
+}

--- a/stellar-contracts/src/test_activity.rs
+++ b/stellar-contracts/src/test_activity.rs
@@ -101,6 +101,7 @@ mod test_activity {
 
 use crate::{
     ActivityType, Gender, PetChainContract, PetChainContractClient, PrivacyLevel, Species,
+    TreatmentType,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
@@ -141,6 +142,64 @@ fn test_add_activity_record() {
     );
 
     assert_eq!(activity_id, 1);
+}
+
+#[test]
+fn test_get_treatment_count_returns_total_for_pet() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+    client.init_admin(&admin);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Max"),
+        &String::from_str(&env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Golden Retriever"),
+        &String::from_str(&env, "Golden"),
+        &30,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr Avery"),
+        &String::from_str(&env, "VET-COUNT-1"),
+        &String::from_str(&env, "General Practice"),
+    );
+    assert!(client.verify_vet(&admin, &vet));
+
+    assert_eq!(client.get_treatment_count(&pet_id), 0);
+
+    client.add_treatment(
+        &pet_id,
+        &vet,
+        &TreatmentType::Routine,
+        &env.ledger().timestamp(),
+        &String::from_str(&env, "Annual wellness exam"),
+        &None,
+        &String::from_str(&env, "Healthy"),
+    );
+    client.add_treatment(
+        &pet_id,
+        &vet,
+        &TreatmentType::Therapy,
+        &env.ledger().timestamp(),
+        &String::from_str(&env, "Physical therapy"),
+        &Some(100),
+        &String::from_str(&env, "Improving"),
+    );
+
+    assert_eq!(client.get_treatment_count(&pet_id), 2);
 }
 
 #[test]

--- a/stellar-contracts/src/test_event_subscriptions.rs
+++ b/stellar-contracts/src/test_event_subscriptions.rs
@@ -1,0 +1,121 @@
+use crate::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String, Vec,
+};
+
+fn setup() -> (Env, PetChainContractClient<'static>, Address, Address, Address, u64) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+    client.init_admin(&admin);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Signal"),
+        &String::from_str(&env, "2020-01-01"),
+        &Gender::Female,
+        &Species::Dog,
+        &String::from_str(&env, "Mixed"),
+        &String::from_str(&env, "Black"),
+        &20u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr Index"),
+        &String::from_str(&env, "SUB-VET-1"),
+        &String::from_str(&env, "General"),
+    );
+    client.verify_vet(&admin, &vet);
+
+    (env, client, admin, owner, vet, pet_id)
+}
+
+#[test]
+fn test_matching_subscription_ids_for_event_and_pet() {
+    let (env, client, _admin, _owner, _vet, pet_id) = setup();
+    let subscriber = Address::generate(&env);
+    let other_pet = pet_id + 1;
+
+    let mut event_types = Vec::new(&env);
+    event_types.push_back(EventType::TreatmentAdded);
+    let mut pet_ids = Vec::new(&env);
+    pet_ids.push_back(pet_id);
+    let matching_id = client.register_subscription(&subscriber, &event_types, &pet_ids, &300u64);
+
+    let mut other_pet_ids = Vec::new(&env);
+    other_pet_ids.push_back(other_pet);
+    let ignored_id =
+        client.register_subscription(&subscriber, &event_types, &other_pet_ids, &300u64);
+
+    let matches = client.get_matching_subscription_ids(&EventType::TreatmentAdded, &pet_id);
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches.get(0).unwrap(), matching_id);
+    assert_ne!(matches.get(0).unwrap(), ignored_id);
+}
+
+#[test]
+fn test_expired_subscriptions_are_excluded() {
+    let (env, client, _admin, _owner, _vet, pet_id) = setup();
+    let subscriber = Address::generate(&env);
+    let mut event_types = Vec::new(&env);
+    event_types.push_back(EventType::MedicalRecordAdded);
+    let mut pet_ids = Vec::new(&env);
+    pet_ids.push_back(pet_id);
+
+    client.register_subscription(&subscriber, &event_types, &pet_ids, &10u64);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 11);
+
+    let matches = client.get_matching_subscription_ids(&EventType::MedicalRecordAdded, &pet_id);
+    assert_eq!(matches.len(), 0);
+}
+
+#[test]
+#[should_panic]
+fn test_subscription_limit_enforced_per_address() {
+    let (env, client, _admin, _owner, _vet, pet_id) = setup();
+    let subscriber = Address::generate(&env);
+    let mut event_types = Vec::new(&env);
+    event_types.push_back(EventType::TreatmentAdded);
+    let mut pet_ids = Vec::new(&env);
+    pet_ids.push_back(pet_id);
+
+    for _ in 0..10 {
+        client.register_subscription(&subscriber, &event_types, &pet_ids, &300u64);
+    }
+
+    client.register_subscription(&subscriber, &event_types, &pet_ids, &300u64);
+}
+
+#[test]
+fn test_event_payload_contains_matching_subscription_ids() {
+    let (env, client, _admin, _owner, vet, pet_id) = setup();
+    let subscriber = Address::generate(&env);
+    let mut event_types = Vec::new(&env);
+    event_types.push_back(EventType::TreatmentAdded);
+    let mut pet_ids = Vec::new(&env);
+    pet_ids.push_back(pet_id);
+    let subscription_id = client.register_subscription(&subscriber, &event_types, &pet_ids, &300u64);
+
+    let ids = client.get_matching_subscription_ids(&EventType::TreatmentAdded, &pet_id);
+    assert_eq!(ids.get(0).unwrap(), subscription_id);
+
+    client.add_treatment(
+        &pet_id,
+        &vet,
+        &TreatmentType::Routine,
+        &env.ledger().timestamp(),
+        &String::from_str(&env, "Routine check"),
+        &None,
+        &String::from_str(&env, "Stable"),
+    );
+}


### PR DESCRIPTION
closes #508 
closes #705 
closes #706 
closes #707


Implement treatment counts, vet specializations, event subscriptions, and 2FA lockout

- Add get_treatment_count for per-pet treatment totals with coverage
- Add admin-verified vet specialization registry and get_vet_specializations
- Enforce Surgery specialization for surgery treatments and surgery medical records
- Add on-chain event subscription filters by event type and pet ID
- Include matching subscription IDs in key emitted event payloads
- Enforce subscription TTL expiry and max 10 active subscriptions per address
- Add progressive 2FA lockout with doubling retry delays through attempt 9
- Persist full account lockout state after 10 failed attempts
- Add admin unlock and recovery-code unlock paths for locked 2FA accounts
- Add Redis-backed failure counter helpers and DB schema for persistent lockouts