### PR TITLE
feat(#863): bounded retention for in-memory webhook delivery log

### DIFF
--- a/backend-2fa/Cargo.toml
+++ b/backend-2fa/Cargo.toml
@@ -28,6 +28,9 @@ redis = "0.27"
 prometheus = { version = "0.13", features = ["process"] }
 url = "2"
 
+[features]
+webhook-client = []
+
 [[example]]
 name = "example_integration"
 path = "examples/example_integration.rs"

--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -1,15 +1,22 @@
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, ToSocketAddrs};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 type HmacSha256 = Hmac<Sha256>;
 
 /// Header under which the webhook signature is sent.
 pub const SIGNATURE_HEADER: &str = "X-PetChain-Signature";
+
+/// Default maximum number of entries retained in the delivery log.
+/// Override with the `WEBHOOK_LOG_MAX_ENTRIES` environment variable.
+const DEFAULT_MAX_LOG_ENTRIES: usize = 1000;
 
 /// Compute the `sha256=<hex>` HMAC-SHA256 signature for a webhook body.
 pub fn sign_webhook_payload(secret: &str, body: &[u8]) -> String {
@@ -147,10 +154,8 @@ fn is_private_ip(ip: &IpAddr) -> bool {
 /// * Must use `https` (or `http` only when `allow_http` is true for testing).
 /// * Must not resolve to loopback, private, or link-local addresses.
 pub fn validate_webhook_url(url: &str, allow_http: bool) -> Result<(), WebhookUrlError> {
-    // Step 1: parse the URL
     let parsed = url::Url::parse(url).map_err(|e| WebhookUrlError::InvalidUrl(e.to_string()))?;
 
-    // Step 2: check scheme
     let scheme = parsed.scheme();
     match scheme {
         "https" => {}
@@ -158,14 +163,11 @@ pub fn validate_webhook_url(url: &str, allow_http: bool) -> Result<(), WebhookUr
         other => return Err(WebhookUrlError::DisallowedScheme(other.to_string())),
     }
 
-    // Step 3: extract host
     let host = parsed.host_str().ok_or(WebhookUrlError::MissingHost)?;
 
-    // Step 4: resolve hostname and check all addresses
     let port = parsed.port().unwrap_or(if scheme == "https" { 443 } else { 80 });
     let addr_str = format!("{host}:{port}");
 
-    // Try DNS resolution; if it fails we still reject known-bad hostnames
     if let Ok(addrs) = addr_str.to_socket_addrs() {
         for addr in addrs {
             if is_private_ip(&addr.ip()) {
@@ -173,7 +175,6 @@ pub fn validate_webhook_url(url: &str, allow_http: bool) -> Result<(), WebhookUr
             }
         }
     } else {
-        // DNS resolution failed — check for obvious private hostnames
         let lower = host.to_lowercase();
         if lower == "localhost"
             || lower == "127.0.0.1"
@@ -198,10 +199,10 @@ pub trait HttpClient: Send + Sync {
     fn post(&self, url: &str, body: &str, signature_header: &str) -> Result<(), String>;
 }
 
-/// Production HTTP client that performs a real HTTP POST via `ureq`.
+/// Production HTTP client that performs a real HTTP POST via raw TCP.
 ///
-/// Uses a 10-second timeout per request.  Falls back to no-op when URL
-/// validation has already been performed at configure() time.
+/// Uses a 10-second timeout per request. For HTTPS, inject a TLS-capable
+/// implementation via `WebhookManager::new`.
 pub struct DefaultHttpClient;
 
 #[cfg(feature = "webhook-client")]
@@ -209,7 +210,7 @@ static HTTP_CLIENT: std::sync::OnceLock<ureq::Agent> = std::sync::OnceLock::new(
 
 #[cfg(feature = "webhook-client")]
 impl HttpClient for DefaultHttpClient {
-    fn post(&self, url: &str, body: &str) -> Result<(), String> {
+    fn post(&self, url: &str, body: &str, signature_header: &str) -> Result<(), String> {
         let agent = HTTP_CLIENT.get_or_init(|| {
             ureq::builder()
                 .timeout(std::time::Duration::from_secs(10))
@@ -219,6 +220,7 @@ impl HttpClient for DefaultHttpClient {
         let response = agent
             .post(url)
             .set("Content-Type", "application/json")
+            .set(SIGNATURE_HEADER, signature_header)
             .send_string(body)
             .map_err(|e| format!("request failed: {}", e))?;
 
@@ -232,13 +234,7 @@ impl HttpClient for DefaultHttpClient {
 
 #[cfg(not(feature = "webhook-client"))]
 impl HttpClient for DefaultHttpClient {
-    fn post(&self, url: &str, body: &str) -> Result<(), String> {
-        // Use ureq for a synchronous blocking HTTP POST with a sane timeout.
-        // ureq is lightweight and does not require an async runtime.
-        // If ureq is not available, we fall back to a minimal TCP implementation.
-        //
-        // For now, use std::net to perform a basic HTTP POST — this avoids adding
-        // an external dependency while still performing a real request.
+    fn post(&self, url: &str, body: &str, signature_header: &str) -> Result<(), String> {
         use std::io::{Read, Write};
         use std::net::TcpStream;
 
@@ -248,14 +244,7 @@ impl HttpClient for DefaultHttpClient {
             .ok_or_else(|| "URL has no host".to_string())?;
         let port = parsed.port().unwrap_or(if parsed.scheme() == "https" { 443 } else { 80 });
 
-        // For HTTPS we cannot do raw TLS without a dependency, so for non-test
-        // deployments that need HTTPS, a TLS-capable client (reqwest/ureq) should
-        // be injected via `WebhookManager::new(client)`.
-        //
-        // This default implementation handles HTTP (test mode) to fulfil #860.
         if parsed.scheme() == "https" {
-            // HTTPS stub — log and succeed so that the delivery log is accurate.
-            // Production deployments should inject a TLS-capable HttpClient.
             eprintln!(
                 "[DefaultHttpClient] HTTPS not supported in default client; \
                  inject a TLS-capable HttpClient for production. url={url}"
@@ -274,12 +263,8 @@ impl HttpClient for DefaultHttpClient {
         )
         .map_err(|e| format!("connection failed: {e}"))?;
 
-        stream
-            .set_write_timeout(Some(Duration::from_secs(10)))
-            .ok();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(10)))
-            .ok();
+        stream.set_write_timeout(Some(Duration::from_secs(10))).ok();
+        stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
 
         let path = if parsed.path().is_empty() {
             "/"
@@ -290,6 +275,7 @@ impl HttpClient for DefaultHttpClient {
             "POST {path} HTTP/1.1\r\n\
              Host: {host}\r\n\
              Content-Type: application/json\r\n\
+             {SIGNATURE_HEADER}: {signature_header}\r\n\
              Content-Length: {}\r\n\
              Connection: close\r\n\
              \r\n\
@@ -306,7 +292,6 @@ impl HttpClient for DefaultHttpClient {
             .read_to_string(&mut response)
             .map_err(|e| format!("read failed: {e}"))?;
 
-        // Check for a 2xx status
         if let Some(status_line) = response.lines().next() {
             let parts: Vec<&str> = status_line.split_whitespace().collect();
             if parts.len() >= 2 {
@@ -324,17 +309,32 @@ impl HttpClient for DefaultHttpClient {
 }
 
 // ---------------------------------------------------------------------------
-// WebhookManager (Issues #861, #862)
+// WebhookManager (Issues #861, #862, #863)
 // ---------------------------------------------------------------------------
+
+/// Read the delivery-log capacity from the environment, falling back to `DEFAULT_MAX_LOG_ENTRIES`.
+fn log_cap_from_env() -> usize {
+    std::env::var("WEBHOOK_LOG_MAX_ENTRIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX_LOG_ENTRIES)
+}
 
 /// Manages webhook configuration and delivery with retry logic.
 pub struct WebhookManager {
     /// event_type -> webhook URL
     config: Arc<Mutex<HashMap<String, String>>>,
-    delivery_log: Arc<Mutex<Vec<WebhookDeliveryLog>>>,
+    /// Bounded ring buffer; oldest entries are evicted when `max_log_entries` is reached.
+    delivery_log: Arc<Mutex<VecDeque<WebhookDeliveryLog>>>,
+    /// Monotonically-increasing counter for log-entry IDs (survives eviction).
+    next_log_id: Arc<AtomicUsize>,
+    /// Maximum number of entries kept in `delivery_log`.
+    max_log_entries: usize,
     http_client: Arc<dyn HttpClient>,
     /// When true, allow http:// URLs (for test/dev environments).
     allow_http: bool,
+    /// HMAC-SHA256 secret used to sign outgoing payloads.
+    signing_secret: String,
 }
 
 impl Default for WebhookManager {
@@ -347,9 +347,12 @@ impl WebhookManager {
     pub fn new(http_client: Arc<dyn HttpClient>, signing_secret: String) -> Self {
         Self {
             config: Arc::new(Mutex::new(HashMap::new())),
-            delivery_log: Arc::new(Mutex::new(Vec::new())),
+            delivery_log: Arc::new(Mutex::new(VecDeque::new())),
+            next_log_id: Arc::new(AtomicUsize::new(0)),
+            max_log_entries: log_cap_from_env(),
             http_client,
             allow_http: false,
+            signing_secret,
         }
     }
 
@@ -357,16 +360,16 @@ impl WebhookManager {
     pub fn new_with_http_allowed(http_client: Arc<dyn HttpClient>) -> Self {
         Self {
             config: Arc::new(Mutex::new(HashMap::new())),
-            delivery_log: Arc::new(Mutex::new(Vec::new())),
+            delivery_log: Arc::new(Mutex::new(VecDeque::new())),
+            next_log_id: Arc::new(AtomicUsize::new(0)),
+            max_log_entries: log_cap_from_env(),
             http_client,
             allow_http: true,
+            signing_secret: String::new(),
         }
     }
 
     /// Admin: configure a webhook URL for a specific event type.
-    ///
-    /// The URL is validated before being stored. Returns an error if the URL
-    /// is invalid, uses a disallowed scheme, or resolves to a private address.
     pub fn configure(
         &self,
         event_type: SecurityEventType,
@@ -383,6 +386,14 @@ impl WebhookManager {
     /// Remove a webhook configuration for an event type.
     pub fn remove_config(&self, event_type: &SecurityEventType) {
         self.config.lock().unwrap().remove(&event_type.to_string());
+    }
+
+    /// Append an entry to the delivery log, evicting the oldest entry if the cap is reached.
+    fn append_log(&self, log: &mut VecDeque<WebhookDeliveryLog>, entry: WebhookDeliveryLog) {
+        if self.max_log_entries > 0 && log.len() >= self.max_log_entries {
+            log.pop_front();
+        }
+        log.push_back(entry);
     }
 
     /// Fire a webhook for the given event.
@@ -416,21 +427,22 @@ impl WebhookManager {
         };
 
         let body = serde_json::to_string(&payload).unwrap_or_default();
+        let signature = sign_webhook_payload(&self.signing_secret, body.as_bytes());
         let client = self.http_client.clone();
         let delivery_log = self.delivery_log.clone();
+        let next_log_id = self.next_log_id.clone();
+        let max_log_entries = self.max_log_entries;
         let url_clone = url.clone();
         let event_str = event_type.to_string();
         let user_str = user_id.to_string();
 
-        // Spawn the retry loop on a dedicated thread so we never block
-        // the caller's async executor (Issue #861).
         std::thread::spawn(move || {
             let mut attempts = 0u32;
             let mut last_error: Option<String> = None;
             let mut success = false;
 
             while attempts < 3 {
-                match client.post(&url_clone, &body) {
+                match client.post(&url_clone, &body, &signature) {
                     Ok(()) => {
                         success = true;
                         break;
@@ -439,7 +451,6 @@ impl WebhookManager {
                         last_error = Some(e);
                         attempts += 1;
                         if attempts < 3 {
-                            // Exponential backoff: 1s, 2s
                             let wait = Duration::from_secs(1u64 << (attempts - 1));
                             std::thread::sleep(wait);
                         }
@@ -447,9 +458,8 @@ impl WebhookManager {
                 }
             }
 
-            let mut log = delivery_log.lock().unwrap();
-            let id = log.len();
-            log.push(WebhookDeliveryLog {
+            let id = next_log_id.fetch_add(1, Ordering::Relaxed);
+            let entry = WebhookDeliveryLog {
                 id,
                 event_type: event_str,
                 user_id: user_str,
@@ -458,12 +468,16 @@ impl WebhookManager {
                 attempts: attempts + if success { 1 } else { 0 },
                 success,
                 last_error,
-            });
+            };
+            let mut log = delivery_log.lock().unwrap();
+            if max_log_entries > 0 && log.len() >= max_log_entries {
+                log.pop_front();
+            }
+            log.push_back(entry);
         });
     }
 
     /// Synchronous fire for testing — runs retry loop on the calling thread.
-    /// Use `fire` in production to avoid blocking the caller.
     pub fn fire_sync(
         &self,
         event_type: SecurityEventType,
@@ -490,13 +504,14 @@ impl WebhookManager {
         };
 
         let body = serde_json::to_string(&payload).unwrap_or_default();
+        let signature = sign_webhook_payload(&self.signing_secret, body.as_bytes());
 
         let mut attempts = 0u32;
         let mut last_error: Option<String> = None;
         let mut success = false;
 
         while attempts < 3 {
-            match self.http_client.post(&url, &body, &signature_header) {
+            match self.http_client.post(&url, &body, &signature) {
                 Ok(()) => {
                     success = true;
                     break;
@@ -512,9 +527,8 @@ impl WebhookManager {
             }
         }
 
-        let mut log = self.delivery_log.lock().unwrap();
-        let id = log.len();
-        log.push(WebhookDeliveryLog {
+        let id = self.next_log_id.fetch_add(1, Ordering::Relaxed);
+        let entry = WebhookDeliveryLog {
             id,
             event_type: event_type.to_string(),
             user_id: user_id.to_string(),
@@ -523,10 +537,12 @@ impl WebhookManager {
             attempts: attempts + if success { 1 } else { 0 },
             success,
             last_error,
-        });
+        };
+        let mut log = self.delivery_log.lock().unwrap();
+        self.append_log(&mut log, entry);
     }
 
-    /// Admin: query the delivery log (paginated, page starts at 1).
+    /// Admin: query the delivery log (paginated, page starts at 1, newest first).
     pub fn get_delivery_log(&self, page: u32, page_size: u32) -> Vec<WebhookDeliveryLog> {
         let log = self.delivery_log.lock().unwrap();
         let offset = (page.saturating_sub(1) as usize) * (page_size as usize);
@@ -538,7 +554,7 @@ impl WebhookManager {
             .collect()
     }
 
-    /// Return the number of entries in the delivery log.
+    /// Return the number of entries currently in the delivery log.
     pub fn delivery_log_count(&self) -> usize {
         self.delivery_log.lock().unwrap().len()
     }
@@ -576,15 +592,18 @@ mod tests {
         }
     }
 
-    const TEST_SIGNING_SECRET: &str = "test-signing-secret";
-
     fn make_manager(fail_times: u32) -> (WebhookManager, Arc<MockHttpClient>) {
         let client = Arc::new(MockHttpClient::new(fail_times));
         let manager = WebhookManager::new_with_http_allowed(client.clone());
         (manager, client)
     }
 
-    // --- Existing tests updated to use fire_sync and configure returning Result ---
+    fn make_manager_with_cap(fail_times: u32, cap: usize) -> (WebhookManager, Arc<MockHttpClient>) {
+        let client = Arc::new(MockHttpClient::new(fail_times));
+        let mut manager = WebhookManager::new_with_http_allowed(client.clone());
+        manager.max_log_entries = cap;
+        (manager, client)
+    }
 
     #[test]
     fn test_configure_and_fire_success() {
@@ -595,11 +614,7 @@ mod tests {
                 "http://example.com/hook".to_string(),
             )
             .unwrap();
-        manager.fire_sync(
-            SecurityEventType::FailedTwoFa,
-            "user1",
-            HashMap::new(),
-        );
+        manager.fire_sync(SecurityEventType::FailedTwoFa, "user1", HashMap::new());
         assert_eq!(mock.call_count.load(Ordering::SeqCst), 1);
         assert_eq!(manager.delivery_log_count(), 1);
         let log = manager.get_delivery_log(1, 10);
@@ -722,46 +737,31 @@ mod tests {
     #[test]
     fn test_validate_localhost_rejected() {
         let result = validate_webhook_url("https://localhost/hook", false);
-        assert!(matches!(
-            result,
-            Err(WebhookUrlError::PrivateAddress(_))
-        ));
+        assert!(matches!(result, Err(WebhookUrlError::PrivateAddress(_))));
     }
 
     #[test]
     fn test_validate_127_0_0_1_rejected() {
         let result = validate_webhook_url("https://127.0.0.1/hook", false);
-        assert!(matches!(
-            result,
-            Err(WebhookUrlError::PrivateAddress(_))
-        ));
+        assert!(matches!(result, Err(WebhookUrlError::PrivateAddress(_))));
     }
 
     #[test]
     fn test_validate_link_local_metadata_rejected() {
         let result = validate_webhook_url("http://169.254.169.254/latest/meta-data", true);
-        assert!(matches!(
-            result,
-            Err(WebhookUrlError::PrivateAddress(_))
-        ));
+        assert!(matches!(result, Err(WebhookUrlError::PrivateAddress(_))));
     }
 
     #[test]
     fn test_validate_private_10_range_rejected() {
         let result = validate_webhook_url("http://10.0.0.1/internal", true);
-        assert!(matches!(
-            result,
-            Err(WebhookUrlError::PrivateAddress(_))
-        ));
+        assert!(matches!(result, Err(WebhookUrlError::PrivateAddress(_))));
     }
 
     #[test]
     fn test_validate_private_192_168_rejected() {
         let result = validate_webhook_url("http://192.168.1.1/hook", true);
-        assert!(matches!(
-            result,
-            Err(WebhookUrlError::PrivateAddress(_))
-        ));
+        assert!(matches!(result, Err(WebhookUrlError::PrivateAddress(_))));
     }
 
     #[test]
@@ -808,24 +808,97 @@ mod tests {
             )
             .unwrap();
 
-        // fire() should return immediately (spawns a thread)
         let start = std::time::Instant::now();
-        manager.fire(
-            SecurityEventType::FailedTwoFa,
-            "user1",
-            HashMap::new(),
-        );
+        manager.fire(SecurityEventType::FailedTwoFa, "user1", HashMap::new());
         let elapsed = start.elapsed();
 
-        // Should return nearly instantly (well under 100ms)
         assert!(
             elapsed < Duration::from_millis(100),
             "fire() blocked for {:?}",
             elapsed
         );
 
-        // Wait for the spawned thread to complete
         std::thread::sleep(Duration::from_millis(200));
         assert_eq!(mock.call_count.load(Ordering::SeqCst), 1);
+    }
+
+    // --- Bounded log tests (Issue #863) ---
+
+    #[test]
+    fn test_log_does_not_exceed_cap() {
+        let cap = 5;
+        let (manager, _mock) = make_manager_with_cap(0, cap);
+        manager
+            .configure(
+                SecurityEventType::FailedTwoFa,
+                "http://example.com/hook".to_string(),
+            )
+            .unwrap();
+
+        for i in 0..10 {
+            manager.fire_sync(
+                SecurityEventType::FailedTwoFa,
+                &format!("user{}", i),
+                HashMap::new(),
+            );
+        }
+
+        assert_eq!(
+            manager.delivery_log_count(),
+            cap,
+            "log should be capped at {cap}"
+        );
+    }
+
+    #[test]
+    fn test_eviction_preserves_newest_entries() {
+        let cap = 3;
+        let (manager, _mock) = make_manager_with_cap(0, cap);
+        manager
+            .configure(
+                SecurityEventType::FailedTwoFa,
+                "http://example.com/hook".to_string(),
+            )
+            .unwrap();
+
+        for i in 0..5u32 {
+            manager.fire_sync(
+                SecurityEventType::FailedTwoFa,
+                &format!("user{}", i),
+                HashMap::new(),
+            );
+        }
+
+        // get_delivery_log returns newest-first; the 3 newest users are user4, user3, user2
+        let log = manager.get_delivery_log(1, cap as u32);
+        assert_eq!(log.len(), cap);
+        assert_eq!(log[0].user_id, "user4");
+        assert_eq!(log[1].user_id, "user3");
+        assert_eq!(log[2].user_id, "user2");
+    }
+
+    #[test]
+    fn test_log_ids_are_monotonic_after_eviction() {
+        let cap = 3;
+        let (manager, _mock) = make_manager_with_cap(0, cap);
+        manager
+            .configure(
+                SecurityEventType::FailedTwoFa,
+                "http://example.com/hook".to_string(),
+            )
+            .unwrap();
+
+        for i in 0..6 {
+            manager.fire_sync(
+                SecurityEventType::FailedTwoFa,
+                &format!("user{}", i),
+                HashMap::new(),
+            );
+        }
+
+        let log = manager.get_delivery_log(1, cap as u32);
+        // IDs should be monotonically increasing (newest first means descending IDs)
+        assert!(log[0].id > log[1].id);
+        assert!(log[1].id > log[2].id);
     }
 }


### PR DESCRIPTION
closes #863 
# Summary

- Replaces the unbounded `Vec` delivery log with a `VecDeque` capped at `WEBHOOK_LOG_MAX_ENTRIES` (env var, default 1000)
- Oldest entries are evicted when the cap is reached, preventing slow memory leaks on busy deployments
- `get_delivery_log` pagination behaviour is fully preserved (still returns newest-first)
- Log entry IDs use an `AtomicUsize` counter so they stay monotonically increasing after eviction
- Fixes pre-existing compile errors: missing `signing_secret` field, mismatched `HttpClient::post` arity, undefined `signature_header` in `fire_sync`, adds `webhook-client` optional feature to `Cargo.toml`

## Test plan

- [ ] `test_log_does_not_exceed_cap` — fires 10 events with a cap of 5; asserts count == 5
- [ ] `test_eviction_preserves_newest_entries` — cap of 3, fires 5; asserts newest 3 users remain
- [ ] `test_log_ids_are_monotonic_after_eviction` — IDs remain ascending across eviction boundary
- [ ] All pre-existing webhook tests continue to pass