### PR TITLE
Add HMAC-SHA256 signing to webhook payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
  "base32 0.5.1",
  "futures-util",
  "hex",
+ "hmac",
  "prometheus",
  "rand 0.8.6",
  "redis",

--- a/backend-2fa/Cargo.toml
+++ b/backend-2fa/Cargo.toml
@@ -9,6 +9,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+hmac = "0.12.1"
 hex = "0.4"
 base32 = "0.5.1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres"] }

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -42,6 +42,6 @@ pub use two_factor::{
     TwoFactorStore, UserTwoFactorSummary,
 };
 pub use webhooks::{
-    DefaultHttpClient, HttpClient, SecurityEventType, WebhookDeliveryLog, WebhookManager,
-    WebhookPayload,
+    sign_webhook_payload, verify_webhook_signature, DefaultHttpClient, HttpClient,
+    SecurityEventType, WebhookDeliveryLog, WebhookManager, WebhookPayload, SIGNATURE_HEADER,
 };

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -2960,7 +2960,7 @@ mod canary_tests {
     }
 
     impl HttpClient for RecordingHttpClient {
-        fn post(&self, url: &str, body: &str) -> Result<(), String> {
+        fn post(&self, url: &str, body: &str, _signature_header: &str) -> Result<(), String> {
             self.calls.lock().unwrap().push(format!("{}:{}", url, body));
             Ok(())
         }
@@ -2972,7 +2972,10 @@ mod canary_tests {
 
     fn make_canary_handlers() -> (CanaryHandlers, Arc<Mutex<Vec<String>>>) {
         let (http_client, calls) = RecordingHttpClient::new();
-        let wm = Arc::new(WebhookManager::new(Arc::new(http_client)));
+        let wm = Arc::new(WebhookManager::new(
+            Arc::new(http_client),
+            "canary-test-signing-secret".to_string(),
+        ));
         wm.configure(
             SecurityEventType::CanaryTriggered,
             "http://alert.example.com/hook".to_string(),

--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -1,7 +1,45 @@
+use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Header under which the webhook signature is sent.
+pub const SIGNATURE_HEADER: &str = "X-PetChain-Signature";
+
+/// Compute the `sha256=<hex>` HMAC-SHA256 signature for a webhook body.
+pub fn sign_webhook_payload(secret: &str, body: &[u8]) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take a key of any size");
+    mac.update(body);
+    let digest = mac.finalize().into_bytes();
+    format!("sha256={}", hex::encode(digest))
+}
+
+/// Verify a webhook signature header against the expected secret and body.
+///
+/// `header_value` is expected to be in the form `sha256=<hex>`. Returns
+/// `false` for malformed headers, tampered bodies, or mismatched secrets.
+/// Comparison is constant-time to avoid timing side channels.
+pub fn verify_webhook_signature(secret: &str, body: &[u8], header_value: &str) -> bool {
+    let Some(provided_hex) = header_value.strip_prefix("sha256=") else {
+        return false;
+    };
+
+    let Ok(provided_bytes) = hex::decode(provided_hex) else {
+        return false;
+    };
+
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(body);
+
+    mac.verify_slice(&provided_bytes).is_ok()
+}
 
 /// Security event types that can trigger webhook notifications.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -49,7 +87,7 @@ pub struct WebhookDeliveryLog {
 
 /// Trait for sending HTTP POST requests (injectable for testing).
 pub trait HttpClient: Send + Sync {
-    fn post(&self, url: &str, body: &str) -> Result<(), String>;
+    fn post(&self, url: &str, body: &str, signature_header: &str) -> Result<(), String>;
 }
 
 /// Production HTTP client using ureq (or a stub if not available).
@@ -57,8 +95,9 @@ pub trait HttpClient: Send + Sync {
 pub struct DefaultHttpClient;
 
 impl HttpClient for DefaultHttpClient {
-    fn post(&self, _url: &str, _body: &str) -> Result<(), String> {
-        // In a real deployment this would use reqwest/ureq.
+    fn post(&self, _url: &str, _body: &str, _signature_header: &str) -> Result<(), String> {
+        // In a real deployment this would use reqwest/ureq and would attach
+        // `signature_header` as the `X-PetChain-Signature` header.
         // For the library crate we keep it as a no-op stub so no extra
         // async runtime dependency is needed.
         Ok(())
@@ -71,20 +110,24 @@ pub struct WebhookManager {
     config: Arc<Mutex<HashMap<String, String>>>,
     delivery_log: Arc<Mutex<Vec<WebhookDeliveryLog>>>,
     http_client: Arc<dyn HttpClient>,
+    /// Secret used to sign outbound webhook payloads (HMAC-SHA256).
+    /// Distinct from any JWT secret used elsewhere in this crate.
+    signing_secret: String,
 }
 
 impl Default for WebhookManager {
     fn default() -> Self {
-        Self::new(Arc::new(DefaultHttpClient))
+        Self::new(Arc::new(DefaultHttpClient), String::new())
     }
 }
 
 impl WebhookManager {
-    pub fn new(http_client: Arc<dyn HttpClient>) -> Self {
+    pub fn new(http_client: Arc<dyn HttpClient>, signing_secret: String) -> Self {
         Self {
             config: Arc::new(Mutex::new(HashMap::new())),
             delivery_log: Arc::new(Mutex::new(Vec::new())),
             http_client,
+            signing_secret,
         }
     }
 
@@ -132,13 +175,14 @@ impl WebhookManager {
         };
 
         let body = serde_json::to_string(&payload).unwrap_or_default();
+        let signature_header = sign_webhook_payload(&self.signing_secret, body.as_bytes());
 
         let mut attempts = 0u32;
         let mut last_error: Option<String> = None;
         let mut success = false;
 
         while attempts < 3 {
-            match self.http_client.post(&url, &body) {
+            match self.http_client.post(&url, &body, &signature_header) {
                 Ok(()) => {
                     success = true;
                     break;
@@ -207,7 +251,7 @@ mod tests {
     }
 
     impl HttpClient for MockHttpClient {
-        fn post(&self, _url: &str, _body: &str) -> Result<(), String> {
+        fn post(&self, _url: &str, _body: &str, _signature_header: &str) -> Result<(), String> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             let remaining = self.fail_times.load(Ordering::SeqCst);
             if remaining > 0 {
@@ -219,9 +263,11 @@ mod tests {
         }
     }
 
+    const TEST_SIGNING_SECRET: &str = "test-signing-secret";
+
     fn make_manager(fail_times: u32) -> (WebhookManager, Arc<MockHttpClient>) {
         let client = Arc::new(MockHttpClient::new(fail_times));
-        let manager = WebhookManager::new(client.clone());
+        let manager = WebhookManager::new(client.clone(), TEST_SIGNING_SECRET.to_string());
         (manager, client)
     }
 
@@ -327,5 +373,33 @@ mod tests {
         manager.remove_config(&SecurityEventType::FailedTwoFa);
         manager.fire(SecurityEventType::FailedTwoFa, "user1", HashMap::new());
         assert_eq!(mock.call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_verify_webhook_signature_valid() {
+        let secret = "supersecret";
+        let body = b"{\"event_type\":\"failed_two_fa\",\"user_id\":\"user1\"}";
+        let header = sign_webhook_payload(secret, body);
+        assert!(verify_webhook_signature(secret, body, &header));
+    }
+
+    #[test]
+    fn test_verify_webhook_signature_tampered_body_fails() {
+        let secret = "supersecret";
+        let body = b"{\"event_type\":\"failed_two_fa\",\"user_id\":\"user1\"}";
+        let header = sign_webhook_payload(secret, body);
+
+        let tampered_body = b"{\"event_type\":\"failed_two_fa\",\"user_id\":\"attacker\"}";
+        assert!(!verify_webhook_signature(secret, tampered_body, &header));
+    }
+
+    #[test]
+    fn test_verify_webhook_signature_wrong_secret_fails() {
+        let secret = "supersecret";
+        let wrong_secret = "wrongsecret";
+        let body = b"{\"event_type\":\"failed_two_fa\",\"user_id\":\"user1\"}";
+        let header = sign_webhook_payload(secret, body);
+
+        assert!(!verify_webhook_signature(wrong_secret, body, &header));
     }
 }


### PR DESCRIPTION
Closes #809

`WebhookManager` now requires a `signing_secret` and includes an `X-PetChain-Signature: sha256=HMAC-SHA256(secret, body)` header on every outbound webhook request. Exports `verify_webhook_signature(secret, body, header_value) -> bool` for downstream consumers. Tests cover valid signature, tampered body, and wrong secret.