### PR TITLE
Add idempotency-key support to TwoFactorHandlers::enroll (#849)

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -53,6 +53,53 @@ fn two_factor_store() -> Arc<dyn TwoFactorStore> {
         .clone()
 }
 
+
+const IDEMPOTENCY_TTL_SECS: u64 = 300; // 5 minutes
+
+#[derive(Clone)]
+struct IdempotencyEntry {
+    response: EnableTwoFactorResponse,
+    stored_at: u64,
+}
+
+#[cfg(test)]
+fn test_idempotency_store() -> Arc<std::sync::Mutex<HashMap<String, IdempotencyEntry>>> {
+    std::thread_local! {
+        static STORE: Arc<std::sync::Mutex<HashMap<String, IdempotencyEntry>>> =
+            Arc::new(std::sync::Mutex::new(HashMap::new()));
+    }
+    STORE.with(|store| store.clone())
+}
+
+#[cfg(test)]
+fn idempotency_store() -> Arc<std::sync::Mutex<HashMap<String, IdempotencyEntry>>> {
+    test_idempotency_store()
+}
+
+#[cfg(not(test))]
+fn idempotency_store() -> Arc<std::sync::Mutex<HashMap<String, IdempotencyEntry>>> {
+    static STORE: OnceLock<Arc<std::sync::Mutex<HashMap<String, IdempotencyEntry>>>> = OnceLock::new();
+    STORE
+        .get_or_init(|| Arc::new(std::sync::Mutex::new(HashMap::new())))
+        .clone()
+}
+
+fn idempotency_key(user_id: &str, key: &str) -> String {
+    format!("{}::{}", user_id, key)
+}
+
+fn current_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+pub(crate) fn clear_idempotency_store_for_tests() {
+    test_idempotency_store().lock().unwrap().clear();
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuthenticatedUser {
     pub user_id: String,
@@ -77,9 +124,11 @@ impl AuthenticatedUser {
 pub struct EnableTwoFactorRequest {
     pub user_id: String,
     pub email: String,
+    #[serde(default)]
+    pub idempotency_key: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct EnableTwoFactorResponse {
     pub secret: String,
     pub otpauth_uri: String,
@@ -224,6 +273,17 @@ impl TwoFactorHandlers {
     ) -> Result<EnableTwoFactorResponse, String> {
         caller.authorize(&req.user_id)?;
 
+        if let Some(key) = req.idempotency_key.as_deref() {
+            let lookup = idempotency_key(&req.user_id, key);
+            let store = idempotency_store();
+            let guard = store.lock().unwrap();
+            if let Some(entry) = guard.get(&lookup) {
+                if current_unix_secs().saturating_sub(entry.stored_at) < IDEMPOTENCY_TTL_SECS {
+                    return Ok(entry.response.clone());
+                }
+            }
+        }
+
         if let Ok(existing) = self.store_get(&req.user_id) {
             if existing.enabled {
                 return Err(
@@ -244,12 +304,25 @@ impl TwoFactorHandlers {
             },
         )?;
 
-        Ok(EnableTwoFactorResponse {
+        let response = EnableTwoFactorResponse {
             secret: setup.secret,
             otpauth_uri: setup.otpauth_uri,
             qr_code: setup.qr_code_base64,
             backup_codes: setup.backup_codes,
-        })
+        };
+
+        if let Some(key) = req.idempotency_key.as_deref() {
+            let lookup = idempotency_key(&req.user_id, key);
+            idempotency_store().lock().unwrap().insert(
+                lookup,
+                IdempotencyEntry {
+                    response: response.clone(),
+                    stored_at: current_unix_secs(),
+                },
+            );
+        }
+
+        Ok(response)
     }
 
     pub fn verify_and_activate(

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -223,6 +223,7 @@ mod tests {
         let user_id = "user123";
         let caller = AuthenticatedUser::new(user_id);
         let req = EnableTwoFactorRequest {
+            idempotency_key: None,
             user_id: user_id.to_string(),
             email: "user@example.com".to_string(),
         };
@@ -317,6 +318,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "persist@petchain.com".to_string(),
             },
@@ -344,6 +346,7 @@ mod tests {
         let resp1 = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "overwrite@petchain.com".to_string(),
             },
@@ -353,6 +356,7 @@ mod tests {
         let resp2 = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "overwrite@petchain.com".to_string(),
             },
@@ -365,6 +369,63 @@ mod tests {
         // The first secret is gone
         assert_ne!(stored.secret, resp1.secret);
     }
+    
+    #[test]
+    fn test_enroll_same_idempotency_key_returns_identical_secret() {
+        clear_two_factor_store_for_tests();
+        crate::handlers::clear_idempotency_store_for_tests();
+
+        let user_id = "user-idempotent";
+        let req = EnableTwoFactorRequest {
+            user_id: user_id.to_string(),
+            email: "idempotent@petchain.com".to_string(),
+            idempotency_key: Some("retry-key-1".to_string()),
+        };
+
+        let resp1 = TwoFactorHandlers::enable_two_factor(&caller(user_id), req.clone()).unwrap();
+        let resp2 = TwoFactorHandlers::enable_two_factor(&caller(user_id), req).unwrap();
+
+        assert_eq!(resp1.secret, resp2.secret);
+        assert_eq!(resp1.backup_codes, resp2.backup_codes);
+        assert_eq!(resp1.otpauth_uri, resp2.otpauth_uri);
+    }
+
+    #[test]
+    fn test_enroll_different_idempotency_key_generates_new_secret() {
+        clear_two_factor_store_for_tests();
+        crate::handlers::clear_idempotency_store_for_tests();
+
+        let user_id = "user-idempotent-2";
+
+        let resp1 = TwoFactorHandlers::enable_two_factor(
+            &caller(user_id),
+            EnableTwoFactorRequest {
+                user_id: user_id.to_string(),
+                email: "idempotent2@petchain.com".to_string(),
+                idempotency_key: Some("key-a".to_string()),
+            },
+        )
+        .unwrap();
+
+        // Same user, different key — but enroll() rejects a second enroll
+        // once a record exists unless it is still unverified, so this proves
+        // the new key path does NOT hit the cached response and instead
+        // re-runs normal enroll logic overwriting the prior unverified record.
+        let resp2 = TwoFactorHandlers::enable_two_factor(
+            &caller(user_id),
+            EnableTwoFactorRequest {
+                user_id: user_id.to_string(),
+                email: "idempotent2@petchain.com".to_string(),
+                idempotency_key: Some("key-b".to_string()),
+            },
+        )
+        .unwrap();
+
+        assert_ne!(resp1.secret, resp2.secret);
+    }
+
+
+
 
     /// Failure path: wrong caller is rejected before any persistence occurs.
     #[test]
@@ -374,6 +435,7 @@ mod tests {
         let result = TwoFactorHandlers::enable_two_factor(
             &caller("attacker"),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: "victim".to_string(),
                 email: "victim@petchain.com".to_string(),
             },
@@ -415,6 +477,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "activate@petchain.com".to_string(),
             },
@@ -448,6 +511,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "no-partial@petchain.com".to_string(),
             },
@@ -517,6 +581,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "enabled@petchain.com".to_string(),
             },
@@ -596,6 +661,7 @@ mod tests {
             .enroll(
                 &caller(user_id),
                 EnableTwoFactorRequest {
+            idempotency_key: None,
                     user_id: user_id.to_string(),
                     email: "mock+user@example.com".to_string(),
                 },
@@ -662,6 +728,7 @@ mod tests {
             .enroll(
                 &caller("mock-fail"),
                 EnableTwoFactorRequest {
+            idempotency_key: None,
                     user_id: "mock-fail".to_string(),
                     email: "mock-fail@example.com".to_string(),
                 },
@@ -930,6 +997,7 @@ mod tests {
             let result = TwoFactorHandlers::enable_two_factor(
                 &caller("user-1"),
                 EnableTwoFactorRequest {
+            idempotency_key: None,
                     user_id: "user-1".to_string(),
                     email: "user1@petchain.com".to_string(),
                 },
@@ -945,6 +1013,7 @@ mod tests {
             let result = TwoFactorHandlers::enable_two_factor(
                 &caller("user-1"),
                 EnableTwoFactorRequest {
+            idempotency_key: None,
                     user_id: "user-2".to_string(),
                     email: "user2@petchain.com".to_string(),
                 },
@@ -1086,6 +1155,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "u1@petchain.com".to_string(),
             },
@@ -1121,6 +1191,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "u2@petchain.com".to_string(),
             },
@@ -1148,6 +1219,7 @@ mod tests {
         TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "u3@petchain.com".to_string(),
             },
@@ -1174,6 +1246,7 @@ mod tests {
         TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "u6@petchain.com".to_string(),
             },
@@ -1199,6 +1272,7 @@ mod tests {
         let resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "u8@petchain.com".to_string(),
             },
@@ -1232,6 +1306,7 @@ mod tests {
         TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "u9@petchain.com".to_string(),
             },
@@ -1301,6 +1376,7 @@ mod integration_tests {
         let enable_resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "user1@petchain.com".to_string(),
             },
@@ -1384,6 +1460,7 @@ mod integration_tests {
         let enable_resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "recover@petchain.com".to_string(),
             },
@@ -1490,6 +1567,7 @@ mod integration_tests {
         let enable_resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "rate-limit-login@petchain.com".to_string(),
             },
@@ -1546,6 +1624,7 @@ mod integration_tests {
         let enable_resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "user4@petchain.com".to_string(),
             },
@@ -1592,6 +1671,7 @@ mod integration_tests {
         let enable_resp = TwoFactorHandlers::enable_two_factor(
             &caller(user_id),
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "reset-rate@petchain.com".to_string(),
             },
@@ -1747,6 +1827,7 @@ mod integration_tests {
         let setup = TwoFactorHandlers::enable_two_factor(
             &caller_user,
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "user@petchain.com".to_string(),
             },
@@ -1789,6 +1870,7 @@ mod integration_tests {
         let setup = TwoFactorHandlers::enable_two_factor(
             &caller_user,
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "user@petchain.com".to_string(),
             },
@@ -1844,6 +1926,7 @@ mod integration_tests {
         let setup = TwoFactorHandlers::enable_two_factor(
             &caller_user,
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "user@petchain.com".to_string(),
             },
@@ -1899,6 +1982,7 @@ mod integration_tests {
             let setup = TwoFactorHandlers::enable_two_factor(
                 &c,
                 EnableTwoFactorRequest {
+            idempotency_key: None,
                     user_id: user_id.clone(),
                     email: format!("{}@petchain.com", user_id),
                 },
@@ -1952,6 +2036,7 @@ mod integration_tests {
         let setup = TwoFactorHandlers::enable_two_factor(
             &caller_user,
             EnableTwoFactorRequest {
+            idempotency_key: None,
                 user_id: user_id.to_string(),
                 email: "user@petchain.com".to_string(),
             },
@@ -3320,6 +3405,7 @@ mod progressive_two_factor_lockout_tests {
             .enroll(
                 &caller,
                 EnableTwoFactorRequest {
+            idempotency_key: None,
                     user_id: user_id.to_string(),
                     email: "lockout@example.com".to_string(),
                 },


### PR DESCRIPTION
 ## Closes #849 

Adds idempotency-key support to `TwoFactorHandlers::enroll()` so retried
enrollment requests don't silently overwrite an unverified secret with
a different one.

### Changes

- `EnableTwoFactorRequest` gains an optional `idempotency_key: Option<String>`.
- `enroll()` checks an in-memory idempotency store (keyed by `user_id` +
  idempotency key) before generating a new secret. A repeat call with the
  same key, within a 5-minute TTL, returns the original response unchanged
  instead of issuing a new secret.
- `EnableTwoFactorResponse` now derives `Clone` (needed to cache and return it).

### Tests added

- `test_enroll_same_idempotency_key_returns_identical_secret`
- `test_enroll_different_idempotency_key_generates_new_secret`

### Test results

`cargo test --lib -- --test-threads=1` → 191 passed, 0 failed, 4 ignored
(Redis integration tests requiring `REDIS_URL`, skipped intentionally).

Pleae Note: running with default parallel threads can show
`db::tests::select_secret_provider_aws` fail intermittently — this is a
pre-existing test-isolation issue with environment-variable access across
parallel test threads, unrelated to this change.