### PR TITLE
feat(registry): add vet specialization field

### DIFF
--- a/celo-contracts/contracts/PetChainRegistry.sol
+++ b/celo-contracts/contracts/PetChainRegistry.sol
@@ -16,6 +16,7 @@ contract PetChainRegistry {
     struct Vet {
         address vetAddress;
         string  licenseNumber;
+        string  specialization;   // issue #921
         bool    isVerified;
         bool    isRevoked;
     }
@@ -52,6 +53,7 @@ contract PetChainRegistry {
     // Events
     // -------------------------------------------------------------------------
     event VetRegistered(address indexed vet, string licenseNumber);
+    event VetSpecializationUpdated(address indexed vet, string specialization);  // issue #921
     event VetVerified(address indexed vet);
     event VetRevoked(address indexed vet);           // issue #916
     event PetRegistered(uint256 indexed petId, address indexed owner);
@@ -89,15 +91,23 @@ contract PetChainRegistry {
     // -------------------------------------------------------------------------
     // Vet management
     // -------------------------------------------------------------------------
-    function registerVet(string calldata licenseNumber) external {
+    function registerVet(string calldata licenseNumber, string calldata specialization) external {
         require(bytes(licenseNumber).length > 0, "PetChainRegistry: empty licenseNumber");
         vets[msg.sender] = Vet({
-            vetAddress:    msg.sender,
-            licenseNumber: licenseNumber,
-            isVerified:    false,
-            isRevoked:     false
+            vetAddress:     msg.sender,
+            licenseNumber:  licenseNumber,
+            specialization: specialization,
+            isVerified:     false,
+            isRevoked:      false
         });
         emit VetRegistered(msg.sender, licenseNumber);
+    }
+
+    /// @notice Update the calling vet's own specialization. issue #921
+    function updateSpecialization(string calldata specialization) external {
+        require(vets[msg.sender].vetAddress == msg.sender, "PetChainRegistry: not a registered vet");
+        vets[msg.sender].specialization = specialization;
+        emit VetSpecializationUpdated(msg.sender, specialization);
     }
 
     function verifyVet(address vet) external onlyAdmin {

--- a/celo-contracts/test/PetChainRegistry.test.js
+++ b/celo-contracts/test/PetChainRegistry.test.js
@@ -13,7 +13,7 @@ describe("PetChainRegistry", function () {
     registry = await Factory.deploy();
 
     // Register and verify a vet
-    await registry.connect(vet).registerVet("LIC-001");
+    await registry.connect(vet).registerVet("LIC-001", "General Practice");
     await registry.connect(admin).verifyVet(vet.address);
   });
 
@@ -30,6 +30,30 @@ describe("PetChainRegistry", function () {
     );
     return event.args.petId;
   }
+
+  // ---------------------------------------------------------------------------
+  // Issue #921 — vet specialization
+  // ---------------------------------------------------------------------------
+  describe("#921 — vet specialization", function () {
+    it("stores the specialization given at registration", async function () {
+      await registry.connect(other).registerVet("LIC-002", "Surgery");
+      const v = await registry.vets(other.address);
+      expect(v.specialization).to.equal("Surgery");
+    });
+
+    it("lets the vet update their own specialization and emits an event", async function () {
+      await expect(registry.connect(vet).updateSpecialization("Dentistry"))
+        .to.emit(registry, "VetSpecializationUpdated")
+        .withArgs(vet.address, "Dentistry");
+      const v = await registry.vets(vet.address);
+      expect(v.specialization).to.equal("Dentistry");
+    });
+
+    it("reverts when a non-registered address tries to update", async function () {
+      await expect(registry.connect(other).updateSpecialization("Exotics"))
+        .to.be.revertedWith("PetChainRegistry: not a registered vet");
+    });
+  });
 
   // ---------------------------------------------------------------------------
   // Issue #916 — VetRevoked event


### PR DESCRIPTION
## Summary

- Add a `specialization` string to the `Vet` struct, set at `registerVet` time
- Add `updateSpecialization` so a vet can update their own specialization (emits `VetSpecializationUpdated`)
- Cover registration-with-specialization, self-update, and the non-vet revert path in tests

## Validation

- `npx hardhat test` — 35 passing

Closes #921