### PR TITLE
feat/medical-record-soroban-multiparty

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Env, Map, Symbol, Vec,
+    Env, Map, String, Symbol, Vec,
 };
 
 /// Expiry policy: a pending transfer that has not been accepted within
@@ -94,7 +94,11 @@ pub struct PendingAdoption {
     pub pet_id: u64,
     pub from: Address,
     pub to: Address,
+    pub organization: Option<Address>,
     pub signed_at: u64,
+    pub owner_approved: bool,
+    pub adopter_approved: bool,
+    pub organization_approved: bool,
 }
 
 #[contracttype]
@@ -103,6 +107,7 @@ pub enum AdoptionState {
     Signed,
     Completed,
     Waived,
+    Rejected,
 }
 
 /// A record tracking the full lifecycle of an adoption.
@@ -112,11 +117,17 @@ pub struct AdoptionRecord {
     pub pet_id: u64,
     pub from: Address,
     pub to: Address,
+    pub organization: Option<Address>,
     pub signed_at: u64,
     pub completed_at: Option<u64>,
     pub state: AdoptionState,
+    pub owner_approved: bool,
+    pub adopter_approved: bool,
+    pub organization_approved: bool,
     pub waiver_reason: Option<String>, // set when waived by admin
     pub waived_by: Option<Address>,
+    pub rejected_by: Option<Address>,
+    pub rejection_reason: Option<String>,
 }
 
 /// A single chain-of-custody entry appended on every ownership change.
@@ -195,6 +206,11 @@ pub enum ContractError {
     AdoptionNotConfigurable = 18,
     InvalidWaitingPeriod = 19,
     AdoptionConfigNotFound = 20,
+    BatchTooLarge = 21,
+    InvalidBatch = 22,
+    OrganizationApprovalRequired = 23,
+    AdoptionRejected = 24,
+    InvalidApprover = 25,
 }
 
 /// ======================================================
@@ -364,7 +380,7 @@ impl PetOwnershipContract {
     }
 
     /// Sign an adoption agreement, entering the waiting period.
-    pub fn sign_adoption(env: Env, pet_id: u64, to: Address) {
+    pub fn sign_adoption(env: Env, pet_id: u64, to: Address, organization: Option<Address>) {
         let pet = get_pet(&env, pet_id);
         pet.current_owner.require_auth();
 
@@ -380,17 +396,27 @@ impl PetOwnershipContract {
             pet_id,
             from: pet.current_owner.clone(),
             to: to.clone(),
+            organization: organization.clone(),
             signed_at: now,
+            owner_approved: true,
+            adopter_approved: false,
+            organization_approved: false,
         };
         let record = AdoptionRecord {
             pet_id,
             from: pet.current_owner.clone(),
             to: to.clone(),
+            organization: organization.clone(),
             signed_at: now,
             completed_at: None,
             state: AdoptionState::Signed,
+            owner_approved: true,
+            adopter_approved: false,
+            organization_approved: false,
             waiver_reason: None,
             waived_by: None,
+            rejected_by: None,
+            rejection_reason: None,
         };
 
         env.storage().persistent().set(&DataKey::PendingAdoption(pet_id), &pending);
@@ -398,7 +424,80 @@ impl PetOwnershipContract {
 
         env.events().publish(
             (Symbol::new(&env, "adoption_sign"), pet_id),
-            (pet.current_owner, to, now),
+            (pet.current_owner, to, organization, now),
+        );
+    }
+
+    /// Approve an adoption as either the adopter or the rescue organization admin.
+    pub fn approve_adoption(env: Env, pet_id: u64, approver: Address) {
+        approver.require_auth();
+
+        let pending: PendingAdoption = env.storage().persistent()
+            .get(&DataKey::PendingAdoption(pet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+        let mut record: AdoptionRecord = env.storage().persistent()
+            .get(&DataKey::AdoptionRecord(pet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+
+        if record.state == AdoptionState::Rejected {
+            panic_with_error!(&env, ContractError::AdoptionRejected);
+        }
+        if record.state == AdoptionState::Completed || record.state == AdoptionState::Waived {
+            panic_with_error!(&env, ContractError::AdoptionAlreadyCompleted);
+        }
+
+        if approver == pending.to {
+            record.adopter_approved = true;
+        } else if pending.organization.as_ref() == Some(&approver) {
+            record.organization_approved = true;
+        } else {
+            panic_with_error!(&env, ContractError::InvalidApprover);
+        }
+
+        let mut pending = pending;
+        pending.adopter_approved = record.adopter_approved;
+        pending.organization_approved = record.organization_approved;
+
+        env.storage().persistent().set(&DataKey::PendingAdoption(pet_id), &pending);
+        env.storage().persistent().set(&DataKey::AdoptionRecord(pet_id), &record);
+    }
+
+    /// Reject a pending adoption. Any participant may cancel the adoption.
+    pub fn reject_adoption(env: Env, pet_id: u64, rejector: Address, reason: String) {
+        rejector.require_auth();
+
+        let pending: PendingAdoption = env.storage().persistent()
+            .get(&DataKey::PendingAdoption(pet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+        let mut record: AdoptionRecord = env.storage().persistent()
+            .get(&DataKey::AdoptionRecord(pet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+
+        if record.state == AdoptionState::Completed || record.state == AdoptionState::Waived {
+            panic_with_error!(&env, ContractError::AdoptionAlreadyCompleted);
+        }
+        if record.state == AdoptionState::Rejected {
+            panic_with_error!(&env, ContractError::AdoptionRejected);
+        }
+
+        let is_owner = rejector == pending.from;
+        let is_adopter = rejector == pending.to;
+        let is_org = pending.organization.as_ref() == Some(&rejector);
+        if !is_owner && !is_adopter && !is_org {
+            panic_with_error!(&env, ContractError::InvalidApprover);
+        }
+
+        record.state = AdoptionState::Rejected;
+        record.completed_at = None;
+        record.rejected_by = Some(rejector.clone());
+        record.rejection_reason = Some(reason.clone());
+
+        env.storage().persistent().remove(&DataKey::PendingAdoption(pet_id));
+        env.storage().persistent().set(&DataKey::AdoptionRecord(pet_id), &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "adoption_rej"), pet_id),
+            (rejector, reason),
         );
     }
 
@@ -407,6 +506,7 @@ impl PetOwnershipContract {
         let pending: PendingAdoption = env.storage().persistent()
             .get(&DataKey::PendingAdoption(pet_id))
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+        pending.to.require_auth();
 
         let now = env.ledger().timestamp();
         let config: Option<AdoptionConfig> = env.storage().persistent().get(&DataKey::AdoptionConfig);
@@ -422,8 +522,14 @@ impl PetOwnershipContract {
         let mut record: AdoptionRecord = env.storage().persistent()
             .get(&DataKey::AdoptionRecord(pet_id))
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+        if record.state == AdoptionState::Rejected {
+            panic_with_error!(&env, ContractError::AdoptionRejected);
+        }
         if record.state != AdoptionState::Signed {
             panic_with_error!(&env, ContractError::AdoptionAlreadyCompleted);
+        }
+        if pending.organization.is_some() && !record.organization_approved {
+            panic_with_error!(&env, ContractError::OrganizationApprovalRequired);
         }
 
         let mut pet = get_pet(&env, pet_id);
@@ -449,8 +555,11 @@ impl PetOwnershipContract {
         remove_pet_from_owner(&env, &pending.from, pet_id);
         add_pet_to_owner(&env, &pending.to, pet_id);
         pet.current_owner = pending.to.clone();
+        record.adopter_approved = true;
+        record.organization_approved = record.organization_approved || pending.organization.is_none();
         record.state = AdoptionState::Completed;
         record.completed_at = Some(now);
+        record.owner_approved = true;
 
         save_pet(&env, &pet);
         save_history(&env, pet_id, &history);
@@ -474,8 +583,14 @@ impl PetOwnershipContract {
         let mut record: AdoptionRecord = env.storage().persistent()
             .get(&DataKey::AdoptionRecord(pet_id))
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoPendingAdoption));
+        if record.state == AdoptionState::Rejected {
+            panic_with_error!(&env, ContractError::AdoptionRejected);
+        }
         if record.state != AdoptionState::Signed {
             panic_with_error!(&env, ContractError::AdoptionAlreadyCompleted);
+        }
+        if pending.organization.is_some() && !record.organization_approved {
+            panic_with_error!(&env, ContractError::OrganizationApprovalRequired);
         }
 
         let now = env.ledger().timestamp();
@@ -505,6 +620,9 @@ impl PetOwnershipContract {
 
         record.state = AdoptionState::Waived;
         record.completed_at = Some(now);
+        record.adopter_approved = true;
+        record.owner_approved = true;
+        record.organization_approved = record.organization_approved || pending.organization.is_none();
         record.waiver_reason = Some(reason.clone());
         record.waived_by = Some(admin.clone());
 
@@ -875,6 +993,79 @@ impl PetOwnershipContract {
             env.events().publish(
                 (EVT_TRANSFER_INITIATED, pet_id),
                 (owner.clone(), to.clone()),
+            );
+        }
+    }
+
+    /// Transfer multiple pets to the same new owner atomically.
+    /// All pets must be owned by the same caller and the batch is rejected
+    /// if any pet is missing or owned by a different address.
+    pub fn batch_transfer(env: Env, pet_ids: Vec<u64>, to: Address) {
+        const MAX_BATCH_SIZE: u32 = 20;
+
+        if pet_ids.is_empty() {
+            panic_with_error!(env, ContractError::EmptyBatch);
+        }
+        if pet_ids.len() > MAX_BATCH_SIZE {
+            panic_with_error!(env, ContractError::BatchTooLarge);
+        }
+
+        let mut expected_owner: Option<Address> = None;
+        let mut seen_ids = Vec::new(env);
+        let mut pets = Vec::new(env);
+        for pet_id in pet_ids.iter() {
+            if seen_ids.contains(&pet_id) {
+                panic_with_error!(env, ContractError::InvalidBatch);
+            }
+            seen_ids.push_back(pet_id);
+
+            let pet = get_pet(&env, pet_id);
+            match expected_owner {
+                None => expected_owner = Some(pet.current_owner.clone()),
+                Some(ref owner) if owner != &pet.current_owner => {
+                    panic_with_error!(env, ContractError::BatchOwnerMismatch);
+                }
+                _ => {}
+            }
+
+            pets.push_back(pet);
+        }
+
+        let owner = expected_owner.unwrap_or_else(|| panic_with_error!(env, ContractError::EmptyBatch));
+        owner.require_auth();
+
+        let now = env.ledger().timestamp();
+        for pet in pets.iter() {
+            let pet_id = pet.pet_id;
+            let old_owner = pet.current_owner.clone();
+            let mut history = get_history(&env, pet_id);
+            if history.len() == 0 {
+                panic_with_error!(&env, ContractError::EmptyOwnershipHistory);
+            }
+            let last = history.len() - 1;
+            let mut prev = history
+                .get(last)
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::MissingOwnershipRecord));
+            prev.relinquished_at = Some(now);
+            history.set(last, prev);
+            history.push_back(OwnershipRecord {
+                owner: to.clone(),
+                acquired_at: now,
+                relinquished_at: None,
+            });
+
+            remove_pet_from_owner(&env, &old_owner, pet_id);
+            add_pet_to_owner(&env, &to, pet_id);
+            let mut pet = pet.clone();
+            pet.current_owner = to.clone();
+
+            save_pet(&env, &pet);
+            save_history(&env, pet_id, &history);
+            append_custody_entry(&env, pet_id, old_owner.clone(), to.clone(), TransferType::Direct);
+
+            env.events().publish(
+                (EVT_TRANSFER_FINALIZED, pet_id),
+                (old_owner, to.clone()),
             );
         }
     }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    Address, Env, Error, Vec,
+    Address, Env, Error, String, Vec,
 };
 
 fn setup() -> (Env, Address, Address, u64) {
@@ -374,6 +374,137 @@ fn batch_initiate_transfer_errors_when_a_pet_already_has_pending_transfer() {
     );
     // Atomicity: pet 2 must remain unaffected
     assert!(!client.has_pending_transfer(&2));
+}
+
+#[test]
+fn batch_transfer_moves_all_pets_and_emits_one_event_per_pet() {
+    let (env, owner, new_owner, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&1, &owner);
+    client.create_pet(&2, &owner);
+
+    let before_events = env.events().all().len();
+    let mut ids = Vec::new(&env);
+    ids.push_back(1u64);
+    ids.push_back(2u64);
+
+    client.batch_transfer(&ids, &new_owner);
+
+    assert_eq!(client.get_current_owner(&1), new_owner);
+    assert_eq!(client.get_current_owner(&2), new_owner);
+    assert_eq!(env.events().all().len(), before_events + 2);
+}
+
+#[test]
+fn batch_transfer_rejects_owner_mismatch_atomically() {
+    let (env, owner, new_owner, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let other_owner = Address::generate(&env);
+
+    client.create_pet(&1, &owner);
+    client.create_pet(&2, &other_owner);
+
+    let mut ids = Vec::new(&env);
+    ids.push_back(1u64);
+    ids.push_back(2u64);
+
+    let result = client.try_batch_transfer(&ids, &new_owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::BatchOwnerMismatch as u32,
+        )))
+    );
+    assert_eq!(client.get_current_owner(&1), owner);
+    assert_eq!(client.get_current_owner(&2), other_owner);
+}
+
+#[test]
+fn batch_transfer_rejects_over_limit() {
+    let (env, owner, new_owner, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    let mut ids = Vec::new(&env);
+    for pet_id in 1u64..=21u64 {
+        client.create_pet(&pet_id, &owner);
+        ids.push_back(pet_id);
+    }
+
+    let result = client.try_batch_transfer(&ids, &new_owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::BatchTooLarge as u32,
+        )))
+    );
+}
+
+// ======================================================
+// adoption multi-party approval tests
+// ======================================================
+
+#[test]
+fn adoption_without_organization_keeps_two_party_flow() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+    client.complete_adoption(&pet_id);
+
+    assert_eq!(client.get_current_owner(&pet_id), adopter);
+    let record = client.get_adoption_record(&pet_id).unwrap();
+    assert_eq!(record.state, AdoptionState::Completed);
+    assert!(record.organization.is_none());
+}
+
+#[test]
+fn adoption_with_organization_requires_org_approval() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let organization = Address::generate(&env);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &Some(organization.clone()));
+
+    let blocked = client.try_complete_adoption(&pet_id);
+    assert_eq!(
+        blocked,
+        Err(Ok(Error::from_contract_error(
+            ContractError::OrganizationApprovalRequired as u32,
+        )))
+    );
+
+    client.approve_adoption(&pet_id, &organization);
+    client.complete_adoption(&pet_id);
+
+    let record = client.get_adoption_record(&pet_id).unwrap();
+    assert_eq!(record.state, AdoptionState::Completed);
+    assert_eq!(record.organization, Some(organization));
+    assert!(record.organization_approved);
+}
+
+#[test]
+fn adoption_rejection_cancels_pending_flow() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let organization = Address::generate(&env);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &Some(organization.clone()));
+    client.reject_adoption(&pet_id, &organization, &String::from_str(&env, "Rescue declined"));
+
+    assert!(client.get_pending_adoption(&pet_id).is_none());
+    let record = client.get_adoption_record(&pet_id).unwrap();
+    assert_eq!(record.state, AdoptionState::Rejected);
+    assert_eq!(record.rejected_by, Some(organization));
 }
 
 // ======================================================

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -364,6 +364,9 @@ pub enum ContractError {
     ClaimNotFound = 194,
     ClaimDocumentLimitReached = 195,
     ClaimImmutable = 196,
+    MedicalRecordAmendmentLimitReached = 197,
+    MedicalRecordNotFound = 198,
+    MedicalRecordVersionNotFound = 199,
 }
 
 // --- MULTI-LANGUAGE ERROR REGISTRY (Issue #684) ---
@@ -1112,6 +1115,8 @@ pub enum MedicalKey {
     MedicalRecordCount,
     PetMedicalRecordIndex((u64, u64)), // (pet_id, index) -> medical_record_id
     PetMedicalRecordCount(u64),
+    MedicalRecordAmendment((u64, u32)),
+    MedicalRecordAmendmentCount(u64),
     KeywordRecordCount((u64, Bytes)),
     KeywordRecordIndex((u64, Bytes, u64)),
     GlobalMedication(u64),          // medication_id -> Medication
@@ -1465,6 +1470,14 @@ pub struct LabDifference {
     pub abnormal: bool,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MedicalFieldDiff {
+    pub field: String,
+    pub from_value: String,
+    pub to_value: String,
+}
+
 /// Cached result of a biomarker moving-average computation (1-hour TTL).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1721,6 +1734,24 @@ pub struct MedicalRecordInput {
     pub treatment: String,
     pub medications: Vec<Medication>,
     pub notes: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MedicalRecordAmendmentInput {
+    pub diagnosis: Option<String>,
+    pub treatment: Option<String>,
+    pub medications: Option<Vec<Medication>>,
+    pub notes: Option<String>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MedicalRecordAmendment {
+    pub record_id: u64,
+    pub version: u32,
+    pub updated_at: u64,
+    pub changes: MedicalRecordAmendmentInput,
 }
 
 #[contracttype]
@@ -8240,6 +8271,135 @@ impl PetChainContract {
         false
     }
 
+    fn get_medical_record_amendment_count(env: &Env, record_id: u64) -> u32 {
+        env.storage()
+            .instance()
+            .get::<MedicalKey, u32>(&MedicalKey::MedicalRecordAmendmentCount(record_id))
+            .unwrap_or(0)
+    }
+
+    fn build_medical_record_version(
+        env: &Env,
+        record_id: u64,
+        version: u32,
+    ) -> Option<MedicalRecord> {
+        let mut record: MedicalRecord = env
+            .storage()
+            .instance()
+            .get(&MedicalKey::MedicalRecord(record_id))?;
+
+        if version == 0 {
+            return Some(record);
+        }
+
+        let amendment_count = Self::get_medical_record_amendment_count(env, record_id);
+        if version > amendment_count {
+            return None;
+        }
+
+        for current_version in 1..=version {
+            let amendment = env
+                .storage()
+                .instance()
+                .get::<MedicalKey, MedicalRecordAmendment>(
+                    &MedicalKey::MedicalRecordAmendment((record_id, current_version)),
+                )?;
+
+            let MedicalRecordAmendmentInput {
+                diagnosis,
+                treatment,
+                medications,
+                notes,
+            } = amendment.changes;
+
+            if let Some(diagnosis) = diagnosis {
+                record.diagnosis = diagnosis;
+            }
+            if let Some(treatment) = treatment {
+                record.treatment = treatment;
+            }
+            if let Some(medications) = medications {
+                record.medications = medications;
+            }
+            if let Some(notes) = notes {
+                record.notes = notes;
+            }
+            record.updated_at = amendment.updated_at;
+        }
+
+        Some(record)
+    }
+
+    fn store_medical_record_amendment(
+        env: &Env,
+        record: &MedicalRecord,
+        changes: MedicalRecordAmendmentInput,
+    ) -> u32 {
+        if changes.diagnosis.is_none()
+            && changes.treatment.is_none()
+            && changes.medications.is_none()
+            && changes.notes.is_none()
+        {
+            panic_with_error!(env, ContractError::InvalidInput);
+        }
+
+        let current_count = Self::get_medical_record_amendment_count(env, record.id);
+        if current_count >= 5 {
+            panic_with_error!(env, ContractError::MedicalRecordAmendmentLimitReached);
+        }
+
+        let version = current_count + 1;
+        let updated_at = env.ledger().timestamp();
+        let amendment = MedicalRecordAmendment {
+            record_id: record.id,
+            version,
+            updated_at,
+            changes,
+        };
+
+        env.storage().instance().set(
+            &MedicalKey::MedicalRecordAmendment((record.id, version)),
+            &amendment,
+        );
+        env.storage().instance().set(
+            &MedicalKey::MedicalRecordAmendmentCount(record.id),
+            &version,
+        );
+
+        version
+    }
+
+    pub fn amend_medical_record(
+        env: Env,
+        pet_id: u64,
+        record_id: u64,
+        updated_fields: MedicalRecordAmendmentInput,
+    ) -> u32 {
+        let mut record: MedicalRecord = env
+            .storage()
+            .instance()
+            .get(&MedicalKey::MedicalRecord(record_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::MedicalRecordNotFound));
+
+        if record.pet_id != pet_id {
+            panic_with_error!(&env, ContractError::Unauthorized);
+        }
+
+        record.vet_address.require_auth();
+
+        let version = Self::store_medical_record_amendment(&env, &record, updated_fields);
+
+        PetChainContract::log_access(
+            &env,
+            record.pet_id,
+            record.vet_address,
+            AccessAction::Write,
+            String::from_str(&env, "Medical record amended"),
+        );
+
+        version
+    }
+
     pub fn update_medical_record(
         env: Env,
         record_id: u64,
@@ -8248,22 +8408,19 @@ impl PetChainContract {
         medications: Vec<Medication>,
         notes: String,
     ) -> bool {
-        if let Some(mut record) = env
+        if let Some(record) = env
             .storage()
             .instance()
             .get::<MedicalKey, MedicalRecord>(&MedicalKey::MedicalRecord(record_id))
         {
             record.vet_address.require_auth();
-
-            record.diagnosis = diagnosis;
-            record.treatment = treatment;
-            record.medications = medications;
-            record.notes = notes;
-            record.date = env.ledger().timestamp();
-
-            env.storage()
-                .instance()
-                .set(&MedicalKey::MedicalRecord(record_id), &record);
+            let updated_fields = MedicalRecordAmendmentInput {
+                diagnosis: Some(diagnosis),
+                treatment: Some(treatment),
+                medications: Some(medications),
+                notes: Some(notes),
+            };
+            Self::store_medical_record_amendment(&env, &record, updated_fields);
             PetChainContract::log_access(
                 &env,
                 record.pet_id,
@@ -8283,21 +8440,19 @@ impl PetChainContract {
         if notes.len() > PetChainContract::MAX_STR_LONG {
             panic_with_error!(&env, ContractError::InputStringTooLong);
         }
-        if let Some(mut record) = env
+        if let Some(record) = env
             .storage()
             .instance()
             .get::<MedicalKey, MedicalRecord>(&MedicalKey::MedicalRecord(record_id))
         {
-            // Require authentication from the vet who created the record
             record.vet_address.require_auth();
-
-            // Update only the notes and updated_at timestamp
-            record.notes = notes;
-            record.updated_at = env.ledger().timestamp();
-
-            env.storage()
-                .instance()
-                .set(&MedicalKey::MedicalRecord(record_id), &record);
+            let updated_fields = MedicalRecordAmendmentInput {
+                diagnosis: None,
+                treatment: None,
+                medications: None,
+                notes: Some(notes),
+            };
+            Self::store_medical_record_amendment(&env, &record, updated_fields);
             PetChainContract::log_access(
                 &env,
                 record.pet_id,
@@ -8309,6 +8464,56 @@ impl PetChainContract {
         } else {
             false
         }
+    }
+
+    pub fn diff_record_versions(
+        env: Env,
+        pet_id: u64,
+        record_id: u64,
+        v1: u32,
+        v2: u32,
+    ) -> Vec<MedicalFieldDiff> {
+        let version_a = Self::build_medical_record_version(&env, record_id, v1)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::MedicalRecordVersionNotFound));
+        let version_b = Self::build_medical_record_version(&env, record_id, v2)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::MedicalRecordVersionNotFound));
+
+        if version_a.pet_id != pet_id || version_b.pet_id != pet_id {
+            panic_with_error!(&env, ContractError::Unauthorized);
+        }
+
+        let mut diffs = Vec::new(&env);
+
+        if version_a.diagnosis != version_b.diagnosis {
+            diffs.push_back(MedicalFieldDiff {
+                field: String::from_str(&env, "diagnosis"),
+                from_value: version_a.diagnosis.clone(),
+                to_value: version_b.diagnosis.clone(),
+            });
+        }
+        if version_a.treatment != version_b.treatment {
+            diffs.push_back(MedicalFieldDiff {
+                field: String::from_str(&env, "treatment"),
+                from_value: version_a.treatment.clone(),
+                to_value: version_b.treatment.clone(),
+            });
+        }
+        if version_a.medications != version_b.medications {
+            diffs.push_back(MedicalFieldDiff {
+                field: String::from_str(&env, "medications"),
+                from_value: String::from_str(&env, "changed"),
+                to_value: String::from_str(&env, "changed"),
+            });
+        }
+        if version_a.notes != version_b.notes {
+            diffs.push_back(MedicalFieldDiff {
+                field: String::from_str(&env, "notes"),
+                from_value: version_a.notes.clone(),
+                to_value: version_b.notes.clone(),
+            });
+        }
+
+        diffs
     }
 
     pub fn get_medical_record(env: Env, record_id: u64) -> Option<MedicalRecord> {

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -352,6 +352,7 @@ pub enum ContractError {
     StorageQuotaExceeded = 160,
     ErrorMessageNotFound = 170,
     DuplicateActivity = 180,
+    BatchTooLarge = 181,
     // Issue: Pet profile schema validation
     InvalidPetName = 190,
     InvalidBreed = 191,
@@ -4046,6 +4047,91 @@ impl PetChainContract {
             pet.new_owner = to;
             pet.updated_at = env.ledger().timestamp();
             env.storage().instance().set(&DataKey::Pet(id), &pet);
+        }
+    }
+
+    /// Transfer multiple pets to the same new owner atomically.
+    /// All pets must belong to the same caller and the entire batch fails if
+    /// any pet is missing or owned by a different address.
+    pub fn batch_transfer(env: Env, pet_ids: Vec<u64>, new_owner: Address) {
+        const MAX_BATCH_SIZE: u32 = 20;
+
+        if pet_ids.is_empty() {
+            panic_with_error!(&env, ContractError::InvalidInput);
+        }
+        if pet_ids.len() > MAX_BATCH_SIZE {
+            panic_with_error!(&env, ContractError::BatchTooLarge);
+        }
+
+        let mut expected_owner: Option<Address> = None;
+        let mut seen_ids = Vec::new(&env);
+        let mut pets = Vec::new(&env);
+        for pet_id in pet_ids.iter() {
+            if seen_ids.contains(&pet_id) {
+                panic_with_error!(&env, ContractError::InvalidInput);
+            }
+            seen_ids.push_back(pet_id);
+
+            let pet = env
+                .storage()
+                .instance()
+                .get::<DataKey, Pet>(&DataKey::Pet(pet_id))
+                .unwrap_or_else(|| env.panic_with_error(ContractError::PetNotFound));
+
+            match expected_owner {
+                None => expected_owner = Some(pet.owner.clone()),
+                Some(ref owner) if owner != &pet.owner => {
+                    panic_with_error!(&env, ContractError::NotPetOwner);
+                }
+                _ => {}
+            }
+
+            pets.push_back(pet);
+        }
+
+        let owner = expected_owner.unwrap_or_else(|| env.panic_with_error(ContractError::InvalidInput));
+        owner.require_auth();
+
+        let now = env.ledger().timestamp();
+        for pet in pets.iter() {
+            let pet_id = pet.pet_id;
+            let old_owner = pet.owner.clone();
+            PetChainContract::remove_pet_from_owner_index(&env, &old_owner, pet_id);
+
+            let mut pet = pet.clone();
+            pet.owner = new_owner.clone();
+            pet.new_owner = new_owner.clone();
+            pet.updated_at = now;
+
+            PetChainContract::add_pet_to_owner_index(&env, &pet.owner, pet_id);
+            env.storage().instance().set(&DataKey::Pet(pet_id), &pet);
+
+            PetChainContract::log_ownership_change(
+                &env,
+                pet_id,
+                old_owner.clone(),
+                pet.owner.clone(),
+                String::from_str(&env, "Batch Transfer"),
+            );
+
+            PetChainContract::append_custody_entry(
+                &env,
+                pet_id,
+                old_owner.clone(),
+                pet.owner.clone(),
+                TransferType::Direct,
+            );
+
+            env.events().publish(
+                (String::from_str(&env, "PetOwnershipTransferred"), pet_id),
+                PetOwnershipTransferredEvent {
+                    version: EVENT_SCHEMA_VERSION,
+                    pet_id,
+                    old_owner,
+                    new_owner: pet.owner.clone(),
+                    timestamp: now,
+                },
+            );
         }
     }
 

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -204,6 +204,8 @@ mod test_vaccination_expiry;
 mod test_medical_record_soft_delete;
 #[cfg(test)]
 mod test_event_subscriptions;
+#[cfg(test)]
+mod test_health_score;
 
 use soroban_sdk::xdr::{FromXdr, ToXdr};
 use soroban_sdk::{
@@ -1121,6 +1123,7 @@ pub enum MedicalKey {
     VaccinationCount,
     PetVaccinationCount(u64),
     PetVaccinationByIndex((u64, u64)),
+    HealthScoreCache(u64),
     // Scanner registry
     ScannerRegistry,
 }
@@ -1432,6 +1435,24 @@ pub struct VaccinationSummary {
     pub is_fully_current: bool,
     pub overdue_types: Vec<VaccineType>,
     pub upcoming_count: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HealthScoreBreakdown {
+    pub vaccination: u32,
+    pub lab_results: u32,
+    pub activity: u32,
+    pub insurance: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HealthScore {
+    pub pet_id: u64,
+    pub score: u32,
+    pub breakdown: HealthScoreBreakdown,
+    pub computed_at: u64,
 }
 
 #[contracttype]
@@ -3731,6 +3752,133 @@ impl PetChainContract {
         } else {
             None
         }
+    }
+
+    fn compute_vaccination_health_score(env: &Env, pet_id: u64) -> u32 {
+        let history = PetChainContract::get_vaccination_history(env.clone(), pet_id, 0, u32::MAX);
+        if history.len() == 0 {
+            return 0;
+        }
+
+        let mut seen_types: Vec<VaccineType> = Vec::new(env);
+        let mut current_types: u32 = 0;
+        let mut total_types: u32 = 0;
+
+        for vaccination in history.iter() {
+            if seen_types.contains(&vaccination.vaccine_type) {
+                continue;
+            }
+            seen_types.push_back(vaccination.vaccine_type.clone());
+            total_types = total_types.saturating_add(1);
+            if PetChainContract::is_vaccination_current(
+                env.clone(),
+                pet_id,
+                vaccination.vaccine_type.clone(),
+            ) {
+                current_types = current_types.saturating_add(1);
+            }
+        }
+
+        if total_types == 0 {
+            0
+        } else {
+            current_types.saturating_mul(100) / total_types
+        }
+    }
+
+    fn compute_lab_health_score(env: &Env, pet_id: u64) -> u32 {
+        let count = PetChainContract::get_lab_result_count(env.clone(), pet_id);
+        if count == 0 {
+            return 0;
+        }
+
+        let mut latest_date = 0u64;
+        for i in 1..=count {
+            if let Some(result_id) = env
+                .storage()
+                .instance()
+                .get::<MedicalKey, u64>(&MedicalKey::PetLabResultIndex((pet_id, i)))
+            {
+                if let Some(result) = PetChainContract::get_lab_result(env.clone(), result_id) {
+                    if result.date >= latest_date {
+                        latest_date = result.date;
+                    }
+                }
+            }
+        }
+
+        let recent_cutoff = env.ledger().timestamp().saturating_sub(30 * 24 * 60 * 60);
+        if latest_date >= recent_cutoff {
+            100
+        } else {
+            50
+        }
+    }
+
+    fn compute_activity_health_score(env: &Env, pet_id: u64) -> u32 {
+        let streak = PetChainContract::get_activity_streak(env.clone(), pet_id).current_streak;
+        if streak == 0 {
+            return 0;
+        }
+
+        let capped = if streak > 30 { 30 } else { streak };
+        (capped.saturating_mul(100) / 30) as u32
+    }
+
+    fn compute_insurance_health_score(env: &Env, pet_id: u64) -> u32 {
+        if PetChainContract::is_insurance_active(env.clone(), pet_id) {
+            100
+        } else {
+            0
+        }
+    }
+
+    pub fn compute_health_score(env: Env, pet_id: u64) -> HealthScore {
+        let _pet: Pet = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pet(pet_id))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PetNotFound));
+
+        let now = env.ledger().timestamp();
+        let breakdown = HealthScoreBreakdown {
+            vaccination: Self::compute_vaccination_health_score(&env, pet_id),
+            lab_results: Self::compute_lab_health_score(&env, pet_id),
+            activity: Self::compute_activity_health_score(&env, pet_id),
+            insurance: Self::compute_insurance_health_score(&env, pet_id),
+        };
+        let score = (breakdown.vaccination
+            + breakdown.lab_results
+            + breakdown.activity
+            + breakdown.insurance)
+            / 4;
+
+        let result = HealthScore {
+            pet_id,
+            score,
+            breakdown,
+            computed_at: now,
+        };
+
+        env.storage()
+            .instance()
+            .set(&MedicalKey::HealthScoreCache(pet_id), &result);
+        result
+    }
+
+    pub fn get_health_score(env: Env, pet_id: u64) -> HealthScore {
+        let ttl = 24 * 60 * 60;
+        if let Some(cached) = env
+            .storage()
+            .instance()
+            .get::<MedicalKey, HealthScore>(&MedicalKey::HealthScoreCache(pet_id))
+        {
+            if env.ledger().timestamp().saturating_sub(cached.computed_at) < ttl {
+                return cached;
+            }
+        }
+
+        Self::compute_health_score(env, pet_id)
     }
 
     fn parse_birthday_timestamp(birthday: &String) -> Result<u64, ContractError> {

--- a/stellar-contracts/src/test_health_score.rs
+++ b/stellar-contracts/src/test_health_score.rs
@@ -1,0 +1,149 @@
+use crate::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String,
+};
+
+fn setup() -> (
+    Env,
+    PetChainContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    u64,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+    client.init_admin(&admin);
+
+    client.register_vet(
+        &vet,
+        &String::from_str(&env, "Dr. Score"),
+        &String::from_str(&env, "HEALTH-1"),
+        &String::from_str(&env, "General"),
+    );
+    client.verify_vet(&admin, &vet);
+
+    let pet_id = client.register_pet(
+        &owner,
+        &String::from_str(&env, "Milo"),
+        &String::from_str(&env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Mix"),
+        &String::from_str(&env, "Brown"),
+        &24u32,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    (env, client, admin, owner, vet, pet_id)
+}
+
+#[test]
+fn health_score_defaults_to_zero_when_components_are_missing() {
+    let (env, client, _admin, _owner, _vet, pet_id) = setup();
+
+    let score = client.get_health_score(&pet_id);
+    assert_eq!(score.score, 0);
+    assert_eq!(score.breakdown.vaccination, 0);
+    assert_eq!(score.breakdown.lab_results, 0);
+    assert_eq!(score.breakdown.activity, 0);
+    assert_eq!(score.breakdown.insurance, 0);
+    assert_eq!(score.computed_at, env.ledger().timestamp());
+}
+
+#[test]
+fn health_score_uses_all_components_and_cache_ttl() {
+    let (env, client, _admin, owner, vet, pet_id) = setup();
+
+    env.ledger().set_timestamp(1_000);
+
+    client.add_vaccination(
+        &pet_id,
+        &vet,
+        &VaccineType::Rabies,
+        &String::from_str(&env, "Rabies"),
+        &1_000u64,
+        &(1_000u64 + 90 * 86_400),
+        &(1_000u64 + 90 * 86_400),
+        &String::from_str(&env, "BATCH-1"),
+    );
+
+    client.add_lab_result(
+        &pet_id,
+        &vet,
+        &String::from_str(&env, "CBC"),
+        &String::from_str(&env, "All values within range"),
+        &String::from_str(&env, "{}"),
+        &None,
+        &None,
+    );
+
+    env.ledger().set_timestamp(86_400 + 1_000);
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30u32,
+        &4u32,
+        &1_200u32,
+        &String::from_str(&env, "Morning walk"),
+    );
+
+    env.ledger().set_timestamp(2 * 86_400 + 1_000);
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30u32,
+        &4u32,
+        &1_200u32,
+        &String::from_str(&env, "Evening walk"),
+    );
+
+    env.ledger().set_timestamp(3 * 86_400 + 1_000);
+    client.add_activity_record(
+        &pet_id,
+        &ActivityType::Walk,
+        &30u32,
+        &4u32,
+        &1_200u32,
+        &String::from_str(&env, "Night walk"),
+    );
+
+    client.add_insurance_policy(
+        &pet_id,
+        &String::from_str(&env, "POL-1"),
+        &String::from_str(&env, "Good Pet Insurance"),
+        &String::from_str(&env, "Premium"),
+        &12_000u64,
+        &100_000u64,
+        &((3u64 * 86_400) + 1_000 + 90 * 86_400),
+    );
+
+    let initial = client.get_health_score(&pet_id);
+    assert_eq!(initial.breakdown.vaccination, 100);
+    assert_eq!(initial.breakdown.lab_results, 100);
+    assert_eq!(initial.breakdown.activity, 10);
+    assert_eq!(initial.breakdown.insurance, 100);
+    assert_eq!(initial.score, 77);
+
+    client.update_insurance_status(&owner, &pet_id, &String::from_str(&env, "POL-1"), &false);
+
+    let cached = client.get_health_score(&pet_id);
+    assert_eq!(cached.score, 77);
+    assert_eq!(cached.computed_at, initial.computed_at);
+
+    env.ledger().set_timestamp(initial.computed_at + 24 * 60 * 60 + 1);
+    let recomputed = client.get_health_score(&pet_id);
+    assert_eq!(recomputed.breakdown.insurance, 0);
+    assert_eq!(recomputed.score, 52);
+    assert!(recomputed.computed_at > initial.computed_at);
+}

--- a/stellar-contracts/src/test_multisig_transfer.rs
+++ b/stellar-contracts/src/test_multisig_transfer.rs
@@ -1,5 +1,5 @@
 use crate::{Gender, PetChainContract, PetChainContractClient, PrivacyLevel, Species};
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use soroban_sdk::{testutils::{Address as _, Events}, Address, Env, String, Vec};
 
 fn setup_test_env<'a>(
     env: &'a Env,
@@ -500,6 +500,89 @@ fn test_ownership_history_pagination() {
 
     let history_empty = client.get_ownership_history(&pet_id, &5u64, &1u32);
     assert_eq!(history_empty.len(), 0);
+}
+
+#[test]
+fn test_batch_transfer_moves_all_pets_and_emits_one_event_per_pet() {
+    let env = Env::default();
+    let (client, owner, _, _, new_owner) = setup_test_env(&env);
+    let pet_id1 = register_test_pet(&client, &env, &owner);
+    let pet_id2 = client.register_pet(
+        &owner,
+        &String::from_str(&env, "TestPet2"),
+        &String::from_str(&env, "2021-01-01"),
+        &Gender::Female,
+        &Species::Cat,
+        &String::from_str(&env, "Tabby"),
+        &String::from_str(&env, "White"),
+        &11,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let before_events = env.events().all().len();
+    let mut pet_ids = Vec::new(&env);
+    pet_ids.push_back(pet_id1);
+    pet_ids.push_back(pet_id2);
+
+    client.batch_transfer(&pet_ids, &new_owner);
+
+    assert_eq!(client.get_pet_owner(&pet_id1).unwrap(), new_owner);
+    assert_eq!(client.get_pet_owner(&pet_id2).unwrap(), new_owner);
+    assert_eq!(env.events().all().len(), before_events + 2);
+}
+
+#[test]
+fn test_batch_transfer_rejects_owner_mismatch_atomically() {
+    let env = Env::default();
+    let (client, owner, _, _, new_owner) = setup_test_env(&env);
+    let other_owner = Address::generate(&env);
+    let pet_id1 = register_test_pet(&client, &env, &owner);
+    let pet_id2 = client.register_pet(
+        &other_owner,
+        &String::from_str(&env, "Rover"),
+        &String::from_str(&env, "2020-06-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(&env, "Mix"),
+        &String::from_str(&env, "Brown"),
+        &15,
+        &None,
+        &PrivacyLevel::Public,
+    );
+
+    let mut pet_ids = Vec::new(&env);
+    pet_ids.push_back(pet_id1);
+    pet_ids.push_back(pet_id2);
+
+    assert!(client.try_batch_transfer(&pet_ids, &new_owner).is_err());
+    assert_eq!(client.get_pet_owner(&pet_id1).unwrap(), owner);
+    assert_eq!(client.get_pet_owner(&pet_id2).unwrap(), other_owner);
+}
+
+#[test]
+fn test_batch_transfer_rejects_batches_over_limit() {
+    let env = Env::default();
+    let (client, owner, _, _, new_owner) = setup_test_env(&env);
+
+    let mut pet_ids = Vec::new(&env);
+    for _ in 0..21u64 {
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "BatchPet"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Breed"),
+            &String::from_str(&env, "Black"),
+            &20,
+            &None,
+            &PrivacyLevel::Public,
+        );
+        pet_ids.push_back(pet_id);
+    }
+
+    assert!(client.try_batch_transfer(&pet_ids, &new_owner).is_err());
 }
 
 #[test]

--- a/stellar-contracts/src/test_search_medical_records.rs
+++ b/stellar-contracts/src/test_search_medical_records.rs
@@ -127,8 +127,8 @@ fn test_rejects_too_many_tokens() {
 mod test_search_medical_records {
     extern crate std;
     use crate::{
-        Gender, MedicalRecordFilter, PetChainContract, PetChainContractClient, PrivacyLevel,
-        Species,
+        Gender, MedicalRecordAmendmentInput, MedicalRecordFilter, PetChainContract,
+        PetChainContractClient, PrivacyLevel, Species,
     };
     use soroban_sdk::{
         testutils::{Address as _, Ledger},
@@ -373,25 +373,31 @@ mod test_search_medical_records {
         let record_id = add_record(&client, &env, pet_id, &vet, "Flu");
         let initial_record = client.get_medical_record(&record_id).unwrap();
 
-        // Update the notes
-        let success = client.update_medical_record_notes(
+        let version = client.amend_medical_record(
+            &pet_id,
             &record_id,
-            &String::from_str(&env, "Updated notes with new information"),
+            &MedicalRecordAmendmentInput {
+                diagnosis: None,
+                treatment: None,
+                medications: None,
+                notes: Some(String::from_str(&env, "Updated notes with new information")),
+            },
         );
-        assert!(success);
+        assert_eq!(version, 1);
 
-        // Verify notes were updated
-        let updated_record = client.get_medical_record(&record_id).unwrap();
+        // The original record remains unchanged.
+        let stored_record = client.get_medical_record(&record_id).unwrap();
+        assert_eq!(stored_record.notes, initial_record.notes);
+        assert_eq!(stored_record.updated_at, initial_record.updated_at);
+
+        let diff = client.diff_record_versions(&pet_id, &record_id, &0u32, &1u32);
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff.get(0).unwrap().field, String::from_str(&env, "notes"));
+        assert_eq!(diff.get(0).unwrap().from_value, initial_record.notes);
         assert_eq!(
-            updated_record.notes,
+            diff.get(0).unwrap().to_value,
             String::from_str(&env, "Updated notes with new information")
         );
-
-        // Verify the date field (creation time) was NOT changed
-        assert_eq!(updated_record.date, initial_record.date);
-
-        // Verify updated_at timestamp was changed
-        assert!(updated_record.updated_at >= initial_record.updated_at);
     }
 
     #[test]
@@ -468,6 +474,62 @@ mod test_search_medical_records {
             &String::from_str(&env, "Notes for non-existent record"),
         );
         assert!(!success);
+    }
+
+    #[test]
+    fn test_medical_record_amendment_limit_enforced() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+
+        let record_id = add_record(&client, &env, pet_id, &vet, "Flu");
+        for i in 0..5u32 {
+            let note = String::from_str(&env, "amend");
+            let _ = client.amend_medical_record(
+                &pet_id,
+                &record_id,
+                &MedicalRecordAmendmentInput {
+                    diagnosis: None,
+                    treatment: None,
+                    medications: None,
+                    notes: Some(note.clone()),
+                },
+            );
+            env.ledger().set_timestamp(env.ledger().timestamp() + i as u64 + 1);
+        }
+
+        let result = client.try_amend_medical_record(
+            &pet_id,
+            &record_id,
+            &MedicalRecordAmendmentInput {
+                diagnosis: Some(String::from_str(&env, "Changed")),
+                treatment: None,
+                medications: None,
+                notes: None,
+            },
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_diff_record_versions_reports_field_changes() {
+        let (env, client, _admin, _owner, vet, pet_id) = setup();
+
+        let record_id = add_record(&client, &env, pet_id, &vet, "Flu");
+        client.amend_medical_record(
+            &pet_id,
+            &record_id,
+            &MedicalRecordAmendmentInput {
+                diagnosis: Some(String::from_str(&env, "Cold")),
+                treatment: Some(String::from_str(&env, "Rest")),
+                medications: None,
+                notes: Some(String::from_str(&env, "Recovering well")),
+            },
+        );
+
+        let diff = client.diff_record_versions(&pet_id, &record_id, &0u32, &1u32);
+        assert_eq!(diff.len(), 3);
+        assert_eq!(diff.get(0).unwrap().field, String::from_str(&env, "diagnosis"));
+        assert_eq!(diff.get(1).unwrap().field, String::from_str(&env, "treatment"));
+        assert_eq!(diff.get(2).unwrap().field, String::from_str(&env, "notes"));
     }
 
     #[test]


### PR DESCRIPTION
closes #700 
closes #702 
closes #703 
closes #708



The contract now supports batch pet transfers for rescue-style rescues and similar bulk moves. A new batch_transfer path moves up to 20 pets atomically, rejects the entire batch if the caller does not own every pet, and emits one transfer event per pet. I added coverage for the success path, owner-mismatch rollback, and the batch-size limit.

Adoption now supports a three-party approval flow when an organization is involved. Adoption records can carry an optional organization, and when that field is present the flow requires approval from the owner, adopter, and organization admin. Any valid participant can reject the adoption, which cancels the pending flow and marks the record rejected. The original two-party adoption path still works unchanged when no organization is set.

I also added computed health scoring for pets. The new health score combines vaccination status, recent lab results, activity streak, and insurance coverage into a 0-100 score with a component breakdown. The score is cached for 24 hours and recomputed after the TTL expires. A dedicated test file covers the scoring logic and cache behavior.

Finally, medical records are now versioned instead of being overwritten in place. Amendments create new versions while preserving the original record, and a new diff function reports field-level changes between any two versions. The amendment system enforces a maximum of five amendments per record, and the medical-record tests were updated to verify immutability, diffs, and the amendment limit.