### PR TITLE
Fix/admin locked retry webhook fuzz

### DIFF
--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -1,8 +1,8 @@
 use crate::ip_access::{CidrBlock, IpAccessEntry, IpAccessStore, IpListType};
 use crate::two_factor::HmacAlgorithm;
 use crate::two_factor::{
-    AuditLogEntry, RecoveryCodeUsageLog, TwoFactorData, TwoFactorLockoutState, TwoFactorStore,
-    UserTwoFactorSummary,
+    AuditLogEntry, LockedUserSummary, RecoveryCodeUsageLog, TwoFactorData, TwoFactorLockoutState,
+    TwoFactorStore, UserTwoFactorSummary,
 };
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::collections::HashMap;
@@ -641,6 +641,39 @@ impl TwoFactorStore for PostgresTwoFactorStore {
         self.reset_two_fa_failures(user_id)?;
         self.append_audit_log(user_id, "two_fa_account_unlocked", actor, None)?;
         Ok(())
+    }
+
+    fn list_locked_users(&self) -> Result<Vec<LockedUserSummary>, String> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            user_id: String,
+            failed_attempts: i32,
+            locked_at: Option<i64>,
+        }
+
+        let rows = self.with_retry(|| {
+            self.block_on_typed(
+                sqlx::query_as::<_, Row>(
+                    r#"
+                SELECT user_id, failed_attempts,
+                       EXTRACT(EPOCH FROM locked_at)::bigint AS locked_at
+                FROM two_fa_lockouts
+                WHERE locked = TRUE
+                ORDER BY user_id
+                "#,
+                )
+                .fetch_all(&self.pool),
+            )
+        })?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| LockedUserSummary {
+                user_id: r.user_id,
+                failed_attempts: r.failed_attempts.max(0) as u32,
+                locked_at: r.locked_at.map(|ts| ts as u64),
+            })
+            .collect())
     }
 
     fn try_pool_stats(&self) -> Option<PoolStats> {

--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -977,6 +977,84 @@ mod tests {
         assert!(result.unwrap_err().contains("timeout"));
     }
 
+    #[test]
+    fn is_connection_error_returns_false_for_non_connection_errors() {
+        let unique_violation = sqlx::Error::Database(Box::new(FakeDatabaseError {
+            message: "duplicate key value violates unique constraint".to_string(),
+        }));
+        assert!(
+            !is_connection_error(&unique_violation),
+            "unique-constraint violation must not be classified as a connection error"
+        );
+
+        let row_not_found = sqlx::Error::RowNotFound;
+        assert!(
+            !is_connection_error(&row_not_found),
+            "RowNotFound must not be classified as a connection error"
+        );
+
+        let decode = sqlx::Error::Protocol("unexpected message".to_string());
+        assert!(
+            !is_connection_error(&decode),
+            "Protocol error must not be classified as a connection error"
+        );
+    }
+
+    #[test]
+    fn is_connection_error_returns_true_for_connection_errors() {
+        let io_err = sqlx::Error::Io(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "connection reset",
+        ));
+        assert!(is_connection_error(&io_err));
+
+        let pool_timeout = sqlx::Error::PoolTimedOut;
+        assert!(is_connection_error(&pool_timeout));
+
+        let pool_closed = sqlx::Error::PoolClosed;
+        assert!(is_connection_error(&pool_closed));
+    }
+
+    struct FakeDatabaseError {
+        message: String,
+    }
+
+    impl std::fmt::Debug for FakeDatabaseError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FakeDatabaseError({})", self.message)
+        }
+    }
+
+    impl std::fmt::Display for FakeDatabaseError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl std::error::Error for FakeDatabaseError {}
+
+    impl sqlx::error::DatabaseError for FakeDatabaseError {
+        fn message(&self) -> &str {
+            &self.message
+        }
+
+        fn as_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+            self
+        }
+
+        fn kind(&self) -> sqlx::error::ErrorKind {
+            sqlx::error::ErrorKind::UniqueViolation
+        }
+    }
+
     /// String-based analogue of `is_connection_error` used by the test helper
     /// below (which works with `String` errors rather than `sqlx::Error`).
     fn is_connection_error_str(e: &str) -> bool {

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -6,8 +6,9 @@ use crate::rate_limiter::{
     InMemoryRateLimiter, RateLimitResult, RateLimiter, TenantRateLimitKey, UserQuotaStore,
 };
 use crate::two_factor::{
-    AuditLogEntry, HmacAlgorithm, InMemoryStore, TenantConfig, TenantRegistry, TenantScopedStore,
-    TotpConfig, TwoFactorAuth, TwoFactorData, TwoFactorStore, UserTwoFactorSummary,
+    AuditLogEntry, HmacAlgorithm, InMemoryStore, LockedUserSummary, TenantConfig, TenantRegistry,
+    TenantScopedStore, TotpConfig, TwoFactorAuth, TwoFactorData, TwoFactorStore,
+    UserTwoFactorSummary,
 };
 use crate::webhooks::{SecurityEventType, WebhookManager};
 use actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
@@ -809,6 +810,13 @@ impl AdminDashboardHandlers {
     /// POST /admin/users/{id}/unlock-2fa — clear persistent lockout state.
     pub fn unlock_two_fa(admin: &AuthenticatedAdmin, user_id: &str) -> Result<(), String> {
         two_factor_store().unlock_two_fa_account(user_id, &admin.admin_id)
+    }
+
+    /// GET /admin/locked-users — list all accounts currently in a locked state.
+    pub fn list_locked_users(
+        _admin: &AuthenticatedAdmin,
+    ) -> Result<Vec<LockedUserSummary>, String> {
+        two_factor_store().list_locked_users()
     }
 
     /// GET /admin/users/{id}/audit-log — full 2FA event history (paginated).

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -51,9 +51,9 @@ pub use rate_limiter::{
 };
 pub use tracing_middleware::sanitize_json_body;
 pub use two_factor::{
-    AuditLogEntry, InMemoryStore, RecoveryResult, TenantConfig, TenantRegistry, TenantScopedStore,
-    TotpConfig, TwoFactorAuth, TwoFactorData, TwoFactorLockoutState, TwoFactorSetup,
-    TwoFactorStore, UserTwoFactorSummary,
+    AuditLogEntry, InMemoryStore, LockedUserSummary, RecoveryResult, TenantConfig, TenantRegistry,
+    TenantScopedStore, TotpConfig, TwoFactorAuth, TwoFactorData, TwoFactorLockoutState,
+    TwoFactorSetup, TwoFactorStore, UserTwoFactorSummary,
 };
 pub use webhooks::{
     DefaultHttpClient, HttpClient, SecurityEventType, WebhookDeliveryLog, WebhookManager,

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -3080,7 +3080,7 @@ mod admin_dashboard_tests {
         clear_two_factor_store_for_tests, get_two_factor_store_for_tests, AdminDashboardHandlers,
         AuthenticatedAdmin, AuthenticatedUser,
     };
-    use crate::two_factor::TwoFactorData;
+    use crate::two_factor::{TwoFactorData, TwoFactorStore};
     use totp_rs::Algorithm;
 
     fn admin() -> AuthenticatedAdmin {
@@ -3173,6 +3173,46 @@ mod admin_dashboard_tests {
         let ids: Vec<&str> = users.iter().map(|u| u.user_id.as_str()).collect();
         assert!(ids.contains(&"normal-user"));
         assert!(!ids.contains(&"canary-user"));
+    }
+
+    #[test]
+    fn test_list_locked_users_returns_only_locked_accounts() {
+        clear_two_factor_store_for_tests();
+        setup_user("locked-user-a");
+        setup_user("locked-user-b");
+        setup_user("unlocked-user");
+
+        let store = get_two_factor_store_for_tests();
+        // Lock two accounts by recording 10 failed attempts each
+        for _ in 0..10 {
+            store.record_failed_two_fa_attempt("locked-user-a").unwrap();
+            store.record_failed_two_fa_attempt("locked-user-b").unwrap();
+        }
+        // Record a few failures for the unlocked user (not enough to lock)
+        for _ in 0..3 {
+            store.record_failed_two_fa_attempt("unlocked-user").unwrap();
+        }
+
+        let locked = AdminDashboardHandlers::list_locked_users(&admin()).unwrap();
+        let ids: Vec<&str> = locked.iter().map(|u| u.user_id.as_str()).collect();
+        assert_eq!(locked.len(), 2);
+        assert!(ids.contains(&"locked-user-a"));
+        assert!(ids.contains(&"locked-user-b"));
+        assert!(!ids.contains(&"unlocked-user"));
+
+        for entry in &locked {
+            assert!(entry.failed_attempts >= 10);
+            assert!(entry.locked_at.is_some());
+        }
+    }
+
+    #[test]
+    fn test_list_locked_users_empty_when_none_locked() {
+        clear_two_factor_store_for_tests();
+        setup_user("healthy-user");
+
+        let locked = AdminDashboardHandlers::list_locked_users(&admin()).unwrap();
+        assert!(locked.is_empty());
     }
 }
 

--- a/backend-2fa/src/tracing_middleware.rs
+++ b/backend-2fa/src/tracing_middleware.rs
@@ -263,6 +263,115 @@ mod tests {
     }
 
     #[test]
+    fn parse_rejects_empty_string() {
+        assert!(TraceContext::parse("").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_wrong_segment_count() {
+        assert!(TraceContext::parse("00").is_none());
+        assert!(TraceContext::parse("00-abc").is_none());
+        assert!(TraceContext::parse("00-abc-def").is_none());
+        assert!(TraceContext::parse("00-a-b-c-d").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_non_hex_characters() {
+        assert!(TraceContext::parse(
+            "zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ).is_none());
+        assert!(TraceContext::parse(
+            "00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-00f067aa0ba902b7-01"
+        ).is_none());
+        assert!(TraceContext::parse(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-ghijklmnopqrstuv-01"
+        ).is_none());
+        assert!(TraceContext::parse(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-xx"
+        ).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_wrong_length_segments() {
+        assert!(TraceContext::parse(
+            "0-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ).is_none());
+        assert!(TraceContext::parse(
+            "00-4bf92f3577b34da6a3ce929d0e0e473-00f067aa0ba902b7-01"
+        ).is_none());
+        assert!(TraceContext::parse(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b-01"
+        ).is_none());
+        assert!(TraceContext::parse(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0"
+        ).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_multibyte_unicode_that_reports_misleading_len() {
+        let multibyte_32 = "é".repeat(16);
+        assert_eq!(multibyte_32.chars().count(), 16);
+        assert!(multibyte_32.len() > 32);
+        let header = format!("00-{}-0000000000000000-01", multibyte_32);
+        assert!(TraceContext::parse(&header).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_embedded_nulls_and_control_chars() {
+        let with_null = "00-4bf92f3577b34da6a3ce929d\x000e4736-00f067aa0ba902b7-01";
+        assert!(TraceContext::parse(with_null).is_none());
+
+        let with_newline = "00-4bf92f3577b34da6a3ce929d\n0e4736-00f067aa0ba902b7-01";
+        assert!(TraceContext::parse(with_newline).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_leading_trailing_dashes_and_only_dashes() {
+        assert!(TraceContext::parse("---").is_none());
+        assert!(TraceContext::parse("-00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_none());
+        assert!(TraceContext::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-").is_none());
+    }
+
+    #[test]
+    fn parse_never_panics_on_random_input() {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..10_000 {
+            let len = rng.gen_range(0..256);
+            let bytes: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
+            let input = String::from_utf8_lossy(&bytes);
+            let _ = TraceContext::parse(&input);
+        }
+
+        for _ in 0..5_000 {
+            let ndashes = rng.gen_range(0..6);
+            let mut parts = Vec::new();
+            for _ in 0..=ndashes {
+                let seg_len = rng.gen_range(0..40);
+                let seg: String = (0..seg_len)
+                    .map(|_| {
+                        let charset = b"0123456789abcdefABCDEF \x00\n\txyz";
+                        charset[rng.gen_range(0..charset.len())] as char
+                    })
+                    .collect();
+                parts.push(seg);
+            }
+            let input = parts.join("-");
+            let _ = TraceContext::parse(&input);
+        }
+    }
+
+    #[test]
+    fn parse_accepts_all_valid_hex_combinations() {
+        let valid = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-00";
+        assert!(TraceContext::parse(valid).is_some());
+
+        let upper_hex = "00-0123456789ABCDEF0123456789ABCDEF-0123456789ABCDEF-FF";
+        assert!(TraceContext::parse(upper_hex).is_some());
+    }
+
+    #[test]
     fn traceparent_parse_roundtrip() {
         let tc = TraceContext {
             trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".to_string(),

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -291,6 +291,13 @@ pub struct TwoFactorLockoutState {
     pub updated_at: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct LockedUserSummary {
+    pub user_id: String,
+    pub failed_attempts: u32,
+    pub locked_at: Option<u64>,
+}
+
 /// Persistence abstraction for 2FA state (kept for compatibility)
 pub trait TwoFactorStore: Send + Sync {
     fn save(&self, user_id: &str, data: TwoFactorData) -> Result<(), String>;
@@ -360,6 +367,9 @@ pub trait TwoFactorStore: Send + Sync {
 
     /// Admin/recovery unlock for fully locked accounts.
     fn unlock_two_fa_account(&self, user_id: &str, actor: &str) -> Result<(), String>;
+
+    /// Return all currently locked-out user accounts.
+    fn list_locked_users(&self) -> Result<Vec<LockedUserSummary>, String>;
 
     /// Return pool utilisation stats when the backing store supports it.
     /// Returns `None` for stores that have no connection pool (e.g. in-memory).
@@ -603,6 +613,10 @@ impl TwoFactorStore for MockTwoFactorStore {
     fn unlock_two_fa_account(&self, _user_id: &str, _actor: &str) -> Result<(), String> {
         Ok(())
     }
+
+    fn list_locked_users(&self) -> Result<Vec<LockedUserSummary>, String> {
+        Ok(vec![])
+    }
 }
 
 impl TwoFactorStore for InMemoryStore {
@@ -822,6 +836,21 @@ impl TwoFactorStore for InMemoryStore {
         self.reset_two_fa_failures(user_id)?;
         self.append_audit_log(user_id, "two_fa_account_unlocked", actor, None)?;
         Ok(())
+    }
+
+    fn list_locked_users(&self) -> Result<Vec<LockedUserSummary>, String> {
+        let lockouts = self.lockouts.lock().unwrap();
+        let mut result: Vec<LockedUserSummary> = lockouts
+            .iter()
+            .filter(|(_, state)| state.locked)
+            .map(|(uid, state)| LockedUserSummary {
+                user_id: uid.clone(),
+                failed_attempts: state.failed_attempts,
+                locked_at: state.locked_at,
+            })
+            .collect();
+        result.sort_by(|a, b| a.user_id.cmp(&b.user_id));
+        Ok(result)
     }
 }
 

--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -1075,6 +1075,70 @@ mod tests {
     }
 
     #[test]
+    fn test_concurrent_fire_logs_every_event_exactly_once() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let thread_count = 20;
+        let client = Arc::new(MockHttpClient::new(0));
+        let mut manager = WebhookManager::new_with_http_allowed(client.clone());
+        manager.max_log_entries = thread_count * 2;
+        let manager = Arc::new(manager);
+
+        manager
+            .configure(
+                SecurityEventType::AccountLockout,
+                "http://example.com/hook".to_string(),
+            )
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(thread_count));
+        let mut handles = Vec::new();
+
+        for i in 0..thread_count {
+            let mgr = manager.clone();
+            let bar = barrier.clone();
+            handles.push(thread::spawn(move || {
+                bar.wait();
+                let mut meta = HashMap::new();
+                meta.insert("index".to_string(), i.to_string());
+                mgr.fire_sync(
+                    SecurityEventType::AccountLockout,
+                    &format!("concurrent-user-{}", i),
+                    meta,
+                );
+            }));
+        }
+
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+
+        assert_eq!(manager.delivery_log_count(), thread_count);
+
+        let log = manager.get_delivery_log(1, thread_count as u32);
+        assert_eq!(log.len(), thread_count);
+
+        let mut user_ids: Vec<String> = log.iter().map(|e| e.user_id.clone()).collect();
+        user_ids.sort();
+        let mut expected: Vec<String> = (0..thread_count)
+            .map(|i| format!("concurrent-user-{}", i))
+            .collect();
+        expected.sort();
+        assert_eq!(user_ids, expected);
+
+        for entry in &log {
+            assert_eq!(entry.event_type, "account_lockout");
+            assert!(entry.success);
+        }
+
+        let mut ids: Vec<usize> = log.iter().map(|e| e.id).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), thread_count, "all log IDs must be unique");
+    }
+
+    #[test]
     fn test_remove_config_url_removes_single_endpoint() {
         let (manager, mock) = make_manager(0);
         manager


### PR DESCRIPTION
closes #899 
closes #900 
closes #901 
closes #902

AdminDashboardHandlers (backend-2fa/src/handlers.rs) exposes list_users, disable_two_fa, unlock_two_fa, and get_audit_log, but nothing lets an admin see, at a glance, which accounts are currently in a locked state — they'd have to call get_lockout_state/check per-user one at a time.
with_retry (backend-2fa/src/db.rs) is supposed to retry only connection-class errors per its doc comment, but there's no test asserting a non-connection error (e.g. a unique-constraint violation, as already handled specially in log_recovery_code_usage) is returned immediately on the first attempt rather than being retried (and needlessly delayed by up to 700ms of backoff).
TraceContext::parse (backend-2fa/src/tracing_middleware.rs) is a hand-written parser over attacker-influenced HTTP header input (a misbehaving or hostile upstream can set any traceparent value), but it's covered only by a small number of hand-picked example tests, not fuzzing.