### PR TITLE
Fix/configurable 2fa params

### DIFF
--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -593,11 +593,13 @@ impl TwoFactorStore for PostgresTwoFactorStore {
             .unwrap_or_default())
     }
 
-    fn record_failed_two_fa_attempt(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+    fn record_failed_two_fa_attempt(
+        &self,
+        user_id: &str,
+        lockout_threshold: u32,
+    ) -> Result<TwoFactorLockoutState, String> {
         let user_id = user_id.to_string();
-        // with_retry covers the INSERT/UPDATE round-trip.  get_lockout_state is
-        // a separate retried read — the two with_retry calls are sequential, not
-        // nested, so there is no double-wrapping.
+        let threshold = lockout_threshold as i32;
         self.with_retry(|| {
             self.block_on_typed(
                 sqlx::query(
@@ -607,9 +609,9 @@ impl TwoFactorStore for PostgresTwoFactorStore {
                 ON CONFLICT (user_id)
                 DO UPDATE SET
                     failed_attempts = two_fa_lockouts.failed_attempts + 1,
-                    locked = (two_fa_lockouts.failed_attempts + 1) >= 10,
+                    locked = (two_fa_lockouts.failed_attempts + 1) >= $2,
                     locked_at = CASE
-                        WHEN (two_fa_lockouts.failed_attempts + 1) >= 10
+                        WHEN (two_fa_lockouts.failed_attempts + 1) >= $2
                              AND two_fa_lockouts.locked_at IS NULL
                         THEN CURRENT_TIMESTAMP
                         ELSE two_fa_lockouts.locked_at
@@ -618,6 +620,7 @@ impl TwoFactorStore for PostgresTwoFactorStore {
                 "#,
                 )
                 .bind(&user_id)
+                .bind(threshold)
                 .execute(&self.pool),
             )
             .map(|_| ())

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -187,6 +187,8 @@ pub struct TwoFactorHandlers {
 }
 
 impl TwoFactorHandlers {
+    const DEFAULT_LOCKOUT_THRESHOLD: u32 = 10;
+
     pub fn new() -> Self {
         Self {
             limiter: Arc::new(InMemoryRateLimiter::default()),
@@ -260,11 +262,11 @@ impl TwoFactorHandlers {
     fn record_failed_verification(&self, user_id: &str) -> Result<(), ApiError> {
         let state = self
             .store
-            .record_failed_two_fa_attempt(user_id)
+            .record_failed_two_fa_attempt(user_id, Self::DEFAULT_LOCKOUT_THRESHOLD)
             .map_err(|e| ApiError::internal_error(e, None))?;
         if state.locked {
             return Err(ApiError::locked(
-                "2FA account locked after 10 failed attempts. Use admin unlock or a recovery code.",
+                "2FA account locked due to too many failed attempts. Use admin unlock or a recovery code.",
                 None,
             ));
         }

--- a/backend-2fa/src/health.rs
+++ b/backend-2fa/src/health.rs
@@ -1,0 +1,127 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubsystemStatus {
+    Healthy,
+    Unhealthy(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthReport {
+    pub healthy: bool,
+    pub subsystems: HashMap<String, SubsystemStatus>,
+}
+
+pub trait HealthCheck: Send + Sync {
+    fn name(&self) -> &str;
+    fn check(&self) -> SubsystemStatus;
+}
+
+pub struct PostgresHealthCheck<'a> {
+    store: &'a crate::db::PostgresTwoFactorStore,
+}
+
+impl<'a> PostgresHealthCheck<'a> {
+    pub fn new(store: &'a crate::db::PostgresTwoFactorStore) -> Self {
+        Self { store }
+    }
+}
+
+impl HealthCheck for PostgresHealthCheck<'_> {
+    fn name(&self) -> &str {
+        "postgres"
+    }
+
+    fn check(&self) -> SubsystemStatus {
+        match self.store.health_check() {
+            Ok(()) => SubsystemStatus::Healthy,
+            Err(e) => SubsystemStatus::Unhealthy(e),
+        }
+    }
+}
+
+pub struct RedisHealthCheck {
+    client: redis::Client,
+}
+
+impl RedisHealthCheck {
+    pub fn new(redis_url: &str) -> Result<Self, String> {
+        let client = redis::Client::open(redis_url).map_err(|e| e.to_string())?;
+        Ok(Self { client })
+    }
+}
+
+impl HealthCheck for RedisHealthCheck {
+    fn name(&self) -> &str {
+        "redis"
+    }
+
+    fn check(&self) -> SubsystemStatus {
+        match self.client.get_connection() {
+            Ok(mut con) => {
+                let result: Result<String, _> = redis::cmd("PING").query(&mut con);
+                match result {
+                    Ok(_) => SubsystemStatus::Healthy,
+                    Err(e) => SubsystemStatus::Unhealthy(e.to_string()),
+                }
+            }
+            Err(e) => SubsystemStatus::Unhealthy(e.to_string()),
+        }
+    }
+}
+
+pub struct WebhookHealthCheck<'a> {
+    manager: &'a crate::webhooks::WebhookManager,
+}
+
+impl<'a> WebhookHealthCheck<'a> {
+    pub fn new(manager: &'a crate::webhooks::WebhookManager) -> Self {
+        Self { manager }
+    }
+}
+
+impl HealthCheck for WebhookHealthCheck<'_> {
+    fn name(&self) -> &str {
+        "webhooks"
+    }
+
+    fn check(&self) -> SubsystemStatus {
+        let _ = self.manager.delivery_log_count();
+        SubsystemStatus::Healthy
+    }
+}
+
+pub struct HealthAggregator<'a> {
+    checks: Vec<Box<dyn HealthCheck + 'a>>,
+}
+
+impl<'a> HealthAggregator<'a> {
+    pub fn new() -> Self {
+        Self { checks: Vec::new() }
+    }
+
+    pub fn add_check(mut self, check: Box<dyn HealthCheck + 'a>) -> Self {
+        self.checks.push(check);
+        self
+    }
+
+    pub fn check_all(&self) -> HealthReport {
+        let mut subsystems = HashMap::new();
+        let mut all_healthy = true;
+
+        for check in &self.checks {
+            let status = check.check();
+            if status != SubsystemStatus::Healthy {
+                all_healthy = false;
+            }
+            subsystems.insert(check.name().to_string(), status);
+        }
+
+        HealthReport {
+            healthy: all_healthy,
+            subsystems,
+        }
+    }
+}

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -61,6 +61,6 @@ pub use two_factor::{
     TwoFactorStore, UserTwoFactorSummary,
 };
 pub use webhooks::{
-    DefaultHttpClient, HttpClient, RetryPolicy, SecurityEventType, WebhookDeliveryLog,
-    WebhookManager, WebhookPayload, WebhookUrlError, validate_webhook_url,
+    DefaultHttpClient, DeliveryLogFilter, HttpClient, RetryPolicy, SecurityEventType,
+    WebhookDeliveryLog, WebhookManager, WebhookPayload, WebhookUrlError, validate_webhook_url,
 };

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod db;
 pub mod error;
 pub mod handlers;
+pub mod health;
 pub mod ip_access;
 pub mod leaderboard;
 pub mod metrics;
@@ -48,6 +49,10 @@ pub use rate_limiter::{
     LiveRedisBackend, MockRedisBackend, RateLimitResult, RateLimiter, RedisBackend,
     RedisRateLimiter, RedisTwoFactorFailureCounter, SlidingWindowRateLimiter,
     TenantRateLimitKey,
+};
+pub use health::{
+    HealthAggregator, HealthCheck, HealthReport, PostgresHealthCheck, RedisHealthCheck,
+    SubsystemStatus, WebhookHealthCheck,
 };
 pub use tracing_middleware::sanitize_json_body;
 pub use two_factor::{

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -56,6 +56,6 @@ pub use two_factor::{
     TwoFactorStore, UserTwoFactorSummary,
 };
 pub use webhooks::{
-    DefaultHttpClient, HttpClient, SecurityEventType, WebhookDeliveryLog, WebhookManager,
-    WebhookPayload, WebhookUrlError, validate_webhook_url,
+    DefaultHttpClient, HttpClient, RetryPolicy, SecurityEventType, WebhookDeliveryLog,
+    WebhookManager, WebhookPayload, WebhookUrlError, validate_webhook_url,
 };

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -3535,12 +3535,12 @@ mod progressive_two_factor_lockout_tests {
     fn persistent_store_locks_after_ten_failures() {
         let store = InMemoryStore::default();
         for attempt in 1..=9 {
-            let state = store.record_failed_two_fa_attempt("user-lock").unwrap();
+            let state = store.record_failed_two_fa_attempt("user-lock", 10).unwrap();
             assert_eq!(state.failed_attempts, attempt);
             assert!(!state.locked);
         }
 
-        let state = store.record_failed_two_fa_attempt("user-lock").unwrap();
+        let state = store.record_failed_two_fa_attempt("user-lock", 10).unwrap();
         assert_eq!(state.failed_attempts, 10);
         assert!(state.locked);
         assert!(state.locked_at.is_some());
@@ -3551,7 +3551,7 @@ mod progressive_two_factor_lockout_tests {
         let store = InMemoryStore::default();
         for _ in 0..10 {
             store
-                .record_failed_two_fa_attempt("user-admin-unlock")
+                .record_failed_two_fa_attempt("user-admin-unlock", 10)
                 .unwrap();
         }
         assert!(store.get_lockout_state("user-admin-unlock").unwrap().locked);

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -352,8 +352,12 @@ pub trait TwoFactorStore: Send + Sync {
     /// Persistent lockout state, used after Redis restarts.
     fn get_lockout_state(&self, user_id: &str) -> Result<TwoFactorLockoutState, String>;
 
-    /// Increment failed 2FA attempts and persist lockout after the tenth failure.
-    fn record_failed_two_fa_attempt(&self, user_id: &str) -> Result<TwoFactorLockoutState, String>;
+    /// Increment failed 2FA attempts and persist lockout once the threshold is reached.
+    fn record_failed_two_fa_attempt(
+        &self,
+        user_id: &str,
+        lockout_threshold: u32,
+    ) -> Result<TwoFactorLockoutState, String>;
 
     /// Reset failed attempts after a successful TOTP verification or recovery.
     fn reset_two_fa_failures(&self, user_id: &str) -> Result<(), String>;
@@ -592,6 +596,7 @@ impl TwoFactorStore for MockTwoFactorStore {
     fn record_failed_two_fa_attempt(
         &self,
         _user_id: &str,
+        _lockout_threshold: u32,
     ) -> Result<TwoFactorLockoutState, String> {
         Ok(TwoFactorLockoutState::default())
     }
@@ -797,7 +802,11 @@ impl TwoFactorStore for InMemoryStore {
             .unwrap_or_default())
     }
 
-    fn record_failed_two_fa_attempt(&self, user_id: &str) -> Result<TwoFactorLockoutState, String> {
+    fn record_failed_two_fa_attempt(
+        &self,
+        user_id: &str,
+        lockout_threshold: u32,
+    ) -> Result<TwoFactorLockoutState, String> {
         let mut lockouts = self.lockouts.lock().unwrap();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -806,7 +815,7 @@ impl TwoFactorStore for InMemoryStore {
         let state = lockouts.entry(user_id.to_string()).or_default();
         state.failed_attempts = state.failed_attempts.saturating_add(1);
         state.updated_at = now;
-        if state.failed_attempts >= 10 {
+        if state.failed_attempts >= lockout_threshold {
             state.locked = true;
             state.locked_at = Some(now);
         }
@@ -835,6 +844,7 @@ pub struct TenantConfig {
     pub tenant_id: String,
     pub totp_issuer: String,
     pub rate_limit_max_failures: u32,
+    pub lockout_threshold: u32,
 }
 
 impl TenantConfig {
@@ -843,6 +853,7 @@ impl TenantConfig {
             tenant_id: tenant_id.into(),
             totp_issuer: "PetChain".to_string(),
             rate_limit_max_failures: 5,
+            lockout_threshold: 10,
         }
     }
 }
@@ -933,7 +944,8 @@ impl TenantScopedStore {
         &self,
         user_id: &str,
     ) -> Result<TwoFactorLockoutState, String> {
-        self.inner.record_failed_two_fa_attempt(&self.key(user_id))
+        self.inner
+            .record_failed_two_fa_attempt(&self.key(user_id), self.config.lockout_threshold)
     }
 
     pub fn reset_two_fa_failures(&self, user_id: &str) -> Result<(), String> {

--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -94,6 +94,13 @@ pub struct WebhookDeliveryLog {
     pub last_error: Option<String>,
 }
 
+/// Filter criteria for querying the delivery log.
+#[derive(Debug, Clone, Default)]
+pub struct DeliveryLogFilter {
+    pub event_type: Option<SecurityEventType>,
+    pub success: Option<bool>,
+}
+
 // ---------------------------------------------------------------------------
 // URL Validation (Issue #862)
 // ---------------------------------------------------------------------------
@@ -625,10 +632,35 @@ impl WebhookManager {
 
     /// Admin: query the delivery log (paginated, page starts at 1, newest first).
     pub fn get_delivery_log(&self, page: u32, page_size: u32) -> Vec<WebhookDeliveryLog> {
+        self.get_delivery_log_filtered(page, page_size, None)
+    }
+
+    /// Admin: query the delivery log with optional filters.
+    pub fn get_delivery_log_filtered(
+        &self,
+        page: u32,
+        page_size: u32,
+        filter: Option<&DeliveryLogFilter>,
+    ) -> Vec<WebhookDeliveryLog> {
         let log = self.delivery_log.lock().unwrap();
         let offset = (page.saturating_sub(1) as usize) * (page_size as usize);
         log.iter()
             .rev()
+            .filter(|entry| {
+                if let Some(f) = filter {
+                    if let Some(ref et) = f.event_type {
+                        if entry.event_type != et.to_string() {
+                            return false;
+                        }
+                    }
+                    if let Some(success_only) = f.success {
+                        if entry.success != success_only {
+                            return false;
+                        }
+                    }
+                }
+                true
+            })
             .skip(offset)
             .take(page_size as usize)
             .cloned()

--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -327,6 +327,22 @@ fn log_cap_from_env() -> usize {
         .unwrap_or(DEFAULT_MAX_LOG_ENTRIES)
 }
 
+/// Configurable retry policy for webhook delivery.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub base_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_backoff: Duration::from_secs(1),
+        }
+    }
+}
+
 /// Manages webhook configuration and delivery with retry logic.
 pub struct WebhookManager {
     /// event_type -> list of webhook URLs (multiple endpoints supported per event).
@@ -343,16 +359,21 @@ pub struct WebhookManager {
     /// HMAC-SHA256 signing secret used to compute `X-PetChain-Signature` headers.
     /// Empty string disables signing.
     signing_secret: String,
+    retry_policy: RetryPolicy,
 }
 
 impl Default for WebhookManager {
     fn default() -> Self {
-        Self::new(Arc::new(DefaultHttpClient), String::new())
+        Self::new(Arc::new(DefaultHttpClient), String::new(), None)
     }
 }
 
 impl WebhookManager {
-    pub fn new(http_client: Arc<dyn HttpClient>, signing_secret: String) -> Self {
+    pub fn new(
+        http_client: Arc<dyn HttpClient>,
+        signing_secret: String,
+        retry_policy: Option<RetryPolicy>,
+    ) -> Self {
         Self {
             config: Arc::new(Mutex::new(HashMap::new())),
             delivery_log: Arc::new(Mutex::new(VecDeque::new())),
@@ -361,6 +382,7 @@ impl WebhookManager {
             http_client,
             allow_http: false,
             signing_secret,
+            retry_policy: retry_policy.unwrap_or_default(),
         }
     }
 
@@ -374,6 +396,7 @@ impl WebhookManager {
             http_client,
             allow_http: true,
             signing_secret: String::new(),
+            retry_policy: RetryPolicy::default(),
         }
     }
 
@@ -436,12 +459,13 @@ impl WebhookManager {
         delivery_log: &Mutex<VecDeque<WebhookDeliveryLog>>,
         next_log_id: &AtomicUsize,
         max_log_entries: usize,
+        retry_policy: &RetryPolicy,
     ) {
         let mut attempts = 0u32;
         let mut last_error: Option<String> = None;
         let mut success = false;
 
-        while attempts < 3 {
+        while attempts < retry_policy.max_attempts {
             match client.post(url, body, signature) {
                 Ok(()) => {
                     success = true;
@@ -450,9 +474,10 @@ impl WebhookManager {
                 Err(e) => {
                     last_error = Some(e);
                     attempts += 1;
-                    if attempts < 3 {
+                    if attempts < retry_policy.max_attempts {
                         record_webhook_retry();
-                        let wait = Duration::from_secs(1u64 << (attempts - 1));
+                        let multiplier = 1u64 << (attempts - 1);
+                        let wait = retry_policy.base_backoff * multiplier as u32;
                         std::thread::sleep(wait);
                     }
                 }
@@ -524,6 +549,7 @@ impl WebhookManager {
             let signature_clone = signature.clone();
             let event_str_clone = event_str.clone();
             let user_str_clone = user_str.clone();
+            let retry_policy = self.retry_policy.clone();
 
             // Spawn the retry loop on a dedicated thread so we never block
             // the caller's async executor (Issue #861).
@@ -539,6 +565,7 @@ impl WebhookManager {
                     &delivery_log,
                     &next_log_id,
                     max_log_entries,
+                    &retry_policy,
                 );
             });
         }
@@ -591,6 +618,7 @@ impl WebhookManager {
                 &self.delivery_log,
                 &self.next_log_id,
                 self.max_log_entries,
+                &self.retry_policy,
             );
         }
     }


### PR DESCRIPTION
closes #903
closes #904
closes #905
closes #906

record_failed_two_fa_attempt hardcodes >= 10 as the lockout threshold in both InMemoryStore (backend-2fa/src/two_factor.rs) and PostgresTwoFactorStore (backend-2fa/src/db.rs). TenantConfig.rate_limit_max_failures only configures the separate in-process RateLimiter used by MultiTenantHandlers, not this persistent lockout threshold — the two thresholds are unrelated despite both being about "how many failures before blocking".
WebhookManager::fire (backend-2fa/src/webhooks.rs) hardcodes while attempts < 3 and a fixed 1s, 2s, 4s exponential backoff with no way to tune either value.
PostgresTwoFactorStore::health_check() exists (backend-2fa/src/db.rs) but nothing aggregates it with Redis reachability (used by LiveRedisBackend/DistributedRateLimiter) or basic webhook-manager sanity into a single liveness/readiness endpoint for orchestrators.



