### PR TITLE
Implement tenant provisioning idempotency

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -773,6 +773,12 @@ pub struct ProvisionTenantRequest {
 pub struct ProvisionTenantResponse {
     pub tenant_id: String,
     pub totp_issuer: String,
+    pub rate_limit_max_failures: u32,
+    /// `true` if `tenant_id` already existed and this call returned the
+    /// existing tenant's config instead of creating a new one. Lets
+    /// infrastructure automation safely retry `POST /tenant/provision`
+    /// without erroring or creating duplicates.
+    pub already_existed: bool,
 }
 
 /// Handlers that operate within a single tenant's namespace.
@@ -911,7 +917,13 @@ impl TenantProvisioningHandlers {
         Self { registry }
     }
 
-    /// Provision a new tenant (super-admin only — caller must be verified externally).
+    /// Provision a tenant (super-admin only — caller must be verified externally).
+    ///
+    /// Idempotent: calling this repeatedly with the same `tenant_id` never
+    /// errors or creates a duplicate. The first call creates the tenant and
+    /// returns `already_existed: false`; subsequent calls return the
+    /// existing tenant's config with `already_existed: true`. This lets
+    /// infrastructure automation safely retry provisioning on failure.
     pub fn provision_tenant(
         &self,
         _super_admin: &AuthenticatedAdmin,
@@ -922,10 +934,12 @@ impl TenantProvisioningHandlers {
             totp_issuer: req.totp_issuer.clone(),
             rate_limit_max_failures: req.rate_limit_max_failures,
         };
-        self.registry.provision(config)?;
+        let (existing_or_new, already_existed) = self.registry.provision(config)?;
         Ok(ProvisionTenantResponse {
-            tenant_id: req.tenant_id,
-            totp_issuer: req.totp_issuer,
+            tenant_id: existing_or_new.tenant_id,
+            totp_issuer: existing_or_new.totp_issuer,
+            rate_limit_max_failures: existing_or_new.rate_limit_max_failures,
+            already_existed,
         })
     }
 

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -3366,3 +3366,103 @@ mod progressive_two_factor_lockout_tests {
             .unwrap());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Issue #807 — Tenant Provisioning Idempotency
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tenant_provisioning_idempotency_tests {
+    use crate::handlers::{
+        AuthenticatedAdmin, ProvisionTenantRequest, TenantProvisioningHandlers,
+    };
+    use crate::two_factor::TenantRegistry;
+    use std::sync::Arc;
+
+    fn admin() -> AuthenticatedAdmin {
+        AuthenticatedAdmin::new("super-admin")
+    }
+
+    fn provision_req(tenant_id: &str) -> ProvisionTenantRequest {
+        ProvisionTenantRequest {
+            tenant_id: tenant_id.to_string(),
+            totp_issuer: "AcmeCo".to_string(),
+            rate_limit_max_failures: 7,
+        }
+    }
+
+    #[test]
+    fn test_first_provision_creates_tenant() {
+        let handlers = TenantProvisioningHandlers::new(Arc::new(TenantRegistry::default()));
+
+        let response = handlers
+            .provision_tenant(&admin(), provision_req("tenant-fresh"))
+            .unwrap();
+
+        assert_eq!(response.tenant_id, "tenant-fresh");
+        assert_eq!(response.totp_issuer, "AcmeCo");
+        assert_eq!(response.rate_limit_max_failures, 7);
+        assert!(!response.already_existed);
+
+        // The tenant is now retrievable from the registry.
+        let config = handlers.get_tenant_config("tenant-fresh").unwrap();
+        assert_eq!(config.tenant_id, "tenant-fresh");
+    }
+
+    #[test]
+    fn test_repeat_provision_returns_existing_tenant_with_flag() {
+        let handlers = TenantProvisioningHandlers::new(Arc::new(TenantRegistry::default()));
+
+        let first = handlers
+            .provision_tenant(&admin(), provision_req("tenant-repeat"))
+            .unwrap();
+        assert!(!first.already_existed);
+
+        // Retry with the same tenant_id, as an infra automation tool would
+        // do after a flaky failure. A different `totp_issuer` is sent to
+        // confirm the *original* config wins rather than being overwritten.
+        let mut retry_req = provision_req("tenant-repeat");
+        retry_req.totp_issuer = "SomeoneElseCo".to_string();
+        let second = handlers.provision_tenant(&admin(), retry_req).unwrap();
+
+        assert!(second.already_existed);
+        assert_eq!(second.tenant_id, "tenant-repeat");
+        // Existing config is returned unchanged, not the new request's data.
+        assert_eq!(second.totp_issuer, "AcmeCo");
+        assert_eq!(second.rate_limit_max_failures, 7);
+
+        // Only one entry exists in the registry — no duplicate was created.
+        let config = handlers.get_tenant_config("tenant-repeat").unwrap();
+        assert_eq!(config.totp_issuer, "AcmeCo");
+    }
+
+    #[test]
+    fn test_concurrent_provision_is_idempotent_and_atomic() {
+        use std::thread;
+
+        let registry = Arc::new(TenantRegistry::default());
+        let handlers = Arc::new(TenantProvisioningHandlers::new(registry));
+
+        let mut join_handles = Vec::new();
+        for _ in 0..16 {
+            let handlers = Arc::clone(&handlers);
+            join_handles.push(thread::spawn(move || {
+                handlers
+                    .provision_tenant(&admin(), provision_req("tenant-concurrent"))
+                    .unwrap()
+            }));
+        }
+
+        let responses: Vec<_> = join_handles
+            .into_iter()
+            .map(|h| h.join().unwrap())
+            .collect();
+
+        // Exactly one caller observed creation; all others observed it as
+        // already existing — proving the check-and-insert was atomic.
+        let created_count = responses.iter().filter(|r| !r.already_existed).count();
+        assert_eq!(created_count, 1);
+
+        let existed_count = responses.iter().filter(|r| r.already_existed).count();
+        assert_eq!(existed_count, 15);
+    }
+}

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -927,14 +927,26 @@ pub struct TenantRegistry {
 }
 
 impl TenantRegistry {
-    /// Provision a new tenant. Returns `Err` if the tenant already exists.
-    pub fn provision(&self, config: TenantConfig) -> Result<(), String> {
+    /// Provision a tenant idempotently.
+    ///
+    /// If `tenant_id` is unknown, it is created and `(config, false)` is
+    /// returned. If it already exists, the existing config is returned
+    /// unchanged along with `(existing_config, true)` — the caller can use
+    /// the `bool` to signal `already_existed` without treating this as an
+    /// error. The check-and-insert happens under a single lock acquisition
+    /// (via `Entry`), so concurrent calls for the same `tenant_id` cannot
+    /// race past each other and create duplicates.
+    pub fn provision(&self, config: TenantConfig) -> Result<(TenantConfig, bool), String> {
         let mut map = self.tenants.lock().unwrap();
-        if map.contains_key(&config.tenant_id) {
-            return Err(format!("Tenant '{}' already exists", config.tenant_id));
+        match map.entry(config.tenant_id.clone()) {
+            std::collections::hash_map::Entry::Occupied(entry) => {
+                Ok((entry.get().clone(), true))
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(config.clone());
+                Ok((config, false))
+            }
         }
-        map.insert(config.tenant_id.clone(), config);
-        Ok(())
     }
 
     /// Retrieve a scoped store for the given tenant. Returns `Err` if the


### PR DESCRIPTION
Closes #807

Provisioning a tenant with an existing tenant_id now returns HTTP 200 with the existing tenant config (instead of a duplicate or an opaque error), with an `already_existed: bool` flag in the response.