### PR TITLE
fix(metrics,tracing): build_info gauge, doc table, W3C trace entropy (#877 #878 #879)

### DIFF
--- a/backend-2fa/build.rs
+++ b/backend-2fa/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    // Emit GIT_SHA at build time. Falls back to "unknown" if git is unavailable.
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_SHA={sha}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}

--- a/backend-2fa/src/metrics.rs
+++ b/backend-2fa/src/metrics.rs
@@ -8,6 +8,7 @@
 //! # Metrics
 //! | Name | Type | Labels |
 //! |------|------|--------|
+//! | `build_info` | Gauge | `version`, `git_sha` |
 //! | `totp_verifications_total` | Counter | `result` (`ok`/`fail`) |
 //! | `recovery_code_uses_total` | Counter | — |
 //! | `rate_limit_hits_total` | Counter | — |
@@ -16,10 +17,12 @@
 //! | `db_pool_idle` | Gauge | — |
 //! | `request_duration_seconds` | Histogram | `endpoint` |
 //! | `leaderboard_ws_connections_total` | Gauge | — |
+//! | `webhook_deliveries_total` | Counter | `status` (`success`/`failure`) |
+//! | `webhook_delivery_duration_seconds` | Histogram | — |
 
 use prometheus::{
-    register_counter_vec, register_gauge, register_histogram_vec, CounterVec, Gauge, HistogramVec,
-    TextEncoder,
+    register_counter_vec, register_gauge, register_gauge_vec, register_histogram_vec, CounterVec,
+    Gauge, GaugeVec, HistogramVec, TextEncoder,
 };
 use std::sync::OnceLock;
 
@@ -28,6 +31,7 @@ use std::sync::OnceLock;
 // ---------------------------------------------------------------------------
 
 pub struct Metrics {
+    pub build_info: GaugeVec,
     pub totp_verifications_total: CounterVec,
     pub recovery_code_uses_total: prometheus::Counter,
     pub rate_limit_hits_total: prometheus::Counter,
@@ -42,8 +46,23 @@ pub struct Metrics {
 static METRICS: OnceLock<Metrics> = OnceLock::new();
 
 pub fn metrics() -> &'static Metrics {
-    METRICS.get_or_init(|| Metrics {
-        totp_verifications_total: register_counter_vec!(
+    METRICS.get_or_init(|| {
+        let build_info = register_gauge_vec!(
+            "build_info",
+            "Build information (always 1)",
+            &["version", "git_sha"]
+        )
+        .expect("register build_info");
+        build_info
+            .with_label_values(&[
+                env!("CARGO_PKG_VERSION"),
+                env!("GIT_SHA"),
+            ])
+            .set(1.0);
+
+        Metrics {
+            build_info,
+            totp_verifications_total: register_counter_vec!(
             "totp_verifications_total",
             "Total TOTP verification attempts",
             &["result"]
@@ -86,6 +105,7 @@ pub fn metrics() -> &'static Metrics {
             "Current number of open leaderboard WebSocket connections"
         )
         .expect("register leaderboard_ws_connections_total"),
+        }
     })
 }
 
@@ -203,6 +223,15 @@ mod tests {
         assert!(output.contains("db_pool_idle"), "missing db_pool_idle gauge");
         assert!(output.contains("request_duration_seconds"), "missing histogram");
         assert!(output.contains("leaderboard_ws_connections_total"), "missing leaderboard ws gauge");
+        assert!(output.contains("build_info"), "missing build_info gauge");
+    }
+
+    #[test]
+    fn build_info_gauge_present() {
+        let output = render_metrics().expect("render");
+        assert!(output.contains("build_info"), "build_info gauge missing");
+        assert!(output.contains(r#"version=""#), "build_info missing version label");
+        assert!(output.contains(r#"git_sha=""#), "build_info missing git_sha label");
     }
 
     #[test]

--- a/backend-2fa/src/metrics.rs
+++ b/backend-2fa/src/metrics.rs
@@ -54,57 +54,57 @@ pub fn metrics() -> &'static Metrics {
         )
         .expect("register build_info");
         build_info
-            .with_label_values(&[
-                env!("CARGO_PKG_VERSION"),
-                env!("GIT_SHA"),
-            ])
+            .with_label_values(&[env!("CARGO_PKG_VERSION"), env!("GIT_SHA")])
             .set(1.0);
 
         Metrics {
             build_info,
             totp_verifications_total: register_counter_vec!(
-            "totp_verifications_total",
-            "Total TOTP verification attempts",
-            &["result"]
-        )
-        .expect("register totp_verifications_total"),
+                "totp_verifications_total",
+                "Total TOTP verification attempts",
+                &["result"]
+            )
+            .expect("register totp_verifications_total"),
 
-        recovery_code_uses_total: prometheus::register_counter!(
-            "recovery_code_uses_total",
-            "Total recovery code uses"
-        )
-        .expect("register recovery_code_uses_total"),
+            recovery_code_uses_total: prometheus::register_counter!(
+                "recovery_code_uses_total",
+                "Total recovery code uses"
+            )
+            .expect("register recovery_code_uses_total"),
 
-        rate_limit_hits_total: prometheus::register_counter!(
-            "rate_limit_hits_total",
-            "Total rate limit blocks"
-        )
-        .expect("register rate_limit_hits_total"),
+            rate_limit_hits_total: prometheus::register_counter!(
+                "rate_limit_hits_total",
+                "Total rate limit blocks"
+            )
+            .expect("register rate_limit_hits_total"),
 
-        rate_limiter_redis_fallback_total: prometheus::register_counter!(
-            "rate_limiter_redis_fallback_total",
-            "Total times DistributedRateLimiter fell back to in-memory due to Redis unavailability"
-        )
-        .expect("register rate_limiter_redis_fallback_total"),
+            rate_limiter_redis_fallback_total: prometheus::register_counter!(
+                "rate_limiter_redis_fallback_total",
+                "Total times DistributedRateLimiter fell back to in-memory due to Redis unavailability"
+            )
+            .expect("register rate_limiter_redis_fallback_total"),
 
-        db_pool_active: register_gauge!("db_pool_active", "Number of active DB pool connections")
+            db_pool_active: register_gauge!(
+                "db_pool_active",
+                "Number of active DB pool connections"
+            )
             .expect("register db_pool_active"),
 
-        db_pool_idle: register_gauge!("db_pool_idle", "Number of idle DB pool connections")
-            .expect("register db_pool_idle"),
+            db_pool_idle: register_gauge!("db_pool_idle", "Number of idle DB pool connections")
+                .expect("register db_pool_idle"),
 
-        request_duration_seconds: register_histogram_vec!(
-            "request_duration_seconds",
-            "HTTP request duration in seconds",
-            &["endpoint"]
-        )
-        .expect("register request_duration_seconds"),
+            request_duration_seconds: register_histogram_vec!(
+                "request_duration_seconds",
+                "HTTP request duration in seconds",
+                &["endpoint"]
+            )
+            .expect("register request_duration_seconds"),
 
-        leaderboard_ws_connections_total: register_gauge!(
-            "leaderboard_ws_connections_total",
-            "Current number of open leaderboard WebSocket connections"
-        )
-        .expect("register leaderboard_ws_connections_total"),
+            leaderboard_ws_connections_total: register_gauge!(
+                "leaderboard_ws_connections_total",
+                "Current number of open leaderboard WebSocket connections"
+            )
+            .expect("register leaderboard_ws_connections_total"),
         }
     })
 }
@@ -216,13 +216,28 @@ mod tests {
         dec_leaderboard_ws_connections();
 
         let output = render_metrics().expect("render");
-        assert!(output.contains("totp_verifications_total"), "missing totp counter");
-        assert!(output.contains("recovery_code_uses_total"), "missing recovery counter");
-        assert!(output.contains("rate_limit_hits_total"), "missing rate limit counter");
+        assert!(
+            output.contains("totp_verifications_total"),
+            "missing totp counter"
+        );
+        assert!(
+            output.contains("recovery_code_uses_total"),
+            "missing recovery counter"
+        );
+        assert!(
+            output.contains("rate_limit_hits_total"),
+            "missing rate limit counter"
+        );
         assert!(output.contains("db_pool_active"), "missing db_pool_active gauge");
         assert!(output.contains("db_pool_idle"), "missing db_pool_idle gauge");
-        assert!(output.contains("request_duration_seconds"), "missing histogram");
-        assert!(output.contains("leaderboard_ws_connections_total"), "missing leaderboard ws gauge");
+        assert!(
+            output.contains("request_duration_seconds"),
+            "missing histogram"
+        );
+        assert!(
+            output.contains("leaderboard_ws_connections_total"),
+            "missing leaderboard ws gauge"
+        );
         assert!(output.contains("build_info"), "missing build_info gauge");
     }
 
@@ -230,8 +245,14 @@ mod tests {
     fn build_info_gauge_present() {
         let output = render_metrics().expect("render");
         assert!(output.contains("build_info"), "build_info gauge missing");
-        assert!(output.contains(r#"version=""#), "build_info missing version label");
-        assert!(output.contains(r#"git_sha=""#), "build_info missing git_sha label");
+        assert!(
+            output.contains(r#"version=""#),
+            "build_info missing version label"
+        );
+        assert!(
+            output.contains(r#"git_sha=""#),
+            "build_info missing git_sha label"
+        );
     }
 
     #[test]

--- a/backend-2fa/src/tracing_middleware.rs
+++ b/backend-2fa/src/tracing_middleware.rs
@@ -169,7 +169,7 @@ where
             .or_else(|| {
                 // Fall back to generating a fresh trace context
                 Some(TraceContext {
-                    trace_id: Uuid::new_v4().to_string().replace("-", ""),
+                    trace_id: hex::encode(rand::random::<[u8; 16]>()),
                     parent_span_id: "0000000000000000".to_string(),
                     flags: "01".to_string(),
                 })
@@ -243,4 +243,33 @@ pub fn init_tracing() {
         .json()
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_trace_id_is_32_lowercase_hex() {
+        let trace_id = hex::encode(rand::random::<[u8; 16]>());
+        assert_eq!(trace_id.len(), 32, "trace_id must be 32 chars");
+        assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()), "trace_id must be hex");
+        // Ensure TraceContext::parse accepts it
+        let header = format!("00-{trace_id}-0000000000000000-01");
+        assert!(TraceContext::parse(&header).is_some());
+    }
+
+    #[test]
+    fn traceparent_parse_roundtrip() {
+        let tc = TraceContext {
+            trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".to_string(),
+            parent_span_id: "00f067aa0ba902b7".to_string(),
+            flags: "01".to_string(),
+        };
+        let header = tc.to_header();
+        let parsed = TraceContext::parse(&header).expect("should parse");
+        assert_eq!(parsed.trace_id, tc.trace_id);
+        assert_eq!(parsed.parent_span_id, tc.parent_span_id);
+        assert_eq!(parsed.flags, tc.flags);
+    }
 }

--- a/backend-2fa/src/tracing_middleware.rs
+++ b/backend-2fa/src/tracing_middleware.rs
@@ -253,7 +253,10 @@ mod tests {
     fn fallback_trace_id_is_32_lowercase_hex() {
         let trace_id = hex::encode(rand::random::<[u8; 16]>());
         assert_eq!(trace_id.len(), 32, "trace_id must be 32 chars");
-        assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()), "trace_id must be hex");
+        assert!(
+            trace_id.chars().all(|c| c.is_ascii_hexdigit()),
+            "trace_id must be hex"
+        );
         // Ensure TraceContext::parse accepts it
         let header = format!("00-{trace_id}-0000000000000000-01");
         assert!(TraceContext::parse(&header).is_some());


### PR DESCRIPTION
## Summary

Closes #877 
closes #878 
closes #879 

### #877 — build_info metric
- Added `backend-2fa/build.rs`: runs `git rev-parse --short HEAD` at build time and emits `GIT_SHA` as a `rustc-env` var (falls back to `"unknown"`).
- Registered `build_info` `GaugeVec` with labels `version` (`CARGO_PKG_VERSION`) and `git_sha` (`GIT_SHA`), set to `1` at init — following the Prometheus `*_build_info` convention.

### #878 — doc table
- Extended the `metrics.rs` module doc table with `webhook_deliveries_total` (Counter, `status`) and `webhook_delivery_duration_seconds` (Histogram).

### #879 — W3C trace entropy
- Replaced `Uuid::new_v4().to_string().replace("-", "")` fallback with `hex::encode(rand::random::<[u8; 16]>())` — 16 bytes of uniform randomness, no fixed version/variant bits.

## Tests
- `build_info_gauge_present`: asserts gauge name and both labels appear in `/metrics` output.
- `fallback_trace_id_is_32_lowercase_hex`: asserts length, charset, and `TraceContext::parse` acceptance.
- `traceparent_parse_roundtrip`: existing-style round-trip sanity check.