### PR TITLE
feat/totp-2fa-twofactordata

### DIFF
--- a/backend-2fa/Cargo.toml
+++ b/backend-2fa/Cargo.toml
@@ -13,13 +13,16 @@ hex = "0.4"
 base32 = "0.5.1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1", features = ["full"] }
+actix = "0.13"
 actix-web = { version = "4" }
+actix-web-actors = "4"
 axum = { version = "0.7", features = ["json"] }
 tower = { version = "0.4" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { version = "1", features = ["v4"] }
 futures-util = "0.3"
+tokio-stream = { version = "0.1", features = ["sync"] }
 redis = "0.27"
 prometheus = { version = "0.13", features = ["process"] }
 

--- a/backend-2fa/README.md
+++ b/backend-2fa/README.md
@@ -16,14 +16,14 @@ Configurable TOTP-based Two-Factor Authentication for PetChain backend with cryp
 ## Configuration Options
 
 ### Default Configuration (Recommended)
-- **Algorithm**: SHA256 (secure, modern)
+- **Algorithm**: SHA1 by default for legacy compatibility; SHA256 or SHA512 can be selected for new enrollments
 - **Digits**: 6 (standard)
 - **Period**: 30 seconds (standard)
 - **Window**: 1 (minimal clock skew tolerance)
 
 ### Available Configurations
 ```rust
-// Default (SHA256)
+// Default (SHA1)
 let setup = TwoFactorAuth::setup("user@example.com", "PetChain")?;
 
 // Legacy SHA1 (backward compatibility)

--- a/backend-2fa/configuration.md
+++ b/backend-2fa/configuration.md
@@ -48,7 +48,7 @@ TotpConfig::high_security()
 ### Setup with Default Configuration
 ```rust
 let setup = TwoFactorAuth::setup("user@example.com", "MyApp")?;
-// Uses SHA256 by default
+// Uses SHA1 by default for backward compatibility
 ```
 
 ### Setup with Custom Configuration
@@ -59,7 +59,7 @@ let setup = TwoFactorAuth::setup_with_config("user@example.com", "MyApp", config
 
 ### Token Verification
 ```rust
-// Default verification (SHA256)
+// Default verification (SHA1)
 let is_valid = TwoFactorAuth::verify_token(&secret, &token)?;
 
 // Custom configuration verification
@@ -79,11 +79,14 @@ let setup = TwoFactorAuth::setup("user@example.com", "MyApp")?;
 
 **After (Backward Compatible):**
 ```rust
-// Option 1: Use default (SHA256 - recommended)
+// Option 1: Use default (SHA1 for legacy compatibility)
 let setup = TwoFactorAuth::setup("user@example.com", "MyApp")?;
 
-// Option 2: Explicit SHA1 for backward compatibility
-let config = TotpConfig::legacy_sha1();
+// Option 2: Explicit SHA256 or SHA512 for stronger new enrollments
+let config = TotpConfig {
+    algorithm: totp_rs::Algorithm::SHA256,
+    ..TotpConfig::default()
+};
 let setup = TwoFactorAuth::setup_with_config("user@example.com", "MyApp", config)?;
 ```
 
@@ -97,9 +100,16 @@ struct TwoFactorData {
     secret: String,
     backup_codes: Vec<String>,
     enabled: bool,
-    config: TotpConfig,  // Store the configuration used
+    algorithm: HmacAlgorithm, // Store the algorithm used for this enrollment
 }
 ```
+
+### Migration Path
+
+Existing rows that do not yet have an `algorithm` column should be treated as
+`SHA1` until the user re-enrolls. New enrollments persist the selected
+algorithm in the database, so SHA256 and SHA512 users verify with the same
+hash they enrolled with.
 
 ## Security Considerations
 

--- a/backend-2fa/migrations/002_create_base_tables.sql
+++ b/backend-2fa/migrations/002_create_base_tables.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS user_two_factor (
     secret TEXT NOT NULL,
     backup_codes TEXT NOT NULL,
     enabled BOOLEAN DEFAULT FALSE,
+    algorithm VARCHAR(16) NOT NULL DEFAULT 'SHA1',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/backend-2fa/migrations/003_add_user_two_factor_algorithm.down.sql
+++ b/backend-2fa/migrations/003_add_user_two_factor_algorithm.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_two_factor
+    DROP COLUMN IF EXISTS algorithm;

--- a/backend-2fa/migrations/003_add_user_two_factor_algorithm.sql
+++ b/backend-2fa/migrations/003_add_user_two_factor_algorithm.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_two_factor
+    ADD COLUMN IF NOT EXISTS algorithm VARCHAR(16) NOT NULL DEFAULT 'SHA1';

--- a/backend-2fa/schema.sql
+++ b/backend-2fa/schema.sql
@@ -15,6 +15,7 @@ CREATE TABLE user_two_factor (
     secret TEXT NOT NULL,
     backup_codes TEXT NOT NULL, -- JSON array of backup codes
     enabled BOOLEAN DEFAULT FALSE,
+    algorithm VARCHAR(16) NOT NULL DEFAULT 'SHA1',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (tenant_id, user_id)

--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -1,4 +1,7 @@
-use crate::two_factor::{AuditLogEntry, RecoveryCodeUsageLog, TwoFactorData, TwoFactorStore, UserTwoFactorSummary};
+use crate::two_factor::{
+    AuditLogEntry, HmacAlgorithm, RecoveryCodeUsageLog, TwoFactorData, TwoFactorStore,
+    UserTwoFactorSummary,
+};
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::sync::Arc;
 use std::time::Duration;
@@ -153,13 +156,14 @@ impl TwoFactorStore for PostgresTwoFactorStore {
             self.block_on(
                 sqlx::query(
                     r#"
-            INSERT INTO user_two_factor (user_id, secret, backup_codes, enabled)
-            VALUES ($1, $2, $3, $4)
+            INSERT INTO user_two_factor (user_id, secret, backup_codes, enabled, algorithm)
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (user_id)
             DO UPDATE SET
                 secret = EXCLUDED.secret,
                 backup_codes = EXCLUDED.backup_codes,
                 enabled = EXCLUDED.enabled,
+                algorithm = EXCLUDED.algorithm,
                 updated_at = CURRENT_TIMESTAMP
             "#,
                 )
@@ -167,6 +171,7 @@ impl TwoFactorStore for PostgresTwoFactorStore {
                 .bind(&data.secret)
                 .bind(&backup_codes)
                 .bind(data.enabled)
+                .bind(Self::algorithm_to_db(data.algorithm))
                 .execute(&self.pool),
             )?;
             Ok(())
@@ -177,9 +182,9 @@ impl TwoFactorStore for PostgresTwoFactorStore {
         let user_id = user_id.to_string();
         let row = self.with_retry(|| {
             self.block_on(
-                sqlx::query_as::<_, (String, String, bool)>(
+                sqlx::query_as::<_, (String, String, bool, Option<String>)>(
                     r#"
-            SELECT secret, backup_codes, enabled
+            SELECT secret, backup_codes, enabled, algorithm
             FROM user_two_factor
             WHERE user_id = $1
             "#,
@@ -189,7 +194,7 @@ impl TwoFactorStore for PostgresTwoFactorStore {
             )
         })?;
 
-        let (secret, backup_codes, enabled) =
+        let (secret, backup_codes, enabled, algorithm) =
             row.ok_or_else(|| format!("No 2FA data found for user: {}", user_id))?;
         let backup_codes = serde_json::from_str(&backup_codes).map_err(|e| e.to_string())?;
 
@@ -197,6 +202,7 @@ impl TwoFactorStore for PostgresTwoFactorStore {
             secret,
             backup_codes,
             enabled,
+            algorithm: Self::algorithm_from_db(algorithm.as_deref()),
         })
     }
 
@@ -489,6 +495,24 @@ impl TwoFactorStore for PostgresTwoFactorStore {
     }
 }
 
+impl PostgresTwoFactorStore {
+    fn algorithm_to_db(algorithm: HmacAlgorithm) -> String {
+        match algorithm {
+            HmacAlgorithm::SHA1 => "SHA1".to_string(),
+            HmacAlgorithm::SHA256 => "SHA256".to_string(),
+            HmacAlgorithm::SHA512 => "SHA512".to_string(),
+        }
+    }
+
+    fn algorithm_from_db(value: Option<&str>) -> HmacAlgorithm {
+        match value {
+            Some("SHA256") => HmacAlgorithm::SHA256,
+            Some("SHA512") => HmacAlgorithm::SHA512,
+            _ => HmacAlgorithm::SHA1,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -498,6 +522,7 @@ mod tests {
             secret: "JBSWY3DPEHPK3PXP".to_string(),
             backup_codes: vec!["1111-2222".to_string(), "3333-4444".to_string()],
             enabled: false,
+            algorithm: HmacAlgorithm::SHA1,
         }
     }
 

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -905,3 +905,13 @@ impl PoolMetricsHandlers {
         Ok(PoolStatsResponse { active: 0, idle: 0, max: 0 })
     }
 }
+
+/// WebSocket endpoint for real-time leaderboard updates.
+///
+/// Mount this at `GET /leaderboard/ws`.
+pub async fn leaderboard_ws(
+    req: HttpRequest,
+    stream: Payload,
+) -> Result<HttpResponse, Error> {
+    leaderboard_ws_endpoint(req, stream).await
+}

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -1,12 +1,16 @@
 #[cfg(not(test))]
 use crate::db::PostgresTwoFactorStore;
-use crate::leaderboard::{FlaggedScoreStore, FlaggedScoreSubmission};
+use crate::leaderboard::{
+    leaderboard_ws_endpoint, FlaggedScoreStore, FlaggedScoreSubmission,
+};
 use crate::rate_limiter::{InMemoryRateLimiter, RateLimitResult, RateLimiter, UserQuotaStore};
 use crate::two_factor::{
-    AuditLogEntry, InMemoryStore, TwoFactorAuth, TwoFactorData, TwoFactorStore,
+    AuditLogEntry, HmacAlgorithm, InMemoryStore, TotpConfig, TwoFactorAuth, TwoFactorData,
+    TwoFactorStore,
     UserTwoFactorSummary, TenantConfig, TenantRegistry, TenantScopedStore,
 };
 use crate::webhooks::{SecurityEventType, WebhookManager};
+use actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -164,6 +168,13 @@ impl TwoFactorHandlers {
             .map_err(|_| format!("2FA not configured for user {}", user_id))
     }
 
+    fn verification_config(algorithm: HmacAlgorithm) -> TotpConfig {
+        TotpConfig {
+            algorithm,
+            ..TotpConfig::default()
+        }
+    }
+
     pub fn enable_two_factor(
         caller: &AuthenticatedUser,
         req: EnableTwoFactorRequest,
@@ -194,6 +205,7 @@ impl TwoFactorHandlers {
                 secret: setup.secret.clone(),
                 backup_codes: setup.backup_codes.clone(),
                 enabled: false,
+                algorithm: setup.config.algorithm,
             },
         )?;
 
@@ -221,7 +233,11 @@ impl TwoFactorHandlers {
         }
 
         let data = self.store_get(&req.user_id)?;
-        let result = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
+        let result = TwoFactorAuth::verify_token_with_config(
+            &data.secret,
+            &req.token,
+            Self::verification_config(data.algorithm),
+        )?;
         if result {
             self.store.update_enabled(&req.user_id, true)?;
         }
@@ -253,7 +269,11 @@ impl TwoFactorHandlers {
             return Ok(false);
         }
 
-        let is_valid = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
+        let is_valid = TwoFactorAuth::verify_token_with_config(
+            &data.secret,
+            &req.token,
+            Self::verification_config(data.algorithm),
+        )?;
 
         if is_valid {
             self.limiter.record_success(&key);
@@ -282,7 +302,11 @@ impl TwoFactorHandlers {
             return Ok(false);
         }
 
-        let result = TwoFactorAuth::verify_token(&data.secret, &req.token)?;
+        let result = TwoFactorAuth::verify_token_with_config(
+            &data.secret,
+            &req.token,
+            Self::verification_config(data.algorithm),
+        )?;
         if result {
             self.store.update_enabled(&req.user_id, false)?;
         }
@@ -356,6 +380,7 @@ impl TwoFactorHandlers {
                 secret: setup.secret.clone(),
                 backup_codes: setup.backup_codes.clone(),
                 enabled: true,
+                algorithm: setup.config.algorithm,
             },
         )?;
 
@@ -612,6 +637,7 @@ impl CanaryHandlers {
                 secret: setup.secret.clone(),
                 backup_codes: setup.backup_codes.clone(),
                 enabled: true,
+                algorithm: setup.config.algorithm,
             },
         )?;
 
@@ -662,7 +688,11 @@ impl CanaryHandlers {
         }
 
         let data = store.get(user_id)?;
-        TwoFactorAuth::verify_token(&data.secret, token)
+        TwoFactorAuth::verify_token_with_config(
+            &data.secret,
+            token,
+            Self::verification_config(data.algorithm),
+        )
     }
 }
 
@@ -732,6 +762,7 @@ impl MultiTenantHandlers {
                 secret: setup.secret.clone(),
                 backup_codes: setup.backup_codes.clone(),
                 enabled: false,
+                algorithm: setup.config.algorithm,
             },
         )?;
 
@@ -764,7 +795,11 @@ impl MultiTenantHandlers {
         let _ = max_failures; // per-tenant config available for custom limiter wiring
 
         let data = self.store.get(user_id)?;
-        let result = TwoFactorAuth::verify_token(&data.secret, token)?;
+        let result = TwoFactorAuth::verify_token_with_config(
+            &data.secret,
+            token,
+            Self::verification_config(data.algorithm),
+        )?;
         if result {
             self.store.update_enabled(user_id, true)?;
             self.limiter.record_success(&key);
@@ -795,7 +830,11 @@ impl MultiTenantHandlers {
         if !data.enabled {
             return Ok(false);
         }
-        let result = TwoFactorAuth::verify_token(&data.secret, token)?;
+        let result = TwoFactorAuth::verify_token_with_config(
+            &data.secret,
+            token,
+            Self::verification_config(data.algorithm),
+        )?;
         if result {
             self.store.update_enabled(user_id, false)?;
             self.limiter.record_success(&key);
@@ -834,6 +873,8 @@ impl TenantProvisioningHandlers {
 
     pub fn get_tenant_config(&self, tenant_id: &str) -> Option<TenantConfig> {
         self.registry.get_config(tenant_id)
+    }
+}
 // Pool metrics endpoint
 // ---------------------------------------------------------------------------
 

--- a/backend-2fa/src/leaderboard.rs
+++ b/backend-2fa/src/leaderboard.rs
@@ -1,6 +1,15 @@
+use actix::{Actor, ActorContext, AsyncContext, StreamHandler};
+use actix_web::error::{ErrorBadRequest, ErrorTooManyRequests};
+use actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
+use actix_web_actors::ws;
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::f64;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Timeframe {
@@ -195,6 +204,218 @@ pub struct LeaderboardEntry {
     pub user_id: String,
     pub decayed_score: f64,
     pub percentile: f64,
+}
+
+/// Score update payload pushed to websocket subscribers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaderboardScoreUpdate {
+    pub user_id: String,
+    pub new_score: u64,
+    pub rank: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum LeaderboardSubscriptionCommand {
+    Subscribe { user_ids: Vec<String> },
+    Unsubscribe { user_ids: Vec<String> },
+    Replace { user_ids: Vec<String> },
+    Clear,
+}
+
+#[derive(Debug)]
+pub struct LeaderboardWsHub {
+    broadcaster: broadcast::Sender<LeaderboardScoreUpdate>,
+    connections_by_ip: Mutex<HashMap<IpAddr, usize>>,
+}
+
+impl LeaderboardWsHub {
+    pub fn global() -> Arc<Self> {
+        static HUB: OnceLock<Arc<LeaderboardWsHub>> = OnceLock::new();
+        HUB.get_or_init(|| {
+            let (broadcaster, _) = broadcast::channel(256);
+            Arc::new(Self {
+                broadcaster,
+                connections_by_ip: Mutex::new(HashMap::new()),
+            })
+        })
+        .clone()
+    }
+
+    pub fn connect(self: &Arc<Self>, ip: IpAddr) -> Result<LeaderboardConnectionGuard, String> {
+        let mut connections = self
+            .connections_by_ip
+            .lock()
+            .map_err(|_| "Leaderboard connection state is unavailable".to_string())?;
+        let count = connections.get(&ip).copied().unwrap_or(0);
+        if count >= 5 {
+            return Err(format!("Connection limit exceeded for IP {}", ip));
+        }
+        connections.insert(ip, count + 1);
+        Ok(LeaderboardConnectionGuard {
+            hub: Arc::clone(self),
+            ip,
+        })
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<LeaderboardScoreUpdate> {
+        self.broadcaster.subscribe()
+    }
+
+    pub fn publish_score_update(&self, update: LeaderboardScoreUpdate) {
+        let _ = self.broadcaster.send(update);
+    }
+
+    fn disconnect(&self, ip: IpAddr) {
+        if let Ok(mut connections) = self.connections_by_ip.lock() {
+            if let Some(current) = connections.get_mut(&ip) {
+                if *current <= 1 {
+                    connections.remove(&ip);
+                } else {
+                    *current -= 1;
+                }
+            }
+        }
+    }
+}
+
+pub struct LeaderboardConnectionGuard {
+    hub: Arc<LeaderboardWsHub>,
+    ip: IpAddr,
+}
+
+impl Drop for LeaderboardConnectionGuard {
+    fn drop(&mut self) {
+        self.hub.disconnect(self.ip);
+    }
+}
+
+pub struct LeaderboardWsSession {
+    hub: Arc<LeaderboardWsHub>,
+    _connection: LeaderboardConnectionGuard,
+    subscriptions: HashSet<String>,
+}
+
+impl LeaderboardWsSession {
+    pub fn new(hub: Arc<LeaderboardWsHub>, connection: LeaderboardConnectionGuard) -> Self {
+        Self {
+            hub,
+            _connection: connection,
+            subscriptions: HashSet::new(),
+        }
+    }
+
+    fn should_forward(&self, update: &LeaderboardScoreUpdate) -> bool {
+        self.subscriptions.is_empty() || self.subscriptions.contains(&update.user_id)
+    }
+
+    fn apply_command(&mut self, command: LeaderboardSubscriptionCommand) {
+        match command {
+            LeaderboardSubscriptionCommand::Subscribe { user_ids } => {
+                for user_id in user_ids {
+                    self.subscriptions.insert(user_id);
+                }
+            }
+            LeaderboardSubscriptionCommand::Unsubscribe { user_ids } => {
+                for user_id in user_ids {
+                    self.subscriptions.remove(&user_id);
+                }
+            }
+            LeaderboardSubscriptionCommand::Replace { user_ids } => {
+                self.subscriptions.clear();
+                for user_id in user_ids {
+                    self.subscriptions.insert(user_id);
+                }
+            }
+            LeaderboardSubscriptionCommand::Clear => {
+                self.subscriptions.clear();
+            }
+        }
+    }
+}
+
+impl Actor for LeaderboardWsSession {
+    type Context = ws::WebsocketContext<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        let receiver = self.hub.subscribe();
+        ctx.add_stream(BroadcastStream::new(receiver));
+    }
+}
+
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for LeaderboardWsSession {
+    fn handle(&mut self, item: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+        match item {
+            Ok(ws::Message::Text(text)) => {
+                if let Ok(command) = serde_json::from_str::<LeaderboardSubscriptionCommand>(&text) {
+                    self.apply_command(command);
+                    ctx.text(r#"{"status":"ok"}"#);
+                } else {
+                    ctx.text(r#"{"status":"error","reason":"invalid_subscription_message"}"#);
+                }
+            }
+            Ok(ws::Message::Ping(payload)) => ctx.pong(&payload),
+            Ok(ws::Message::Pong(_)) => {}
+            Ok(ws::Message::Close(reason)) => {
+                ctx.close(reason);
+                ctx.stop();
+            }
+            Ok(ws::Message::Binary(_)) => {
+                ctx.text(r#"{"status":"error","reason":"binary_not_supported"}"#);
+            }
+            Ok(ws::Message::Continuation(_)) => {}
+            Ok(ws::Message::Nop) => {}
+            Err(_) => {
+                ctx.stop();
+            }
+        }
+    }
+}
+
+impl StreamHandler<Result<LeaderboardScoreUpdate, tokio_stream::wrappers::errors::BroadcastStreamRecvError>>
+    for LeaderboardWsSession
+{
+    fn handle(
+        &mut self,
+        item: Result<LeaderboardScoreUpdate, tokio_stream::wrappers::errors::BroadcastStreamRecvError>,
+        ctx: &mut Self::Context,
+    ) {
+        match item {
+            Ok(update) if self.should_forward(&update) => {
+                if let Ok(payload) = serde_json::to_string(&update) {
+                    ctx.text(payload);
+                }
+            }
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+}
+
+/// Broadcast a score update to all connected websocket clients.
+pub fn broadcast_score_update(user_id: impl Into<String>, new_score: u64, rank: u64) {
+    LeaderboardWsHub::global().publish_score_update(LeaderboardScoreUpdate {
+        user_id: user_id.into(),
+        new_score,
+        rank,
+    });
+}
+
+/// Actix-web websocket endpoint for `GET /leaderboard/ws`.
+pub async fn leaderboard_ws_endpoint(
+    req: HttpRequest,
+    stream: Payload,
+) -> Result<HttpResponse, Error> {
+    let peer_ip = req
+        .peer_addr()
+        .map(|addr| addr.ip())
+        .ok_or_else(|| ErrorBadRequest("Missing peer address for leaderboard websocket"))?;
+
+    let hub = LeaderboardWsHub::global();
+    let connection = hub
+        .connect(peer_ip)
+        .map_err(|err| ErrorTooManyRequests(err))?;
+    ws::start(LeaderboardWsSession::new(hub, connection), &req, stream)
 }
 
 /// Get decay lambda from environment variable with sensible default

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -16,10 +16,11 @@ pub use handlers::{
     AdminDashboardHandlers, AdminRateLimitHandlers, AdminScoreHandlers, AuthenticatedAdmin,
     AuthenticatedUser, CanaryHandlers, CreateCanaryRequest, CreateCanaryResponse,
     GrantUnlimitedRequest, PoolMetricsHandlers, PoolStatsResponse, SetUserQuotaRequest,
-    TwoFactorHandlers,
+    TwoFactorHandlers, leaderboard_ws,
 };
 pub use leaderboard::{
-    FlaggedScoreStore, FlaggedScoreSubmission, ScoreSubmissionError, ScoreValidationConfig,
+    broadcast_score_update, FlaggedScoreStore, FlaggedScoreSubmission, LeaderboardEntry,
+    LeaderboardScoreUpdate, LeaderboardWsHub, ScoreSubmissionError, ScoreValidationConfig,
 };
 pub use rate_limiter::{
     DistributedRateLimiter, EndpointConfig, InMemoryRateLimiter, LiveRedisBackend,

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -490,6 +490,7 @@ mod tests {
                 secret,
                 backup_codes: vec![],
                 enabled: false,
+                algorithm: Algorithm::SHA1,
             },
         );
 
@@ -528,6 +529,7 @@ mod tests {
                 secret: resp.secret.clone(),
                 backup_codes: resp.backup_codes,
                 enabled: true,
+                algorithm: Algorithm::SHA1,
             },
         );
 
@@ -561,6 +563,7 @@ mod tests {
                 secret: stored_secret.clone(),
                 backup_codes: vec![],
                 enabled: true,
+                algorithm: Algorithm::SHA1,
             },
         );
 
@@ -870,6 +873,7 @@ mod tests {
                     secret: "AAAA".to_string(),
                     backup_codes: vec![],
                     enabled: true,
+                    algorithm: Algorithm::SHA1,
                 },
             );
             let disable_result = handlers.disable_two_factor(
@@ -1205,6 +1209,7 @@ mod tests {
                 secret: resp.secret,
                 backup_codes: resp.backup_codes,
                 enabled: true,
+                algorithm: Algorithm::SHA1,
             },
         );
 
@@ -2838,6 +2843,7 @@ mod admin_dashboard_tests {
                 secret: "JBSWY3DPEHPK3PXP".to_string(),
                 backup_codes: vec![],
                 enabled: true,
+                algorithm: Algorithm::SHA1,
             },
         );
     }
@@ -3077,15 +3083,16 @@ mod canary_tests {
 
         // Set up a normal user
         let store = get_two_factor_store_for_tests();
-        store
-            .save(
-                "normal-user",
-                crate::two_factor::TwoFactorData {
-                    secret: "JBSWY3DPEHPK3PXP".to_string(),
-                    backup_codes: vec![],
-                    enabled: true,
-                },
-            )
+            store
+                .save(
+                    "normal-user",
+                    crate::two_factor::TwoFactorData {
+                        secret: "JBSWY3DPEHPK3PXP".to_string(),
+                        backup_codes: vec![],
+                        enabled: true,
+                        algorithm: Algorithm::SHA1,
+                    },
+                )
             .unwrap();
 
         // Verification attempt on a normal user should NOT fire canary webhook

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -7,6 +7,16 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use totp_rs::{Algorithm, Secret, TOTP};
 
+/// HMAC algorithm used for TOTP generation and verification.
+///
+/// Existing enrollments that pre-date this field should be treated as SHA1
+/// until the user re-enrolls with a fresh secret.
+pub type HmacAlgorithm = Algorithm;
+
+fn default_hmac_algorithm() -> HmacAlgorithm {
+    HmacAlgorithm::SHA1
+}
+
 /// Configuration for TOTP parameters to ensure cryptographic agility
 #[derive(Debug, Clone)]
 pub struct TotpConfig {
@@ -61,6 +71,8 @@ pub struct TwoFactorData {
     pub secret: String,
     pub backup_codes: Vec<String>,
     pub enabled: bool,
+    #[serde(default = "default_hmac_algorithm")]
+    pub algorithm: HmacAlgorithm,
 }
 
 /// Returned after a successful backup-code recovery.
@@ -129,7 +141,7 @@ impl TwoFactorAuth {
             .collect()
     }
 
-    /// Setup 2FA with default configuration (SHA256)
+    /// Setup 2FA with default configuration (SHA1).
     pub fn setup(user_email: &str, issuer: &str) -> Result<TwoFactorSetup, String> {
         Self::setup_with_config(user_email, issuer, TotpConfig::default())
     }
@@ -171,7 +183,7 @@ impl TwoFactorAuth {
         })
     }
 
-    /// Verify token with default configuration (SHA256)
+    /// Verify token with default configuration (SHA1).
     pub fn verify_token(secret: &str, token: &str) -> Result<bool, String> {
         Self::verify_token_with_config(secret, token, TotpConfig::default())
     }

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -304,6 +304,9 @@ pub enum ContractError {
     NotPetOwner = 60,
     NotConsentOwner = 61,
     ConsentAlreadyRevoked = 62,
+    InvalidConsentChain = 63,
+    ConsentScopeEscalation = 64,
+    DelegationDepthExceeded = 65,
     SlotAlreadyBooked = 70,
     SlotNotBooked = 71,
     ProposalNotFound = 80,
@@ -1026,6 +1029,12 @@ pub enum ConsentKey {
     ConsentCount,
     PetConsentIndex((u64, u64)),
     PetConsentCount(u64),
+}
+
+#[contracttype]
+pub enum CrossChainKey {
+    PetChainMapping((u64, String)),
+    ChainLookup((String, String)),
 }
 
 #[contracttype]
@@ -9159,25 +9168,114 @@ impl PetChainContract {
 
     // --- CONSENT SYSTEM ---
 
-    pub fn grant_consent(
-        env: Env,
-        pet_id: u64,
-        owner: Address,
-        consent_type: ConsentType,
-        granted_to: Address,
-        scope: ConsentScope,
-    ) -> u64 {
-        Self::grant_consent_with_expiry(env, pet_id, owner, consent_type, granted_to, None)
+    fn scope_allows(parent_scope: &ConsentScope, child_scope: &ConsentScope) -> bool {
+        parent_scope == child_scope
     }
 
-    pub fn grant_consent_with_expiry(
+    fn consent_chain_is_valid(env: &Env, consent_id: u64) -> bool {
+        let mut chain = Vec::new(env);
+        let mut current_id = Some(consent_id);
+
+        while let Some(id) = current_id {
+            let consent = match env
+                .storage()
+                .instance()
+                .get::<ConsentKey, Consent>(&ConsentKey::Consent(id))
+            {
+                Some(consent) => consent,
+                None => return false,
+            };
+
+            chain.push_back(consent.clone());
+            if chain.len() > 3 {
+                return false;
+            }
+            current_id = consent.parent_consent_id;
+        }
+
+        let total = chain.len();
+        if total == 0 {
+            return false;
+        }
+
+        let pet = match env
+            .storage()
+            .instance()
+            .get::<DataKey, Pet>(&DataKey::Pet(chain.get(total - 1).unwrap().pet_id))
+        {
+            Some(pet) => pet,
+            None => return false,
+        };
+
+        for i in 0..total {
+            let consent = chain.get(i).unwrap();
+            if !Self::is_consent_active_at(env, &consent) {
+                return false;
+            }
+
+            let depth_from_root = total - i;
+            if depth_from_root > consent.max_depth as u32 {
+                return false;
+            }
+
+            if i + 1 < total {
+                let parent = chain.get(i + 1).unwrap();
+                if consent.pet_id != parent.pet_id {
+                    return false;
+                }
+                if consent.parent_consent_id != Some(parent.id) {
+                    return false;
+                }
+                if consent.owner != parent.granted_to {
+                    return false;
+                }
+                if !Self::scope_allows(&parent.scope, &consent.scope) {
+                    return false;
+                }
+            } else if consent.owner != pet.owner {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn find_delegate_parent(
+        env: &Env,
+        pet_id: u64,
+        delegator: &Address,
+        scope: &ConsentScope,
+    ) -> Option<Consent> {
+        let history = Self::get_consent_history(env.clone(), pet_id);
+        let mut index = history.len();
+        while index > 0 {
+            index -= 1;
+            if let Some(consent) = history.get(index) {
+                if consent.granted_to == *delegator
+                    && Self::scope_allows(&consent.scope, scope)
+                    && Self::consent_chain_is_valid(env, consent.id)
+                {
+                    return Some(consent);
+                }
+            }
+        }
+        None
+    }
+
+    fn grant_consent_record(
         env: Env,
         pet_id: u64,
         owner: Address,
         consent_type: ConsentType,
         granted_to: Address,
         expires_at: Option<u64>,
+        scope: ConsentScope,
+        parent_consent_id: Option<u64>,
+        max_depth: u32,
     ) -> u64 {
+        const MAX_CONSENTS_PER_PET: u64 = 50;
+        const MAX_CONSENT_CHAIN_DEPTH: u32 = 3;
+
         owner.require_auth();
 
         let pet: Pet = env
@@ -9185,11 +9283,33 @@ impl PetChainContract {
             .instance()
             .get(&DataKey::Pet(pet_id))
             .unwrap_or_else(|| env.panic_with_error(ContractError::PetNotFound));
-        if pet.owner != owner {
+
+        if parent_consent_id.is_none() && pet.owner != owner {
             env.panic_with_error(ContractError::NotPetOwner);
         }
 
-        const MAX_CONSENTS_PER_PET: u64 = 50;
+        let allowed_max_depth = core::cmp::min(max_depth, MAX_CONSENT_CHAIN_DEPTH);
+
+        if let Some(parent_id) = parent_consent_id {
+            let parent = env
+                .storage()
+                .instance()
+                .get::<ConsentKey, Consent>(&ConsentKey::Consent(parent_id))
+                .unwrap_or_else(|| env.panic_with_error(ContractError::InvalidConsentChain));
+
+            if parent.pet_id != pet_id || parent.granted_to != owner {
+                env.panic_with_error(ContractError::InvalidConsentChain);
+            }
+            if !Self::consent_chain_is_valid(&env, parent_id) {
+                env.panic_with_error(ContractError::InvalidConsentChain);
+            }
+            if !Self::scope_allows(&parent.scope, &scope) {
+                env.panic_with_error(ContractError::ConsentScopeEscalation);
+            }
+            if parent.max_depth == 0 {
+                env.panic_with_error(ContractError::DelegationDepthExceeded);
+            }
+        }
 
         let count: u64 = env
             .storage()
@@ -9212,7 +9332,6 @@ impl PetChainContract {
                         .get::<ConsentKey, Consent>(&ConsentKey::Consent(cid))
                     {
                         if !Self::is_consent_active_at(&env, &c) {
-                            // Shift remaining indices down
                             for j in i..count {
                                 if let Some(next_cid) =
                                     env.storage().instance().get::<ConsentKey, u64>(
@@ -9266,7 +9385,12 @@ impl PetChainContract {
             revoked_at: None,
             is_active: true,
             scope,
-            parent_consent_id: None,
+            parent_consent_id,
+            max_depth: if parent_consent_id.is_some() {
+                allowed_max_depth
+            } else {
+                MAX_CONSENT_CHAIN_DEPTH
+            },
         };
 
         env.storage()
@@ -9288,6 +9412,48 @@ impl PetChainContract {
         consent_id
     }
 
+    pub fn grant_consent(
+        env: Env,
+        pet_id: u64,
+        owner: Address,
+        consent_type: ConsentType,
+        granted_to: Address,
+        scope: ConsentScope,
+    ) -> u64 {
+        Self::grant_consent_record(
+            env,
+            pet_id,
+            owner,
+            consent_type,
+            granted_to,
+            None,
+            scope,
+            None,
+            3,
+        )
+    }
+
+    pub fn grant_consent_with_expiry(
+        env: Env,
+        pet_id: u64,
+        owner: Address,
+        consent_type: ConsentType,
+        granted_to: Address,
+        expires_at: Option<u64>,
+    ) -> u64 {
+        Self::grant_consent_record(
+            env,
+            pet_id,
+            owner,
+            consent_type,
+            granted_to,
+            expires_at,
+            ConsentScope::ReadMedical,
+            None,
+            3,
+        )
+    }
+
     /// Grant a consent that is a sub-delegation of an existing consent.
     /// The `parent_consent_id` links this consent to its parent for cascade revocation.
     pub fn grant_consent_with_parent(
@@ -9299,24 +9465,101 @@ impl PetChainContract {
         scope: ConsentScope,
         parent_consent_id: Option<u64>,
     ) -> u64 {
-        let consent_id =
-            Self::grant_consent_with_expiry(env.clone(), pet_id, owner, consent_type, granted_to, None);
-
-        // Patch the stored consent to set parent_consent_id
-        if let Some(pid) = parent_consent_id {
-            if let Some(mut c) = env
+        let max_depth = if let Some(pid) = parent_consent_id {
+            if let Some(parent) = env
                 .storage()
                 .instance()
-                .get::<ConsentKey, Consent>(&ConsentKey::Consent(consent_id))
+                .get::<ConsentKey, Consent>(&ConsentKey::Consent(pid))
             {
-                c.parent_consent_id = Some(pid);
-                env.storage()
-                    .instance()
-                    .set(&ConsentKey::Consent(consent_id), &c);
+                let parent_depth = Self::consent_history_depth(&env, pid);
+                if parent.granted_to != owner
+                    || parent.pet_id != pet_id
+                    || !Self::consent_chain_is_valid(&env, pid)
+                    || !Self::scope_allows(&parent.scope, &scope)
+                {
+                    env.panic_with_error(ContractError::InvalidConsentChain);
+                }
+                if parent_depth + 1 > parent.max_depth {
+                    env.panic_with_error(ContractError::DelegationDepthExceeded);
+                }
+                core::cmp::min(parent.max_depth, 3)
+            } else {
+                env.panic_with_error(ContractError::InvalidConsentChain);
             }
+        } else {
+            3
+        };
+
+        Self::grant_consent_record(
+            env,
+            pet_id,
+            owner,
+            consent_type,
+            granted_to,
+            None,
+            scope,
+            parent_consent_id,
+            max_depth,
+        )
+    }
+
+    /// Delegate one or more scopes from the caller's active consent chain to a
+    /// trusted party. Each delegated scope must remain within the delegator's
+    /// own permission scope, and the resulting chain cannot exceed depth 3.
+    pub fn delegate_consent(
+        env: Env,
+        pet_id: u64,
+        delegator: Address,
+        delegate: Address,
+        scopes: Vec<ConsentScope>,
+        max_depth: u32,
+    ) -> Vec<u64> {
+        delegator.require_auth();
+
+        let mut results = Vec::new(&env);
+        let effective_max_depth = core::cmp::min(max_depth, 3);
+
+        for scope in scopes.iter() {
+            let parent = Self::find_delegate_parent(&env, pet_id, &delegator, scope)
+                .unwrap_or_else(|| env.panic_with_error(ContractError::InvalidConsentChain));
+            let parent_depth = Self::consent_history_depth(&env, parent.id);
+            if parent_depth + 1 > effective_max_depth || parent_depth >= parent.max_depth {
+                env.panic_with_error(ContractError::DelegationDepthExceeded);
+            }
+
+            let consent_id = Self::grant_consent_record(
+                env.clone(),
+                pet_id,
+                delegator.clone(),
+                parent.consent_type.clone(),
+                delegate.clone(),
+                None,
+                scope,
+                Some(parent.id),
+                effective_max_depth,
+            );
+            results.push_back(consent_id);
         }
 
-        consent_id
+        results
+    }
+
+    fn consent_history_depth(env: &Env, consent_id: u64) -> u32 {
+        let mut depth = 0u32;
+        let mut current_id = Some(consent_id);
+        while let Some(id) = current_id {
+            let consent = match env
+                .storage()
+                .instance()
+                .get::<ConsentKey, Consent>(&ConsentKey::Consent(id))
+            {
+                Some(consent) => consent,
+                None => return 0,
+            };
+            depth += 1;
+            current_id = consent.parent_consent_id;
+        }
+        depth
     }
 
     fn is_consent_active_at(env: &Env, consent: &Consent) -> bool {
@@ -9339,6 +9582,33 @@ impl PetChainContract {
         } else {
             false
         }
+    }
+
+    /// Check whether a user has a valid consent chain for the requested scope.
+    /// Every hop in the chain is validated, including ownership, scope and
+    /// branch-depth constraints.
+    pub fn check_consent_access(
+        env: Env,
+        pet_id: u64,
+        user: Address,
+        scope: ConsentScope,
+    ) -> bool {
+        let history = Self::get_consent_history(env.clone(), pet_id);
+        let mut index = history.len();
+
+        while index > 0 {
+            index -= 1;
+            if let Some(consent) = history.get(index) {
+                if consent.granted_to == user
+                    && consent.scope == scope
+                    && Self::consent_chain_is_valid(&env, consent.id)
+                {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     pub fn extend_consent(
@@ -14173,6 +14443,8 @@ mod test;
 mod test_access_control;
 #[cfg(test)]
 mod test_activity;
+#[cfg(test)]
+mod test_consent_pagination;
 #[cfg(test)]
 mod test_behavior;
 #[cfg(test)]

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -341,6 +341,8 @@ pub enum ContractError {
     ClaimNotFound = 164,
     ClaimDocumentLimitReached = 165,
     ClaimImmutable = 166,
+    CrossChainIdentityAlreadyRegistered = 167,
+    CrossChainIdentityNotFound = 168,
 }
 
 #[contracttype]
@@ -1214,6 +1216,8 @@ pub struct Consent {
     pub scope: ConsentScope,
     /// ID of the parent consent this was delegated from (None = root consent).
     pub parent_consent_id: Option<u64>,
+    /// Maximum delegation depth allowed for this consent branch.
+    pub max_depth: u32,
 }
 
 #[contracttype]
@@ -1344,6 +1348,17 @@ pub struct ConsentRevoked {
     pub pet_id: u64,
     pub consent_id: u64,
     pub revoked_at: u64,
+}
+
+/// Event emitted when a pet is linked to an external chain identity.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CrossChainIdentityRegistered {
+    pub version: u32,
+    pub pet_id: u64,
+    pub chain_id: String,
+    pub external_id: String,
+    pub registered_at: u64,
 }
 
 /// A single entry in the immutable append-only audit ledger.
@@ -9892,8 +9907,6 @@ impl PetChainContract {
         active
     }
 
-    pub fn get_consent_history_page(env: Env, pet_id: u64, page: u64, page_size: u32) -> Vec<Consent> {
-        let size = if page_size == 0 { 50u32 } else { page_size };
     pub fn get_consent_history_page(
         env: Env,
         pet_id: u64,
@@ -9968,6 +9981,66 @@ impl PetChainContract {
             }
         }
         result
+    }
+
+    pub fn register_cross_chain_id(
+        env: Env,
+        pet_id: u64,
+        owner: Address,
+        chain_id: String,
+        external_id: String,
+    ) -> bool {
+        owner.require_auth();
+
+        let pet: Pet = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pet(pet_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PetNotFound));
+        if pet.owner != owner {
+            env.panic_with_error(ContractError::NotPetOwner);
+        }
+
+        if env
+            .storage()
+            .instance()
+            .has(&CrossChainKey::PetChainMapping((pet_id, chain_id.clone())))
+            || env
+                .storage()
+                .instance()
+                .has(&CrossChainKey::ChainLookup((chain_id.clone(), external_id.clone())))
+        {
+            env.panic_with_error(ContractError::CrossChainIdentityAlreadyRegistered);
+        }
+
+        env.storage().instance().set(
+            &CrossChainKey::PetChainMapping((pet_id, chain_id.clone())),
+            &external_id,
+        );
+        env.storage().instance().set(
+            &CrossChainKey::ChainLookup((chain_id.clone(), external_id.clone())),
+            &pet_id,
+        );
+
+        let registered_at = env.ledger().timestamp();
+        env.events().publish(
+            (Symbol::new(&env, "CrossChainIdentityRegistered"), pet_id),
+            CrossChainIdentityRegistered {
+                version: EVENT_SCHEMA_VERSION,
+                pet_id,
+                chain_id,
+                external_id,
+                registered_at,
+            },
+        );
+
+        true
+    }
+
+    pub fn resolve_cross_chain(env: Env, chain_id: String, external_id: String) -> Option<u64> {
+        env.storage()
+            .instance()
+            .get::<CrossChainKey, u64>(&CrossChainKey::ChainLookup((chain_id, external_id)))
     }
 
     // --- IMMUTABLE AUDIT LEDGER ---
@@ -14449,6 +14522,8 @@ mod test_consent_pagination;
 mod test_behavior;
 #[cfg(test)]
 mod test_grooming;
+#[cfg(test)]
+mod test_cross_chain_identity;
 mod gas_profile_tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Ledger};

--- a/stellar-contracts/src/test_consent_pagination.rs
+++ b/stellar-contracts/src/test_consent_pagination.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Env};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Env, Vec};
 
 fn setup() -> (Env, PetChainContractClient<'static>, u64, Address) {
     let env = Env::default();
@@ -431,4 +431,88 @@ fn test_preview_revocation_cascade_root_only() {
     let preview = client.preview_revocation_cascade(&pet_id, &root_id);
     assert_eq!(preview.len(), 1);
     assert!(preview.contains(&root_id));
+}
+
+#[test]
+fn test_delegate_consent_chain_allows_access_with_valid_chain() {
+    let (env, client, pet_id, owner) = setup();
+    let trusted = Address::generate(&env);
+    let sub_delegate = Address::generate(&env);
+
+    let root_id = client.grant_consent(
+        &pet_id,
+        &owner,
+        &ConsentType::Research,
+        &trusted,
+        &ConsentScope::ReadMedical,
+    );
+
+    let scopes = Vec::from_array(&env, [ConsentScope::ReadMedical]);
+    let delegated = client.delegate_consent(&pet_id, &trusted, &sub_delegate, &scopes, &3);
+    assert_eq!(delegated.len(), 1);
+    assert!(client.check_consent_access(&pet_id, &sub_delegate, &ConsentScope::ReadMedical));
+    assert!(client.is_consent_active(&root_id));
+}
+
+#[test]
+#[should_panic]
+fn test_delegate_consent_scope_escalation_rejected() {
+    let (env, client, pet_id, owner) = setup();
+    let trusted = Address::generate(&env);
+    let sub_delegate = Address::generate(&env);
+
+    client.grant_consent(
+        &pet_id,
+        &owner,
+        &ConsentType::Research,
+        &trusted,
+        &ConsentScope::ReadMedical,
+    );
+
+    let scopes = Vec::from_array(&env, [ConsentScope::WriteMedical]);
+    let _ = client.delegate_consent(&pet_id, &trusted, &sub_delegate, &scopes, &3);
+}
+
+#[test]
+#[should_panic]
+fn test_delegate_consent_depth_limit_enforced() {
+    let (env, client, pet_id, owner) = setup();
+    let level1 = Address::generate(&env);
+    let level2 = Address::generate(&env);
+    let level3 = Address::generate(&env);
+    let level4 = Address::generate(&env);
+
+    client.grant_consent(
+        &pet_id,
+        &owner,
+        &ConsentType::Research,
+        &level1,
+        &ConsentScope::ReadMedical,
+    );
+
+    let scopes = Vec::from_array(&env, [ConsentScope::ReadMedical]);
+    let _ = client.delegate_consent(&pet_id, &level1, &level2, &scopes, &3);
+    let _ = client.delegate_consent(&pet_id, &level2, &level3, &scopes, &3);
+    let _ = client.delegate_consent(&pet_id, &level3, &level4, &scopes, &3);
+}
+
+#[test]
+fn test_consent_access_fails_when_parent_chain_is_revoked() {
+    let (env, client, pet_id, owner) = setup();
+    let trusted = Address::generate(&env);
+    let sub_delegate = Address::generate(&env);
+
+    let root_id = client.grant_consent(
+        &pet_id,
+        &owner,
+        &ConsentType::Research,
+        &trusted,
+        &ConsentScope::ReadMedical,
+    );
+    let scopes = Vec::from_array(&env, [ConsentScope::ReadMedical]);
+    let _ = client.delegate_consent(&pet_id, &trusted, &sub_delegate, &scopes, &3);
+
+    assert!(client.check_consent_access(&pet_id, &sub_delegate, &ConsentScope::ReadMedical));
+    client.revoke_consent(&root_id, &owner);
+    assert!(!client.check_consent_access(&pet_id, &sub_delegate, &ConsentScope::ReadMedical));
 }

--- a/stellar-contracts/src/test_cross_chain_identity.rs
+++ b/stellar-contracts/src/test_cross_chain_identity.rs
@@ -1,0 +1,118 @@
+#[cfg(test)]
+mod test_cross_chain_identity {
+    use crate::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn setup() -> (Env, PetChainContractClient<'static>, u64, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Labrador"),
+            &String::from_str(&env, "Black"),
+            &20u32,
+            &None,
+            &PrivacyLevel::Public,
+        );
+
+        (env, client, pet_id, owner)
+    }
+
+    #[test]
+    fn test_cross_chain_registration_and_resolution() {
+        let (env, client, pet_id, owner) = setup();
+
+        let chain_id = String::from_str(&env, "ethereum");
+        let external_id = String::from_str(&env, "0xabc123");
+
+        assert!(client.register_cross_chain_id(
+            &pet_id,
+            &owner,
+            &chain_id,
+            &external_id,
+        ));
+
+        let resolved = client
+            .resolve_cross_chain(&chain_id, &external_id)
+            .expect("cross-chain lookup should resolve");
+        assert_eq!(resolved, pet_id);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_cross_chain_duplicate_registration_rejected() {
+        let (env, client, pet_id, owner) = setup();
+        let chain_id = String::from_str(&env, "ethereum");
+        let external_id = String::from_str(&env, "0xabc123");
+
+        assert!(client.register_cross_chain_id(
+            &pet_id,
+            &owner,
+            &chain_id,
+            &external_id,
+        ));
+        let _ = client.register_cross_chain_id(&pet_id, &owner, &chain_id, &external_id);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_cross_chain_non_owner_registration_rejected() {
+        let (env, client, pet_id, owner) = setup();
+        let attacker = Address::generate(&env);
+        let chain_id = String::from_str(&env, "ethereum");
+        let external_id = String::from_str(&env, "0xdeadbeef");
+
+        let _ = owner;
+        let _ = client.register_cross_chain_id(
+            &pet_id,
+            &attacker,
+            &chain_id,
+            &external_id,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_cross_chain_duplicate_external_id_on_same_chain_rejected() {
+        let (env, client, pet_id, owner) = setup();
+        let other_owner = Address::generate(&env);
+        let other_pet = client.register_pet(
+            &other_owner,
+            &String::from_str(&env, "Milo"),
+            &String::from_str(&env, "2021-02-02"),
+            &Gender::Male,
+            &Species::Cat,
+            &String::from_str(&env, "Tabby"),
+            &String::from_str(&env, "Gray"),
+            &12u32,
+            &None,
+            &PrivacyLevel::Public,
+        );
+
+        let chain_id = String::from_str(&env, "ethereum");
+        let external_id = String::from_str(&env, "0xabc123");
+
+        assert!(client.register_cross_chain_id(
+            &pet_id,
+            &owner,
+            &chain_id,
+            &external_id,
+        ));
+        let _ = client.register_cross_chain_id(
+            &other_pet,
+            &other_owner,
+            &chain_id,
+            &external_id,
+        );
+    }
+}


### PR DESCRIPTION
closes #695 
closes #696 
closes #697 
closes #698 

Implemented Work
I completed four separate feature sets, each landed in its own commit:
Add TOTP algorithm storage and verification
Add realtime leaderboard websocket
Add consent delegation chains
Add cross-chain pet identity registry
1. TOTP algorithm agility and persistence
I updated the 2FA system so each enrollment now stores the HMAC algorithm used for that user’s TOTP secret. The TOTP config already supported SHA1, SHA256, and SHA512, but verification previously relied on a default config instead of the enrolled algorithm.
What changed:
Added an algorithm field to TwoFactorData in backend-2fa/src/two_factor.rs
Added a serde fallback so older stored records without an algorithm still load as SHA1
Updated enrollment, recovery, canary creation, and tenant flows to persist the selected algorithm
Updated verification paths to use the stored algorithm instead of a hardcoded default
Added database storage for the algorithm column in backend-2fa/src/db.rs
Added schema and migration support in:backend-2fa/schema.sql
backend-2fa/migrations/002_create_base_tables.sql
backend-2fa/migrations/003_add_user_two_factor_algorithm.sql

Updated docs to explain the migration path and legacy SHA1 compatibility in:backend-2fa/README.md
backend-2fa/configuration.md

Net result:
New users can be enrolled with SHA1, SHA256, or SHA512
Verification uses the exact algorithm stored with the account
Existing users remain compatible through the SHA1 fallback
2. Real-time leaderboard websocket
I added a websocket endpoint so leaderboard score changes can be pushed to connected clients in real time rather than requiring polling.
What changed:
Added a websocket hub and session management in backend-2fa/src/leaderboard.rs
Added broadcast support for score updates using a shared in-process channel
Added per-IP connection limiting with a cap of 5 simultaneous connections
Added subscription commands so clients can subscribe to specific user_id values
Added a websocket endpoint wrapper in backend-2fa/src/handlers.rs
Exported the websocket handler and update helpers through backend-2fa/src/lib.rs
Behavior:
GET /leaderboard/ws upgrades to websocket
The server broadcasts update payloads shaped like:{ user_id, new_score, rank }

Clients can subscribe to one or more user IDs for targeted updates
Clients with no active subscription receive all updates
Connections are limited per IP to prevent abuse
3. Consent delegation chains
I expanded the consent model so an owner can delegate consent to a trusted party, and that delegated party can further delegate within the scope and depth they were granted.
What changed:
Added consent chain validation helpers in stellar-contracts/src/lib.rs
Added a new delegate_consent(...) flow that allows a delegate to create sub-consents
Enforced scope non-escalation so sub-consents cannot exceed the delegator’s permissions
Enforced a maximum delegation depth of 3
Added full-chain validation on access checks
Added supporting error codes for invalid chain, scope escalation, and depth overflow
Added tests in stellar-contracts/src/test_consent_pagination.rs
Notable behavior:
A delegated consent must stay within the parent scope
Every access check walks and validates the full chain
If a parent consent is revoked or invalidated, downstream access is rejected
The chain cannot grow beyond three hops
4. Cross-chain pet identity registry
I added a mapping layer that lets a pet identity be anchored to external chain identifiers, such as Ethereum NFT token IDs.
What changed:
Added new cross-chain storage keys in stellar-contracts/src/lib.rs
Added register_cross_chain_id(pet_id, chain_id, external_id) for the pet owner to register an external identity
Added resolve_cross_chain(chain_id, external_id) to map an external chain identifier back to a PetChain pet ID
Added an event emitted on successful registration
Added tests in stellar-contracts/src/test_cross_chain_identity.rs
Behavior:
Only the pet owner can register the cross-chain mapping
A pet cannot register duplicate identifiers for the same chain
A chain/external ID pair can resolve to exactly one pet
Duplicate registrations are rejected
Successful registration emits an event for off-chain indexers
Notes
I did not run tests or compile, per your instruction.
The repository is clean and the changes were pushed to GitHub.
If you want, I can also turn this into:
a polished PR description
a shorter changelog entry