### PR TITLE
fix/855: validate EndpointConfig fields at construction

### DIFF
--- a/backend-2fa/src/metrics.rs
+++ b/backend-2fa/src/metrics.rs
@@ -27,7 +27,7 @@
 //! no-op, rather than panicking the service.
 
 use prometheus::{
-    CounterVec, Gauge, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder,
+    CounterVec, Gauge, GaugeVec, HistogramOpts, HistogramVec, Opts, Registry, TextEncoder,
 };
 use std::sync::OnceLock;
 
@@ -46,6 +46,10 @@ pub struct Metrics {
     pub request_duration_seconds: HistogramVec,
     /// Tracks the current number of open leaderboard WebSocket connections.
     pub leaderboard_ws_connections_total: Gauge,
+    /// Total webhook delivery attempts with `result` label (`ok`/`fail`).
+    pub webhook_delivery_total: CounterVec,
+    /// Total webhook delivery retries (one per retry, not per initial attempt).
+    pub webhook_delivery_retries_total: prometheus::Counter,
     /// Dedicated Prometheus registry. All metrics in this struct are registered
     /// here, never in the global default registry.
     pub(crate) registry: Registry,
@@ -144,7 +148,41 @@ pub fn metrics() -> &'static Metrics {
             "leaderboard_ws_connections_total",
         );
 
+        let build_info = try_register(
+            &registry,
+            GaugeVec::new(
+                Opts::new("build_info", "Static build information"),
+                &["version", "git_sha"],
+            )
+            .expect("valid metric name"),
+            "build_info",
+        );
+        let version = env!("CARGO_PKG_VERSION");
+        let git_sha = option_env!("GIT_SHA").unwrap_or("");
+        build_info.with_label_values(&[version, git_sha]).set(1.0);
+
+        let webhook_delivery_total = try_register(
+            &registry,
+            CounterVec::new(
+                Opts::new("webhook_delivery_total", "Total webhook delivery attempts"),
+                &["result"],
+            )
+            .expect("valid metric name"),
+            "webhook_delivery_total",
+        );
+
+        let webhook_delivery_retries_total = try_register(
+            &registry,
+            prometheus::Counter::new(
+                "webhook_delivery_retries_total",
+                "Total webhook delivery retries",
+            )
+            .expect("valid metric name"),
+            "webhook_delivery_retries_total",
+        );
+
         Metrics {
+            build_info,
             totp_verifications_total,
             recovery_code_uses_total,
             rate_limit_hits_total,
@@ -153,6 +191,8 @@ pub fn metrics() -> &'static Metrics {
             db_pool_idle,
             request_duration_seconds,
             leaderboard_ws_connections_total,
+            webhook_delivery_total,
+            webhook_delivery_retries_total,
             registry,
         }
     })

--- a/backend-2fa/src/rate_limiter.rs
+++ b/backend-2fa/src/rate_limiter.rs
@@ -75,6 +75,14 @@ pub struct EndpointConfig {
 
 impl EndpointConfig {
     pub fn new(window_secs: u64, max_failures: u32, lockout_secs: u64) -> Self {
+        assert!(
+            window_secs > 0,
+            "EndpointConfig: window_secs must be greater than zero"
+        );
+        assert!(
+            max_failures > 0,
+            "EndpointConfig: max_failures must be greater than zero"
+        );
         Self {
             window_secs,
             max_failures,
@@ -881,6 +889,35 @@ impl RateLimiter for DistributedRateLimiter {
             }
         }
         self.fallback.record_success(key);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests for EndpointConfig validation (Issue #855)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod endpoint_config_tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_endpoint_config_is_accepted() {
+        let cfg = EndpointConfig::new(60, 5, 300);
+        assert_eq!(cfg.window_secs, 60);
+        assert_eq!(cfg.max_failures, 5);
+        assert_eq!(cfg.lockout_secs, 300);
+    }
+
+    #[test]
+    #[should_panic(expected = "EndpointConfig: max_failures must be greater than zero")]
+    fn test_zero_max_failures_panics() {
+        EndpointConfig::new(60, 0, 300);
+    }
+
+    #[test]
+    #[should_panic(expected = "EndpointConfig: window_secs must be greater than zero")]
+    fn test_zero_window_secs_panics() {
+        EndpointConfig::new(0, 5, 300);
     }
 }
 

--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -511,48 +511,35 @@ impl WebhookManager {
 
         let body = serde_json::to_string(&payload).unwrap_or_default();
         let signature = sign_webhook_payload(&self.signing_secret, body.as_bytes());
-        let client = self.http_client.clone();
-        let delivery_log = self.delivery_log.clone();
-        let url_clone = url.clone();
         let event_str = event_type.to_string();
         let user_str = user_id.to_string();
 
-        // Spawn the retry loop on a dedicated thread so we never block
-        // the caller's async executor (Issue #861).
-        std::thread::spawn(move || {
-            let mut attempts = 0u32;
-            let mut last_error: Option<String> = None;
-            let mut success = false;
+        for url in urls {
+            let url_clone = url.clone();
+            let client = self.http_client.clone();
+            let delivery_log = self.delivery_log.clone();
+            let next_log_id = self.next_log_id.clone();
+            let max_log_entries = self.max_log_entries;
+            let body_clone = body.clone();
+            let signature_clone = signature.clone();
+            let event_str_clone = event_str.clone();
+            let user_str_clone = user_str.clone();
 
-            while attempts < 3 {
-                match client.post(&url_clone, &body, &signature) {
-                    Ok(()) => {
-                        success = true;
-                        break;
-                    }
-                    Err(e) => {
-                        last_error = Some(e);
-                        attempts += 1;
-                        if attempts < 3 {
-                            // Exponential backoff: 1s, 2s
-                            let wait = Duration::from_secs(1u64 << (attempts - 1));
-                            std::thread::sleep(wait);
-                        }
-                    }
-                }
-            }
-
-            let mut log = delivery_log.lock().unwrap();
-            let id = log.len();
-            log.push(WebhookDeliveryLog {
-                id,
-                event_type: event_str,
-                user_id: user_str,
-                timestamp,
-                url: url_clone,
-                attempts: attempts + if success { 1 } else { 0 },
-                success,
-                last_error,
+            // Spawn the retry loop on a dedicated thread so we never block
+            // the caller's async executor (Issue #861).
+            std::thread::spawn(move || {
+                Self::deliver_one(
+                    client.as_ref(),
+                    &url_clone,
+                    &body_clone,
+                    &signature_clone,
+                    &event_str_clone,
+                    &user_str_clone,
+                    timestamp,
+                    &delivery_log,
+                    &next_log_id,
+                    max_log_entries,
+                );
             });
         }
     }
@@ -589,13 +576,15 @@ impl WebhookManager {
 
         let body = serde_json::to_string(&payload).unwrap_or_default();
         let signature_header = sign_webhook_payload(&self.signing_secret, body.as_bytes());
+        let event_str = event_type.to_string();
+        let user_str = user_id.to_string();
 
         for url in urls {
             Self::deliver_one(
                 self.http_client.as_ref(),
                 &url,
                 &body,
-                &signature,
+                &signature_header,
                 &event_str,
                 &user_str,
                 timestamp,


### PR DESCRIPTION
Closes #855

## Summary

- `EndpointConfig::new` in `backend-2fa/src/rate_limiter.rs` now validates that `window_secs > 0` and `max_failures == 0` at construction time, panicking with a clear message rather than silently misconfiguring the rate limiter.
- Three tests added: valid config succeeds, zero `max_failures` panics, zero `window_secs` panics.
- Also fixed two pre-existing compile errors that were blocking CI (details below).

## Changes

### `rate_limiter.rs` (issue #855)
- Added `assert!` guards in `EndpointConfig::new` for `window_secs > 0` and `max_failures > 0`.
- Added `endpoint_config_tests` module with three unit tests.

### `webhooks.rs` (pre-existing compile error — required to get CI green)
- `fire()` was missing the `for url in urls` loop; the single-URL spawn code also had an unclosed parenthesis and reimplemented retry logic instead of using `deliver_one`. Fixed by adding the loop and calling `deliver_one` per URL.
- `fire_sync()` referenced undefined variables `event_str`, `user_str`, and `signature` (correct name: `signature_header`). Fixed by defining the string variables before the loop and correcting the variable name.

### `metrics.rs` (pre-existing compile error — required to get CI green)
- Missing `use prometheus::GaugeVec` import for the `build_info` field.
- `build_info` `GaugeVec` metric was declared in the struct but never created or registered in `metrics()`.
- `webhook_delivery_total` (`CounterVec`) and `webhook_delivery_retries_total` (`Counter`) were referenced in helper functions but missing from the struct definition and initialiser.

## Test plan

- [x] `cargo test` — 267 passed, 0 failed, 4 ignored (Redis-integration tests skipped without a live Redis instance)
- [x] All three new `EndpointConfig` tests pass
- [x] All existing webhook and metrics tests pass