### PR TITLE
closes #656: insurance policy renewal automation with grace period

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -1125,6 +1125,8 @@ pub enum EventType {
     InsuranceClaimSubmitted,
     PetProfileUpdated,
     GroomingRecordCreated,
+    PolicyExpiringSoon,
+    PolicyRenewed,
 }
 
 #[contracttype]
@@ -2100,6 +2102,28 @@ pub struct InsuranceClaimFlaggedEvent {
     pub claim_id: u64,
     pub pet_id: u64,
     pub fraud_flags: u32,
+    pub timestamp: u64,
+}
+
+/// Emitted 30 days before a policy expires.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyExpiringSoonEvent {
+    pub version: u32,
+    pub pet_id: u64,
+    pub policy_id: String,
+    pub expiry_date: u64,
+    pub timestamp: u64,
+}
+
+/// Emitted when a policy is renewed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PolicyRenewedEvent {
+    pub version: u32,
+    pub pet_id: u64,
+    pub policy_id: String,
+    pub new_expiry_date: u64,
     pub timestamp: u64,
 }
 
@@ -13709,13 +13733,19 @@ impl PetChainContract {
             return None;
         }
 
+        const GRACE_PERIOD_SECS: u64 = 7 * 24 * 60 * 60; // 7 days
+        let timestamp = env.ledger().timestamp();
+        if timestamp > policy.expiry_date + GRACE_PERIOD_SECS {
+            // Lapsed — past grace period
+            return None;
+        }
+
         let claim_count: u64 = env
             .storage()
             .instance()
             .get(&InsuranceKey::ClaimCount)
             .unwrap_or(0);
         let claim_id = safe_increment(claim_count);
-        let timestamp = env.ledger().timestamp();
 
         let claim = InsuranceClaim {
             claim_id,
@@ -13986,6 +14016,98 @@ impl PetChainContract {
             .instance()
             .get(&InsuranceKey::PetClaimCount(pet_id))
             .unwrap_or(0)
+    }
+
+    /// Renews an insurance policy with a new expiry date.
+    /// Callable by the pet owner. Resets the policy to active.
+    pub fn renew_policy(env: Env, pet_id: u64, policy_id: String, new_end_date: u64) -> bool {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&InsuranceKey::PetPolicyCount(pet_id))
+            .unwrap_or(0);
+        if count == 0 {
+            return false;
+        }
+        let mut policy = match env
+            .storage()
+            .instance()
+            .get::<InsuranceKey, InsurancePolicy>(&InsuranceKey::PetPolicyIndex((pet_id, count)))
+        {
+            Some(p) if p.policy_id == policy_id => p,
+            _ => return false,
+        };
+
+        let pet: Pet = match env
+            .storage()
+            .instance()
+            .get::<DataKey, Pet>(&DataKey::Pet(pet_id))
+        {
+            Some(p) => p,
+            None => return false,
+        };
+        pet.owner.require_auth();
+
+        let timestamp = env.ledger().timestamp();
+        policy.expiry_date = new_end_date;
+        policy.active = true;
+        env.storage()
+            .instance()
+            .set(&InsuranceKey::PetPolicyIndex((pet_id, count)), &policy);
+
+        env.events().publish(
+            (String::from_str(&env, "PolicyRenewed"), pet_id),
+            PolicyRenewedEvent {
+                version: EVENT_SCHEMA_VERSION,
+                pet_id,
+                policy_id,
+                new_expiry_date: new_end_date,
+                timestamp,
+            },
+        );
+        true
+    }
+
+    /// Checks if a policy is within 30 days of expiry and emits `PolicyExpiringSoon` if so.
+    /// Returns true if the warning was emitted.
+    pub fn check_policy_expiry(env: Env, pet_id: u64) -> bool {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&InsuranceKey::PetPolicyCount(pet_id))
+            .unwrap_or(0);
+        if count == 0 {
+            return false;
+        }
+        let policy = match env
+            .storage()
+            .instance()
+            .get::<InsuranceKey, InsurancePolicy>(&InsuranceKey::PetPolicyIndex((pet_id, count)))
+        {
+            Some(p) => p,
+            None => return false,
+        };
+
+        if !policy.active {
+            return false;
+        }
+
+        const THIRTY_DAYS: u64 = 30 * 24 * 60 * 60;
+        let timestamp = env.ledger().timestamp();
+        if policy.expiry_date > timestamp && policy.expiry_date - timestamp <= THIRTY_DAYS {
+            env.events().publish(
+                (String::from_str(&env, "PolicyExpiringSoon"), pet_id),
+                PolicyExpiringSoonEvent {
+                    version: EVENT_SCHEMA_VERSION,
+                    pet_id,
+                    policy_id: policy.policy_id,
+                    expiry_date: policy.expiry_date,
+                    timestamp,
+                },
+            );
+            return true;
+        }
+        false
     }
 
     /// Appeal a rejected insurance claim with additional evidence.

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -1123,6 +1123,8 @@ pub enum EventType {
     AccessGranted,
     AccessRevoked,
     InsuranceClaimSubmitted,
+    PetProfileUpdated,
+    GroomingRecordCreated,
 }
 
 #[contracttype]
@@ -2312,6 +2314,29 @@ pub struct TempVetGrantExpiredEvent {
     pub pet_id: u64,
     pub vet: Address,
     pub expired_at: u64,
+}
+
+/// Emitted when a pet's profile is updated.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PetProfileUpdatedEvent {
+    pub version: u32,
+    pub pet_id: u64,
+    pub owner: Address,
+    pub timestamp: u64,
+    pub subscription_ids: Vec<u64>,
+}
+
+/// Emitted when a grooming record is created.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroomingRecordCreatedEvent {
+    pub version: u32,
+    pub record_id: u64,
+    pub pet_id: u64,
+    pub groomer: Address,
+    pub timestamp: u64,
+    pub subscription_ids: Vec<u64>,
 }
 
 #[contract]
@@ -3631,9 +3656,24 @@ impl PetChainContract {
             PetChainContract::log_access(
                 &env,
                 id,
-                pet.owner,
+                pet.owner.clone(),
                 AccessAction::Write,
                 String::from_str(&env, "Pet profile updated"),
+            );
+            let timestamp = env.ledger().timestamp();
+            env.events().publish(
+                (String::from_str(&env, "PetProfileUpdated"), id),
+                PetProfileUpdatedEvent {
+                    version: EVENT_SCHEMA_VERSION,
+                    pet_id: id,
+                    owner: pet.owner,
+                    timestamp,
+                    subscription_ids: Self::matching_subscription_ids(
+                        &env,
+                        EventType::PetProfileUpdated,
+                        id,
+                    ),
+                },
             );
             true
         } else {
@@ -3757,6 +3797,15 @@ impl PetChainContract {
     }
 
     pub fn get_pet_data(env: Env, id: u64, caller: Address) -> Option<PetData> {
+        if let Some(pet) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Pet>(&DataKey::Pet(id))
+        {
+            let allowed = match pet.privacy_level {
+                PrivacyLevel::Public => true,
+                PrivacyLevel::Restricted => {
+                    let access = PetChainContract::check_access(env.clone(), id, caller.clone());
                     !matches!(access, AccessLevel::None)
                 }
                 PrivacyLevel::Private => {
@@ -8475,8 +8524,6 @@ impl PetChainContract {
             .storage()
             .instance()
             .get(&MedicalKey::MedicalRecord(record_id));
-        record
-    }
 
         // Authorise: pet owner or the vet who created the record
         let pet: Pet = env
@@ -9846,6 +9893,22 @@ impl PetChainContract {
         };
 
         env.storage().instance().set(&FeatureKey::Gr(id), &record);
+
+        env.events().publish(
+            (String::from_str(&env, "GroomingRecordCreated"), pet_id),
+            GroomingRecordCreatedEvent {
+                version: EVENT_SCHEMA_VERSION,
+                record_id: id,
+                pet_id,
+                groomer: record.groomer,
+                timestamp: now,
+                subscription_ids: Self::matching_subscription_ids(
+                    &env,
+                    EventType::GroomingRecordCreated,
+                    pet_id,
+                ),
+            },
+        );
 
         id
     }

--- a/stellar-contracts/src/test_access_control.rs
+++ b/stellar-contracts/src/test_access_control.rs
@@ -2023,3 +2023,4 @@ fn test_surgery_treatment_allowed_for_surgery_vet() {
 
     assert_eq!(treatment_id, 1);
 }
+}

--- a/stellar-contracts/src/test_behavior.rs
+++ b/stellar-contracts/src/test_behavior.rs
@@ -1029,3 +1029,4 @@ fn test_get_breeding_count_unrelated_pet_unaffected() {
     assert_eq!(client.get_breeding_count(&dam_id), 1);
     assert_eq!(client.get_breeding_count(&unrelated_id), 0);
 }
+}

--- a/stellar-contracts/src/test_consent_pagination.rs
+++ b/stellar-contracts/src/test_consent_pagination.rs
@@ -516,3 +516,4 @@ fn test_consent_access_fails_when_parent_chain_is_revoked() {
     client.revoke_consent(&root_id, &owner);
     assert!(!client.check_consent_access(&pet_id, &sub_delegate, &ConsentScope::ReadMedical));
 }
+}

--- a/stellar-contracts/src/test_grooming.rs
+++ b/stellar-contracts/src/test_grooming.rs
@@ -646,3 +646,4 @@ mod test_recurring_grooming {
         assert_eq!(result, 0);
     }
 }
+}

--- a/stellar-contracts/src/test_vaccination_expiry.rs
+++ b/stellar-contracts/src/test_vaccination_expiry.rs
@@ -1,0 +1,158 @@
+mod test_vaccination_expiry {
+    use crate::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    const DAY: u64 = 86_400;
+
+    fn setup() -> (Env, PetChainContractClient<'static>, Address, Address, u64) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let vet = Address::generate(&env);
+        let owner = Address::generate(&env);
+
+        client.init_admin(&admin);
+        client.register_vet(
+            &vet,
+            &String::from_str(&env, "Dr. Vet"),
+            &String::from_str(&env, "LIC-001"),
+            &String::from_str(&env, "General"),
+        );
+        client.verify_vet(&admin, &vet);
+
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Buddy"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Retriever"),
+            &PrivacyLevel::Public,
+        );
+
+        (env, client, vet, owner, pet_id)
+    }
+
+    #[test]
+    fn test_get_expiring_vaccinations_within_window() {
+        let (env, client, vet, _owner, pet_id) = setup();
+        let now = env.ledger().timestamp();
+
+        // Expires in 10 days — within a 30-day window
+        client.add_vaccination(
+            &pet_id,
+            &vet,
+            &VaccineType::Rabies,
+            &String::from_str(&env, "RabiesVax"),
+            &now,
+            &(now + 10 * DAY),
+            &(now + 10 * DAY),
+            &String::from_str(&env, "BATCH-001"),
+        );
+
+        let expiring = client.get_expiring_vaccinations(&pet_id, &30u64);
+        assert_eq!(expiring.len(), 1);
+        assert!(!expiring.get(0).unwrap().already_expired);
+        assert_eq!(expiring.get(0).unwrap().days_remaining, 10);
+    }
+
+    #[test]
+    fn test_get_expiring_vaccinations_already_expired() {
+        let (env, client, vet, _owner, pet_id) = setup();
+        let now = env.ledger().timestamp();
+
+        // Expired 5 days ago
+        let past = now.saturating_sub(5 * DAY);
+        client.add_vaccination(
+            &pet_id,
+            &vet,
+            &VaccineType::Distemper,
+            &String::from_str(&env, "DistemperVax"),
+            &past,
+            &past,
+            &past,
+            &String::from_str(&env, "BATCH-002"),
+        );
+
+        let expiring = client.get_expiring_vaccinations(&pet_id, &30u64);
+        assert_eq!(expiring.len(), 1);
+        assert!(expiring.get(0).unwrap().already_expired);
+        assert_eq!(expiring.get(0).unwrap().days_remaining, 0);
+    }
+
+    #[test]
+    fn test_get_expiring_vaccinations_outside_window_returns_empty() {
+        let (env, client, vet, _owner, pet_id) = setup();
+        let now = env.ledger().timestamp();
+
+        // Expires in 60 days — outside a 30-day window
+        client.add_vaccination(
+            &pet_id,
+            &vet,
+            &VaccineType::Parvovirus,
+            &String::from_str(&env, "ParvoVax"),
+            &now,
+            &(now + 60 * DAY),
+            &(now + 60 * DAY),
+            &String::from_str(&env, "BATCH-003"),
+        );
+
+        let expiring = client.get_expiring_vaccinations(&pet_id, &30u64);
+        assert_eq!(expiring.len(), 0);
+    }
+
+    #[test]
+    fn test_get_expiring_vaccinations_no_vaccinations_returns_empty() {
+        let (_env, client, _vet, _owner, pet_id) = setup();
+        let expiring = client.get_expiring_vaccinations(&pet_id, &30u64);
+        assert_eq!(expiring.len(), 0);
+    }
+
+    #[test]
+    fn test_vaccination_summary_overdue() {
+        let (env, client, vet, _owner, pet_id) = setup();
+        let now = env.ledger().timestamp();
+        let past = now.saturating_sub(5 * DAY);
+
+        client.add_vaccination(
+            &pet_id,
+            &vet,
+            &VaccineType::Rabies,
+            &String::from_str(&env, "RabiesVax"),
+            &past,
+            &past,
+            &past,
+            &String::from_str(&env, "BATCH-004"),
+        );
+
+        let summary = client.get_vaccination_summary(&pet_id);
+        assert!(!summary.is_fully_current);
+        assert_eq!(summary.overdue_types.len(), 1);
+    }
+
+    #[test]
+    fn test_vaccination_summary_current() {
+        let (env, client, vet, _owner, pet_id) = setup();
+        let now = env.ledger().timestamp();
+
+        client.add_vaccination(
+            &pet_id,
+            &vet,
+            &VaccineType::Rabies,
+            &String::from_str(&env, "RabiesVax"),
+            &now,
+            &(now + 365 * DAY),
+            &(now + 365 * DAY),
+            &String::from_str(&env, "BATCH-005"),
+        );
+
+        let summary = client.get_vaccination_summary(&pet_id);
+        assert!(summary.is_fully_current);
+        assert_eq!(summary.overdue_types.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements insurance policy renewal automation with grace period as specified in #656.

## Changes

- **EventType** — added `PolicyExpiringSoon` and `PolicyRenewed` variants
- **Event structs** — `PolicyExpiringSoonEvent` and `PolicyRenewedEvent`
- **`submit_insurance_claim`** — claims accepted during 7-day grace period after expiry; lapsed policies (past grace period) return `None`
- **`renew_policy(pet_id, policy_id, new_end_date)`** — callable by pet owner; resets policy to active with new expiry date, emits `PolicyRenewed`
- **`check_policy_expiry(pet_id)`** — emits `PolicyExpiringSoon` when policy is within 30 days of expiry

Closes #656