### PR TITLE
fix(#914): remove petId from _ownerPets[from] on transferPet

### DIFF
--- a/celo-contracts/contracts/PetChainRegistry.sol
+++ b/celo-contracts/contracts/PetChainRegistry.sol
@@ -151,6 +151,17 @@ contract PetChainRegistry {
         require(to != address(0), "PetChainRegistry: zero address");
         require(pets[petId].active, "PetChainRegistry: pet inactive");
         address from = pets[petId].owner;
+
+        // Remove petId from the previous owner's array (swap-and-pop)
+        uint256[] storage fromPets = _ownerPets[from];
+        for (uint256 i = 0; i < fromPets.length; i++) {
+            if (fromPets[i] == petId) {
+                fromPets[i] = fromPets[fromPets.length - 1];
+                fromPets.pop();
+                break;
+            }
+        }
+
         pets[petId].owner = to;
         _ownerPets[to].push(petId);
         emit PetTransferred(petId, from, to);

--- a/celo-contracts/test/PetChainRegistry.test.js
+++ b/celo-contracts/test/PetChainRegistry.test.js
@@ -174,6 +174,38 @@ describe("PetChainRegistry", function () {
   });
 
   // ---------------------------------------------------------------------------
+  // Issue #914 — transferPet removes petId from previous owner's _ownerPets
+  // ---------------------------------------------------------------------------
+  describe("#914 — transferPet removes stale _ownerPets entry", function () {
+    it("pet no longer appears in previous owner's getPetsByOwner after transfer", async function () {
+      const petId = await registerPet();
+
+      await registry.connect(owner).transferPet(petId, other.address);
+
+      const fromPets = await registry.getPetsByOwner(owner.address);
+      expect(fromPets.map(id => id.toString())).to.not.include(petId.toString());
+
+      const toPets = await registry.getPetsByOwner(other.address);
+      expect(toPets.map(id => id.toString())).to.include(petId.toString());
+    });
+
+    it("multiple transfers leave no stale entries in intermediate owners", async function () {
+      const petId = await registerPet();
+
+      await registry.connect(owner).transferPet(petId, other.address);
+      await registry.connect(other).transferPet(petId, admin.address);
+
+      const ownerPets = await registry.getPetsByOwner(owner.address);
+      const otherPets = await registry.getPetsByOwner(other.address);
+      const adminPets = await registry.getPetsByOwner(admin.address);
+
+      expect(ownerPets.map(id => id.toString())).to.not.include(petId.toString());
+      expect(otherPets.map(id => id.toString())).to.not.include(petId.toString());
+      expect(adminPets.map(id => id.toString())).to.include(petId.toString());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Issue #919 — registerPet input length validation
   // ---------------------------------------------------------------------------
   describe("#919 — registerPet string validation", function () {


### PR DESCRIPTION
Use swap-and-pop to remove petId from the previous owner's _ownerPets array before assigning to the new owner, preventing stale entries.

Add regression tests asserting the old owner's getPetsByOwner no longer includes the transferred pet, and that multi-hop transfers leave no stale entries in intermediate owners' arrays.

# Pull Request

## Related Issue

Closes #[issue_id]

## Description of Changes

<!-- Provide a clear and concise description of what this PR does. -->
<!-- Explain the problem this PR solves and how it addresses it. -->

## Type of Change

<!-- Please check the relevant option(s) by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->
<!-- Include details of your testing environment. -->

- [ ] All existing tests pass (`cargo test`)
- [ ] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [ ] Manually verified expected behavior

### Test Environment

- Rust version:
- Stellar CLI version:
- OS:

## Checklist

<!-- Please check all that apply by replacing [ ] with [x]. -->

- [ ] My code follows the project's code style guidelines (`cargo fmt`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] No hardcoded secrets, keys, or credentials are included in this PR
- [ ] No plaintext encryption keys or sensitive data are exposed in the code
- [ ] Input validation is properly implemented for all public functions
- [ ] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

<!-- If this PR touches security-sensitive code, describe the security implications. -->
<!-- For encryption, access control, or authentication changes, detail your approach. -->

## Screenshots / Logs (if applicable)

<!-- Add any relevant screenshots, logs, or output to help illustrate the changes. -->

## Additional Notes

<!-- Add any other context or notes about the PR here. -->

Closes #914 
