### PR TITLE
Add postgres pool acquire timeout configuration

### DIFF
--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -73,11 +73,17 @@ impl PostgresTwoFactorStore {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(10);
+        let acquire_timeout_secs: u64 = std::env::var("DB_POOL_ACQUIRE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+
         let pool = runtime
             .block_on(
                 PgPoolOptions::new()
                     .min_connections(min_conns)
                     .max_connections(max_conns)
+                    .acquire_timeout(Duration::from_secs(acquire_timeout_secs))
                     .connect(database_url),
             )
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #846

## Description of Changes

This PR adds support for configuring the PostgreSQL connection acquire timeout through a new environment variable.

### Changes
- Added `DB_POOL_ACQUIRE_TIMEOUT_SECS` environment variable.
- Wired the value into `PgPoolOptions::acquire_timeout`.
- Added a default timeout value when the environment variable is not set.

## Why

Previously, requests could wait indefinitely when the connection pool was exhausted. This change allows deployments to configure a timeout and fail faster with a clear error.

## Testing

- Verified code changes locally through code review.
- Confirmed timeout configuration is read from environment variables.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
