### PR TITLE
closes #689 closes #691 closes #699: test fixtures, OpenAPI spec, governance voting

### DIFF
--- a/.github/workflows/backend-2fa.yml
+++ b/.github/workflows/backend-2fa.yml
@@ -47,3 +47,20 @@ jobs:
       - name: Test
         run: cargo test -- --test-threads=1
         working-directory: backend-2fa
+
+  # #691 — Validate the OpenAPI spec on every PR so docs never drift from the
+  # implementation. Uses Spectral (the de-facto OAS linter) with the built-in
+  # oas ruleset which enforces OpenAPI 3.0 structural correctness.
+  validate-openapi-spec:
+    name: Validate OpenAPI 3.0 spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Spectral CLI
+        run: npm install -g @stoplight/spectral-cli
+      - name: Validate docs/openapi.yaml
+        run: spectral lint docs/openapi.yaml --ruleset @stoplight/spectral-oas --fail-severity warn

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,43 @@
 # API Overview
 
+## Backend 2FA — OpenAPI Specification
+
+The Backend 2FA service is fully documented as an **OpenAPI 3.0** spec.
+
+- **Machine-readable spec:** [`docs/openapi.yaml`](./openapi.yaml)
+- **Validation:** The spec is validated automatically on every PR via the
+  `backend-2fa.yml` CI workflow using `@stoplight/spectral-cli`.
+
+### Endpoints at a glance
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/2fa/enable` | Enable 2FA — returns secret and backup codes |
+| `POST` | `/2fa/disable` | Disable 2FA (requires current TOTP token) |
+| `POST` | `/2fa/verify` | Verify a TOTP token |
+| `POST` | `/2fa/login` | Complete login with 2FA |
+| `POST` | `/2fa/recover` | Recover access with a backup code |
+| `GET`  | `/2fa/recovery-log` | Paginated backup-code usage log |
+| `GET`  | `/2fa/audit-log/{user_id}` | Paginated 2FA audit log for a user |
+| `POST` | `/admin/quota` | Set per-user storage quota (admin) |
+| `POST` | `/admin/quota/unlimited` | Grant unlimited quota (admin) |
+| `POST` | `/admin/canary` | Create a canary user (admin) |
+| `GET`  | `/admin/flagged` | List all flagged submissions (admin) |
+| `GET`  | `/admin/flagged/{user_id}` | Flagged submissions for a user (admin) |
+| `POST` | `/tenant/provision` | Provision a new tenant (admin) |
+| `GET`  | `/ws/leaderboard` | WebSocket leaderboard feed |
+| `GET`  | `/health` | Health check |
+
+### Authentication
+All write and sensitive read endpoints require a Bearer JWT (`Authorization: Bearer <token>`).
+
+### Error format
+```json
+{ "error": "INVALID_TOKEN", "message": "The provided TOTP token has expired" }
+```
+
+---
+
 ## View Functions (pure reads — no storage writes or event emissions)
 
 The following functions are guaranteed to have no side effects. They do not write to storage, emit events, or update access timestamps.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,785 @@
+openapi: 3.0.3
+info:
+  title: PetChain Backend 2FA API
+  version: "1.0.0"
+  description: |
+    OpenAPI 3.0 specification for the PetChain Backend 2FA service.
+
+    ## Authentication
+    All write endpoints require a Bearer JWT in the `Authorization` header.
+    Read / verification endpoints accept either Bearer JWT or an `X-User-Id`
+    header for service-to-service calls.
+
+    ## Error format
+    All error responses share the same envelope:
+    ```json
+    { "error": "<machine-readable code>", "message": "<human-readable detail>" }
+    ```
+
+    ## Rate limiting
+    Verification and login endpoints are rate-limited per `user_id`.  After 5
+    consecutive failures the account is locked for 15 minutes.
+
+servers:
+  - url: http://localhost:8080
+    description: Local development
+  - url: https://api.petchain.io
+    description: Production
+
+tags:
+  - name: 2FA Setup
+    description: Enable, configure, and disable two-factor authentication
+  - name: 2FA Verification
+    description: Verify TOTP tokens and log in with 2FA
+  - name: Recovery
+    description: Backup-code recovery and audit logs
+  - name: Admin
+    description: Admin-only quota, canary, and flagged-score operations
+  - name: Tenant
+    description: Multi-tenant provisioning
+  - name: Leaderboard
+    description: WebSocket leaderboard feed
+
+paths:
+  # ─── 2FA Setup ──────────────────────────────────────────────────────────────
+
+  /2fa/enable:
+    post:
+      tags: [2FA Setup]
+      summary: Enable 2FA for a user
+      description: |
+        Generates a TOTP secret, produces a QR-code URI, and stores the pending
+        setup. The user must call `/2fa/verify` to confirm possession before 2FA
+        is considered active.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnableTwoFactorRequest'
+      responses:
+        '200':
+          description: 2FA setup initiated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EnableTwoFactorResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: 2FA already enabled for this user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /2fa/disable:
+    post:
+      tags: [2FA Setup]
+      summary: Disable 2FA for a user
+      description: Disables 2FA and clears all stored secrets. Requires current TOTP token to confirm intent.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DisableTwoFactorRequest'
+      responses:
+        '200':
+          description: 2FA disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ─── 2FA Verification ────────────────────────────────────────────────────────
+
+  /2fa/verify:
+    post:
+      tags: [2FA Verification]
+      summary: Verify a TOTP token
+      description: |
+        Validates a 6-digit TOTP code. On first call after `/2fa/enable` this
+        activates 2FA. Subsequent calls act as a plain verification check.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyTwoFactorRequest'
+      responses:
+        '200':
+          description: Token valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: Invalid or expired TOTP token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '423':
+          description: Account locked due to too many failed attempts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /2fa/login:
+    post:
+      tags: [2FA Verification]
+      summary: Complete login with 2FA
+      description: |
+        Second factor in a two-step login flow. Accepts a TOTP token alongside
+        the user ID. Returns a session token on success.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginWithTwoFactorRequest'
+      responses:
+        '200':
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: Invalid TOTP token or 2FA not enabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '423':
+          description: Account locked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Recovery ────────────────────────────────────────────────────────────────
+
+  /2fa/recover:
+    post:
+      tags: [Recovery]
+      summary: Recover access with a backup code
+      description: |
+        Consumes one of the user's pre-generated backup codes and disables 2FA,
+        allowing the user to re-enrol with a new device.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecoverWithBackupRequest'
+      responses:
+        '200':
+          description: Recovery successful, 2FA disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecoverWithBackupResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: Invalid backup code
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /2fa/recovery-log:
+    get:
+      tags: [Recovery]
+      summary: List backup-code usage log (paginated)
+      description: Returns a paginated list of backup-code recovery events for audit purposes.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+      responses:
+        '200':
+          description: Recovery log entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecoveryLogPage'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /2fa/audit-log/{user_id}:
+    get:
+      tags: [Recovery]
+      summary: Get 2FA audit log for a user
+      description: Returns paginated 2FA audit events (enable, disable, verify, recover) for the given user.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/PageSizeParam'
+      responses:
+        '200':
+          description: Audit log entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLogPage'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  # ─── Admin ───────────────────────────────────────────────────────────────────
+
+  /admin/quota:
+    post:
+      tags: [Admin]
+      summary: Set per-user storage quota
+      description: Override the default storage quota for a specific user. Admin-only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetUserQuotaRequest'
+      responses:
+        '200':
+          description: Quota updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/quota/unlimited:
+    post:
+      tags: [Admin]
+      summary: Grant unlimited quota to a user
+      description: Removes the quota cap for a user. Admin-only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantUnlimitedRequest'
+      responses:
+        '200':
+          description: Unlimited quota granted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/canary:
+    post:
+      tags: [Admin]
+      summary: Create a canary user for anomaly detection
+      description: Marks a user as a canary so anomalous activity triggers alerts. Admin-only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCanaryRequest'
+      responses:
+        '200':
+          description: Canary user created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCanaryResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/flagged:
+    get:
+      tags: [Admin]
+      summary: List all flagged score submissions
+      description: Returns all submissions flagged for manual review. Admin-only.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Flagged submissions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FlaggedScoreSubmission'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /admin/flagged/{user_id}:
+    get:
+      tags: [Admin]
+      summary: List flagged score submissions for a user
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Flagged submissions for user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FlaggedScoreSubmission'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  # ─── Tenant ──────────────────────────────────────────────────────────────────
+
+  /tenant/provision:
+    post:
+      tags: [Tenant]
+      summary: Provision a new tenant
+      description: Creates a new tenant namespace with its own isolated 2FA store. Admin-only.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionTenantRequest'
+      responses:
+        '200':
+          description: Tenant provisioned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProvisionTenantResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Tenant already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  # ─── Leaderboard ─────────────────────────────────────────────────────────────
+
+  /ws/leaderboard:
+    get:
+      tags: [Leaderboard]
+      summary: WebSocket leaderboard feed
+      description: |
+        Upgrades the connection to WebSocket. The server streams leaderboard
+        update messages as JSON whenever the top-N rankings change.
+      responses:
+        '101':
+          description: Switching Protocols (WebSocket upgrade)
+        '400':
+          description: Not a WebSocket upgrade request
+
+  # ─── Health ──────────────────────────────────────────────────────────────────
+
+  /health:
+    get:
+      summary: Health check
+      description: Returns 200 if the service is healthy. No authentication required.
+      responses:
+        '200':
+          description: Service healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+
+# ─── Components ───────────────────────────────────────────────────────────────
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Supabase / PetChain JWT
+
+  parameters:
+    PageParam:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: Zero-based page index
+    PageSizeParam:
+      name: page_size
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+      description: Number of items per page
+
+  responses:
+    BadRequest:
+      description: Invalid request body or parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: Insufficient permissions (not an admin)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code
+          example: INVALID_TOKEN
+        message:
+          type: string
+          description: Human-readable error detail
+          example: The provided TOTP token has expired
+
+    SuccessResponse:
+      type: object
+      required: [success]
+      properties:
+        success:
+          type: boolean
+          example: true
+        message:
+          type: string
+          example: 2FA disabled
+
+    # ── 2FA Setup ──────────────────────────────────────────────────────────────
+
+    EnableTwoFactorRequest:
+      type: object
+      required: [user_id, email]
+      properties:
+        user_id:
+          type: string
+          description: Unique user identifier
+          example: user_abc123
+        email:
+          type: string
+          format: email
+          example: alice@petchain.io
+        issuer:
+          type: string
+          description: Issuer label shown in authenticator apps
+          default: PetChain
+          example: PetChain
+
+    EnableTwoFactorResponse:
+      type: object
+      required: [secret, qr_code_uri, backup_codes]
+      properties:
+        secret:
+          type: string
+          description: Base32-encoded TOTP secret (store securely)
+          example: JBSWY3DPEHPK3PXP
+        qr_code_uri:
+          type: string
+          description: otpauth:// URI for QR code generation
+          example: "otpauth://totp/PetChain:alice@petchain.io?secret=JBSWY3DP&issuer=PetChain"
+        backup_codes:
+          type: array
+          description: One-time backup codes for account recovery
+          items:
+            type: string
+          example: ["A1B2-C3D4", "E5F6-G7H8"]
+
+    DisableTwoFactorRequest:
+      type: object
+      required: [user_id, token]
+      properties:
+        user_id:
+          type: string
+          example: user_abc123
+        token:
+          type: string
+          description: Current TOTP code to confirm the user's intent
+          example: "123456"
+
+    VerifyTwoFactorRequest:
+      type: object
+      required: [user_id, token]
+      properties:
+        user_id:
+          type: string
+          example: user_abc123
+        token:
+          type: string
+          minLength: 6
+          maxLength: 6
+          example: "654321"
+
+    LoginWithTwoFactorRequest:
+      type: object
+      required: [user_id, token]
+      properties:
+        user_id:
+          type: string
+          example: user_abc123
+        token:
+          type: string
+          minLength: 6
+          maxLength: 6
+          example: "111222"
+
+    LoginResponse:
+      type: object
+      required: [session_token]
+      properties:
+        session_token:
+          type: string
+          description: Short-lived session token for subsequent requests
+          example: eyJhbGciOiJIUzI1NiJ9...
+
+    # ── Recovery ───────────────────────────────────────────────────────────────
+
+    RecoverWithBackupRequest:
+      type: object
+      required: [user_id, backup_code]
+      properties:
+        user_id:
+          type: string
+          example: user_abc123
+        backup_code:
+          type: string
+          example: A1B2-C3D4
+
+    RecoverWithBackupResponse:
+      type: object
+      required: [success, remaining_codes]
+      properties:
+        success:
+          type: boolean
+        remaining_codes:
+          type: integer
+          description: Number of backup codes still available
+          example: 7
+
+    RecoveryLogPage:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecoveryLogEntry'
+        total:
+          type: integer
+        page:
+          type: integer
+        page_size:
+          type: integer
+
+    RecoveryLogEntry:
+      type: object
+      properties:
+        user_id:
+          type: string
+        used_at:
+          type: string
+          format: date-time
+        code_index:
+          type: integer
+          description: Index of the backup code that was consumed
+
+    AuditLogPage:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLogEntry'
+        total:
+          type: integer
+        page:
+          type: integer
+
+    AuditLogEntry:
+      type: object
+      properties:
+        event:
+          type: string
+          enum: [enabled, disabled, verified, recovered, login]
+        timestamp:
+          type: string
+          format: date-time
+        ip_address:
+          type: string
+          nullable: true
+        user_agent:
+          type: string
+          nullable: true
+
+    # ── Admin ──────────────────────────────────────────────────────────────────
+
+    SetUserQuotaRequest:
+      type: object
+      required: [user_id, quota]
+      properties:
+        user_id:
+          type: string
+          example: user_abc123
+        quota:
+          type: integer
+          description: Maximum number of storage entries
+          minimum: 1
+          example: 5000
+
+    GrantUnlimitedRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id:
+          type: string
+          example: user_abc123
+
+    CreateCanaryRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id:
+          type: string
+          example: canary_sentinel_01
+
+    CreateCanaryResponse:
+      type: object
+      required: [user_id, is_canary]
+      properties:
+        user_id:
+          type: string
+        is_canary:
+          type: boolean
+          example: true
+
+    FlaggedScoreSubmission:
+      type: object
+      properties:
+        user_id:
+          type: string
+        submitted_at:
+          type: string
+          format: date-time
+        score:
+          type: number
+        reason:
+          type: string
+          description: Why this submission was flagged
+
+    # ── Tenant ─────────────────────────────────────────────────────────────────
+
+    ProvisionTenantRequest:
+      type: object
+      required: [tenant_id, issuer]
+      properties:
+        tenant_id:
+          type: string
+          example: acme-corp
+        issuer:
+          type: string
+          description: TOTP issuer label shown in authenticator apps
+          example: ACME Corp
+        max_users:
+          type: integer
+          nullable: true
+          description: Optional user cap for this tenant
+          example: 500
+
+    ProvisionTenantResponse:
+      type: object
+      required: [tenant_id, provisioned_at]
+      properties:
+        tenant_id:
+          type: string
+        provisioned_at:
+          type: string
+          format: date-time

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -199,6 +199,10 @@ mod test_custody_chain;
 #[cfg(test)]
 mod test_upgrade_proposal;
 #[cfg(test)]
+mod test_governance_voting;
+#[cfg(test)]
+mod test_fixtures;
+#[cfg(test)]
 mod test_vaccination_expiry;
 #[cfg(test)]
 mod test_medical_record_soft_delete;
@@ -1219,6 +1223,8 @@ pub enum SystemKey {
     LabThreshold,
     // Chain-of-custody log (Issue #637)
     CustodyChain(u64), // pet_id -> Vec<CustodyEntry>
+    // #699: governance-controlled parameters
+    HealthScoreCacheTtl, // TTL (seconds) for health-score cache entries
 }
 
 #[contracttype]
@@ -1813,6 +1819,21 @@ pub enum ProposalState {
     Vetoed,            // Vetoed during timelock
 }
 
+/// Identifies a contract parameter that can be changed via governance vote.
+///
+/// Adding new variants here is the only change needed to expose a new
+/// on-chain parameter to the governance system.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ParamKey {
+    /// Global storage quota (max entries per pet). Stored as `u64`.
+    GlobalStorageQuota,
+    /// Cache TTL in seconds for computed health scores. Stored as `u64`.
+    HealthScoreCacheTtl,
+    /// Multisig approval threshold. Stored as `u32` (cast to u64 in proposal).
+    AdminThreshold,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposalAction {
@@ -1820,6 +1841,10 @@ pub enum ProposalAction {
     VerifyVet(Address),
     RevokeVet(Address),
     ChangeAdmin((Vec<Address>, u32)),
+    /// Governance vote to change a named contract parameter.
+    /// `(key, new_value_as_u64)` — the value is cast to the parameter's
+    /// native type at execution time.
+    ParameterChange((ParamKey, u64)),
 }
 
 #[contracttype]
@@ -12274,6 +12299,50 @@ impl PetChainContract {
                     .set(&SystemKey::AdminThreshold, &threshold);
                 // Also clean up legacy admin if needed
                 env.storage().instance().remove(&DataKey::Admin);
+            }
+            // #699 — Governance voting for parameter changes.
+            // The parameter is updated atomically when the proposal executes,
+            // ensuring no partial state is ever observed.
+            ProposalAction::ParameterChange(params) => {
+                let (key, new_value) = params;
+                match key {
+                    ParamKey::GlobalStorageQuota => {
+                        env.storage()
+                            .persistent()
+                            .set(&DataKey::GlobalStorageQuota, &new_value);
+                        env.events().publish(
+                            (Symbol::new(&env, "ParamChanged"),),
+                            (Symbol::new(&env, "GlobalStorageQuota"), new_value),
+                        );
+                    }
+                    ParamKey::HealthScoreCacheTtl => {
+                        env.storage()
+                            .instance()
+                            .set(&SystemKey::HealthScoreCacheTtl, &new_value);
+                        env.events().publish(
+                            (Symbol::new(&env, "ParamChanged"),),
+                            (Symbol::new(&env, "HealthScoreCacheTtl"), new_value),
+                        );
+                    }
+                    ParamKey::AdminThreshold => {
+                        let threshold = new_value as u32;
+                        let admins: Vec<Address> = env
+                            .storage()
+                            .instance()
+                            .get(&SystemKey::Admins)
+                            .unwrap_or(Vec::new(&env));
+                        if threshold == 0 || threshold > admins.len() {
+                            panic_with_error!(&env, ContractError::InvalidThreshold);
+                        }
+                        env.storage()
+                            .instance()
+                            .set(&SystemKey::AdminThreshold, &threshold);
+                        env.events().publish(
+                            (Symbol::new(&env, "ParamChanged"),),
+                            (Symbol::new(&env, "AdminThreshold"), new_value),
+                        );
+                    }
+                }
             }
         }
 

--- a/stellar-contracts/src/test_fixtures.rs
+++ b/stellar-contracts/src/test_fixtures.rs
@@ -1,0 +1,280 @@
+//! # Shared Deterministic Test Fixtures — Issue #689
+//!
+//! Builder functions for creating test contracts, pets, vets, and admins with
+//! deterministic, reproducible addresses and IDs. All test modules should use
+//! these helpers instead of duplicating setup code.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use crate::test_fixtures::{TestEnv, create_test_pet, create_test_vet, create_test_admin};
+//!
+//! let te = TestEnv::new();
+//! let pet_id = create_test_pet(&te.env, &te.client, &te.owner);
+//! let vet    = create_test_vet(&te.env, &te.client);
+//! ```
+//!
+//! ## Determinism guarantee
+//!
+//! `TestEnv::new()` seeds the environment with a fixed timestamp (1_700_000_000)
+//! and sequence number (1_000) so that ledger-timestamp-dependent calculations
+//! (age, expiry, TTL) produce the same result across every test run.
+
+use crate::{Gender, PetChainContract, PetChainContractClient, PrivacyLevel, Species};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env, String, Vec,
+};
+
+// ─── Fixed seed values ────────────────────────────────────────────────────────
+
+/// Baseline ledger timestamp used by all fixtures.
+/// Corresponds to 2023-11-14 22:13:20 UTC — a stable reference point.
+pub const BASE_TIMESTAMP: u64 = 1_700_000_000;
+
+/// Fixed protocol version used in test ledger state.
+pub const PROTOCOL_VERSION: u32 = 22;
+
+/// Fixed sequence number for all test environments.
+pub const BASE_SEQUENCE: u32 = 1_000;
+
+// ─── TestEnv ──────────────────────────────────────────────────────────────────
+
+/// A fully initialised PetChain test environment with a two-of-two multisig
+/// admin and a pre-registered owner address.
+///
+/// Create with [`TestEnv::new()`]. Fields are public so individual tests can
+/// reach in without extra boilerplate.
+pub struct TestEnv<'a> {
+    pub env: Env,
+    pub client: PetChainContractClient<'a>,
+    /// First multisig admin (also used as the default proposer in governance tests).
+    pub admin1: Address,
+    /// Second multisig admin (provides the second approval to reach quorum).
+    pub admin2: Address,
+    /// Pre-registered pet owner.
+    pub owner: Address,
+}
+
+impl<'a> TestEnv<'a> {
+    /// Create a deterministic test environment with a two-of-two multisig and
+    /// a pre-registered owner. The ledger timestamp is set to `BASE_TIMESTAMP`.
+    pub fn new() -> TestEnv<'a> {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        // Seed ledger with a fixed timestamp so tests are reproducible.
+        env.ledger().set(LedgerInfo {
+            timestamp: BASE_TIMESTAMP,
+            protocol_version: PROTOCOL_VERSION,
+            sequence_number: BASE_SEQUENCE,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 100,
+            min_persistent_entry_ttl: 100,
+            max_entry_ttl: 9_999_999,
+        });
+
+        let contract_id = env.register(PetChainContract, ());
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        let mut admins = Vec::new(&env);
+        admins.push_back(admin1.clone());
+        admins.push_back(admin2.clone());
+        client.init_multisig(&admin1, &admins, &2);
+
+        let owner = Address::generate(&env);
+
+        TestEnv { env, client, admin1, admin2, owner }
+    }
+
+    /// Advance the ledger timestamp by `secs` seconds.
+    pub fn advance_time(&self, secs: u64) {
+        let current = self.env.ledger().timestamp();
+        self.env.ledger().set(LedgerInfo {
+            timestamp: current + secs,
+            protocol_version: PROTOCOL_VERSION,
+            sequence_number: self.env.ledger().sequence() + 1,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 100,
+            min_persistent_entry_ttl: 100,
+            max_entry_ttl: 9_999_999,
+        });
+    }
+}
+
+// ─── Builder: pet ─────────────────────────────────────────────────────────────
+
+/// Create and register a test pet owned by `owner`.
+///
+/// Returns the new pet's on-chain ID (starts at 1, increments per call).
+///
+/// # Defaults
+/// | Field    | Value                |
+/// |----------|----------------------|
+/// | name     | "TestPet"            |
+/// | birthday | "2020-01-01"         |
+/// | gender   | Male                 |
+/// | species  | Dog                  |
+/// | breed    | "Labrador"           |
+/// | color    | "Yellow"             |
+/// | weight   | 25                   |
+/// | privacy  | Public               |
+pub fn create_test_pet(
+    env: &Env,
+    client: &PetChainContractClient,
+    owner: &Address,
+) -> u64 {
+    client.register_pet(
+        owner,
+        &String::from_str(env, "TestPet"),
+        &String::from_str(env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(env, "Labrador"),
+        &String::from_str(env, "Yellow"),
+        &25u32,
+        &None,
+        &PrivacyLevel::Public,
+    )
+}
+
+/// Create a test pet with a custom name (all other fields use the same
+/// defaults as [`create_test_pet`]).
+pub fn create_named_pet(
+    env: &Env,
+    client: &PetChainContractClient,
+    owner: &Address,
+    name: &str,
+) -> u64 {
+    client.register_pet(
+        owner,
+        &String::from_str(env, name),
+        &String::from_str(env, "2020-01-01"),
+        &Gender::Male,
+        &Species::Dog,
+        &String::from_str(env, "Labrador"),
+        &String::from_str(env, "Yellow"),
+        &25u32,
+        &None,
+        &PrivacyLevel::Public,
+    )
+}
+
+// ─── Builder: vet ─────────────────────────────────────────────────────────────
+
+/// Create and register a test vet with a deterministic licence number.
+///
+/// Returns the vet's address.
+///
+/// # Defaults
+/// | Field          | Value              |
+/// |----------------|--------------------|
+/// | name           | "Dr. TestVet"      |
+/// | license_number | "VET-TEST-001"     |
+/// | specialization | "General Practice" |
+pub fn create_test_vet(env: &Env, client: &PetChainContractClient) -> Address {
+    let vet_address = Address::generate(env);
+    client.register_vet(
+        &vet_address,
+        &String::from_str(env, "Dr. TestVet"),
+        &String::from_str(env, "VET-TEST-001"),
+        &String::from_str(env, "General Practice"),
+    );
+    vet_address
+}
+
+/// Create and register a test vet with a custom licence number to avoid
+/// collisions when multiple vets are needed in one test.
+pub fn create_vet_with_license(
+    env: &Env,
+    client: &PetChainContractClient,
+    license: &str,
+) -> Address {
+    let vet_address = Address::generate(env);
+    client.register_vet(
+        &vet_address,
+        &String::from_str(env, "Dr. TestVet"),
+        &String::from_str(env, license),
+        &String::from_str(env, "General Practice"),
+    );
+    vet_address
+}
+
+// ─── Builder: admin setup ─────────────────────────────────────────────────────
+
+/// Return a `(admin1, admin2, client)` triple backed by a fresh multisig
+/// environment, mirroring the legacy `setup()` pattern used in several test
+/// files. Prefer `TestEnv::new()` for new tests.
+pub fn create_test_admin(env: &Env) -> (Address, Address, PetChainContractClient) {
+    env.mock_all_auths();
+    let contract_id = env.register(PetChainContract, ());
+    let client = PetChainContractClient::new(env, &contract_id);
+
+    let admin1 = Address::generate(env);
+    let admin2 = Address::generate(env);
+    let mut admins = Vec::new(env);
+    admins.push_back(admin1.clone());
+    admins.push_back(admin2.clone());
+    client.init_multisig(&admin1, &admins, &2);
+
+    (admin1, admin2, client)
+}
+
+// ─── Self-tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn fixture_test_env_initialises_correctly() {
+    let te = TestEnv::new();
+    // Ledger timestamp should match BASE_TIMESTAMP
+    assert_eq!(te.env.ledger().timestamp(), BASE_TIMESTAMP);
+    // Two admins should be registered
+    let admins = te.client.get_admins();
+    assert_eq!(admins.len(), 2);
+}
+
+#[test]
+fn fixture_create_test_pet_returns_incrementing_ids() {
+    let te = TestEnv::new();
+    let id1 = create_test_pet(&te.env, &te.client, &te.owner);
+    let id2 = create_test_pet(&te.env, &te.client, &te.owner);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn fixture_create_test_vet_is_registered() {
+    let te = TestEnv::new();
+    let vet = create_test_vet(&te.env, &te.client);
+    assert!(te.client.is_vet_registered(&vet));
+}
+
+#[test]
+fn fixture_advance_time_updates_ledger() {
+    let te = TestEnv::new();
+    te.advance_time(3_600);
+    assert_eq!(te.env.ledger().timestamp(), BASE_TIMESTAMP + 3_600);
+}
+
+#[test]
+fn fixture_create_admin_returns_two_admins() {
+    let env = Env::default();
+    let (admin1, admin2, client) = create_test_admin(&env);
+    let admins = client.get_admins();
+    assert!(admins.contains(&admin1));
+    assert!(admins.contains(&admin2));
+}
+
+#[test]
+fn fixture_create_vet_with_license_avoids_collision() {
+    let te = TestEnv::new();
+    let v1 = create_vet_with_license(&te.env, &te.client, "VET-A");
+    let v2 = create_vet_with_license(&te.env, &te.client, "VET-B");
+    assert_ne!(v1, v2);
+    assert!(te.client.is_vet_registered(&v1));
+    assert!(te.client.is_vet_registered(&v2));
+}

--- a/stellar-contracts/src/test_governance_voting.rs
+++ b/stellar-contracts/src/test_governance_voting.rs
@@ -1,0 +1,234 @@
+//! # Governance Voting for Parameter Changes — Issue #699
+//!
+//! Tests for the `ParameterChange` proposal action:
+//! - Vote passes only after quorum
+//! - Expired vote is rejected
+//! - Parameter is updated atomically on vote passage
+//! - Governance workflow uses the shared `TestEnv` fixture
+
+use crate::{
+    test_fixtures::{TestEnv, BASE_TIMESTAMP},
+    ParamKey, ProposalAction, ProposalState,
+};
+use soroban_sdk::{testutils::Ledger, Env};
+
+// ─── Helper: propose + approve + execute a parameter change ──────────────────
+
+/// Propose a `ParameterChange` as admin1, approve with admin2 (reaching quorum),
+/// advance past the timelock, then execute. Returns the proposal ID.
+fn propose_param_and_execute(te: &TestEnv, key: ParamKey, value: u64) -> u64 {
+    let action = ProposalAction::ParameterChange((key, value));
+    // 72-hour voting window as required by the issue
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+
+    // Advance past the default 24-hour timelock
+    let proposal = te.client.get_proposal(&proposal_id).unwrap();
+    te.advance_time(proposal.timelock_end - BASE_TIMESTAMP + 1);
+
+    te.client.execute_proposal(&proposal_id);
+    proposal_id
+}
+
+// ─── Vote passes only after quorum ───────────────────────────────────────────
+
+#[test]
+fn param_change_cannot_execute_without_quorum() {
+    let te = TestEnv::new();
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 2000));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+
+    // Only admin1 has approved (count = 1, required = 2) — must not execute
+    let result = te.client.try_execute_proposal(&proposal_id);
+    assert!(result.is_err(), "must fail when quorum not reached");
+}
+
+#[test]
+fn param_change_executes_after_quorum_and_timelock() {
+    let te = TestEnv::new();
+    let proposal_id = propose_param_and_execute(&te, ParamKey::GlobalStorageQuota, 2000);
+
+    let proposal = te.client.get_proposal(&proposal_id).unwrap();
+    assert!(proposal.executed);
+    assert_eq!(proposal.state, ProposalState::Executed);
+}
+
+#[test]
+fn param_change_proposal_enters_timelock_pending_after_quorum() {
+    let te = TestEnv::new();
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 1500));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+
+    // Before second approval: Pending
+    let p = te.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(p.state, ProposalState::Pending);
+
+    // After second approval: TimelockPending (quorum reached)
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+    let p = te.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(p.state, ProposalState::TimelockPending);
+}
+
+// ─── Parameter updated atomically ────────────────────────────────────────────
+
+#[test]
+fn global_storage_quota_updated_atomically_on_execution() {
+    let te = TestEnv::new();
+    // Verify that the parameter is only changed after execute, not before.
+    let initial_quota = te.client.get_global_storage_quota();
+
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 9999));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+
+    // After approval (in timelock) the quota must NOT have changed yet.
+    let after_approval = te.client.get_global_storage_quota();
+    assert_eq!(initial_quota, after_approval, "quota must not change before execution");
+
+    // Advance past timelock and execute
+    let p = te.client.get_proposal(&proposal_id).unwrap();
+    te.advance_time(p.timelock_end - BASE_TIMESTAMP + 1);
+    te.client.execute_proposal(&proposal_id);
+
+    // Now the quota must reflect the new value.
+    let final_quota = te.client.get_global_storage_quota();
+    assert_eq!(final_quota, 9999, "quota must be updated after execution");
+}
+
+#[test]
+fn admin_threshold_updated_via_governance() {
+    // Build an env with 3 admins so we can lower the threshold to 2 via governance.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let contract_id = env.register(crate::PetChainContract, ());
+    let client = crate::PetChainContractClient::new(&env, &contract_id);
+
+    let admin1 = soroban_sdk::Address::generate(&env);
+    let admin2 = soroban_sdk::Address::generate(&env);
+    let admin3 = soroban_sdk::Address::generate(&env);
+    let mut admins = soroban_sdk::Vec::new(&env);
+    admins.push_back(admin1.clone());
+    admins.push_back(admin2.clone());
+    admins.push_back(admin3.clone());
+    client.init_multisig(&admin1, &admins, &3); // threshold = 3
+
+    let action = ProposalAction::ParameterChange((ParamKey::AdminThreshold, 2));
+    let proposal_id = client.propose_action(&admin1, &action, &(72 * 3_600));
+    client.approve_proposal(&admin2, &proposal_id);
+    client.approve_proposal(&admin3, &proposal_id); // third approval reaches quorum
+
+    // Advance past default 24-hour timelock
+    let p = client.get_proposal(&proposal_id).unwrap();
+    env.ledger().with_mut(|l| l.timestamp = p.timelock_end + 1);
+    client.execute_proposal(&proposal_id);
+
+    assert_eq!(client.get_admin_threshold(), 2);
+}
+
+// ─── Expired vote rejected ────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn param_change_approve_after_expiry_panics() {
+    let te = TestEnv::new();
+    // 72-hour voting window
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 500));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+
+    // Advance past the voting window
+    te.advance_time(72 * 3_600 + 1);
+
+    // admin2 tries to approve an expired vote — must panic
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn param_change_execute_after_expiry_panics() {
+    let te = TestEnv::new();
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 500));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+
+    // Advance past the voting window (note: timelock + expiry window overlap)
+    te.advance_time(72 * 3_600 + 1);
+
+    te.client.execute_proposal(&proposal_id);
+}
+
+// ─── Cannot execute before timelock elapses ──────────────────────────────────
+
+#[test]
+#[should_panic]
+fn param_change_execute_before_timelock_panics() {
+    let te = TestEnv::new();
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 1234));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+
+    // Quorum reached but timelock has NOT elapsed — must panic
+    te.client.execute_proposal(&proposal_id);
+}
+
+// ─── Non-admin cannot propose ────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn non_admin_cannot_propose_param_change() {
+    let te = TestEnv::new();
+    let outsider = soroban_sdk::Address::generate(&te.env);
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 100));
+    te.client.propose_action(&outsider, &action, &(72 * 3_600));
+}
+
+// ─── Duplicate approval rejected ─────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn duplicate_approval_on_param_change_panics() {
+    let te = TestEnv::new();
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 800));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+    // admin2 approves a second time — must panic
+    te.client.approve_proposal(&te.admin2, &proposal_id);
+}
+
+// ─── Cannot execute twice ────────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn param_change_cannot_execute_twice() {
+    let te = TestEnv::new();
+    let proposal_id = propose_param_and_execute(&te, ParamKey::GlobalStorageQuota, 500);
+    // Second execution must panic
+    te.client.execute_proposal(&proposal_id);
+}
+
+// ─── HealthScoreCacheTtl parameter ───────────────────────────────────────────
+
+#[test]
+fn health_score_cache_ttl_updated_via_governance() {
+    let te = TestEnv::new();
+    propose_param_and_execute(&te, ParamKey::HealthScoreCacheTtl, 7_200); // 2 hours
+    // No panic == success; the key is stored in instance storage.
+    // If the contract panics on an unknown key the test would fail here.
+}
+
+// ─── 72-hour voting window enforced ─────────────────────────────────────────
+
+#[test]
+fn param_change_window_is_72_hours() {
+    let te = TestEnv::new();
+    let action = ProposalAction::ParameterChange((ParamKey::GlobalStorageQuota, 300));
+    let proposal_id = te.client.propose_action(&te.admin1, &action, &(72 * 3_600));
+
+    let p = te.client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(
+        p.expires_at,
+        BASE_TIMESTAMP + 72 * 3_600,
+        "voting window must be 72 hours"
+    );
+}


### PR DESCRIPTION
closes #689
closes #691
closes #699

## Summary

### closes #699 — Soroban Contract Governance Voting for Parameter Changes
Adds `ParamKey` enum (`GlobalStorageQuota`, `HealthScoreCacheTtl`, `AdminThreshold`) and `ParameterChange((ParamKey, u64))` variant to `ProposalAction`. The `execute_proposal` match arm applies the parameter atomically after quorum is reached and the timelock elapses. Each execution emits a `ParamChanged` event. New `SystemKey::HealthScoreCacheTtl` storage key added. Tests in `test_governance_voting.rs` cover: quorum enforcement, 72-hour voting window, atomic update (value unchanged before execution), timelock rejection, expired-vote rejection, non-admin cannot propose, duplicate approval panic, double-execute panic, AdminThreshold update via governance.

### closes #691 — Backend 2FA OpenAPI Specification
Adds `docs/openapi.yaml` — a full OpenAPI 3.0 spec covering all 14 Backend 2FA endpoints with request/response schemas, authentication requirements, error envelopes, and pagination parameters. Updates `docs/api.md` with a link to the spec, an endpoint summary table, and auth/error documentation. Adds `validate-openapi-spec` job to `.github/workflows/backend-2fa.yml` using `@stoplight/spectral-cli` with the built-in OAS ruleset to validate the spec on every PR.

### closes #689 — Soroban Contract Deterministic Test Fixtures
Adds `stellar-contracts/src/test_fixtures.rs` with `TestEnv` struct (fixed `BASE_TIMESTAMP = 1_700_000_000`, two-of-two multisig, pre-registered owner, `advance_time()` helper), `create_test_pet()`, `create_named_pet()`, `create_test_vet()`, `create_vet_with_license()`, and `create_test_admin()`. Fixtures use deterministic addresses and IDs for reproducibility. Module is documented and includes self-tests.

## Test plan
- [ ] `cargo test -p petchain-stellar-contracts -- test_governance` — governance voting tests
- [ ] `cargo test -p petchain-stellar-contracts -- test_fixtures` — fixture self-tests
- [ ] `spectral lint docs/openapi.yaml --ruleset @stoplight/spectral-oas` — spec validates
- [ ] CI `validate-openapi-spec` job passes on PR