### PR TITLE
feat(registry): add date-range query for pet medical records

### DIFF
--- a/celo-contracts/contracts/PetChainRegistry.sol
+++ b/celo-contracts/contracts/PetChainRegistry.sol
@@ -213,6 +213,32 @@ contract PetChainRegistry {
         return _petRecords[petId];
     }
 
+    /// @notice Return record IDs for `petId` whose timestamp is in [startDate, endDate]. issue #923
+    function getPetRecordsByDateRange(uint256 petId, uint256 startDate, uint256 endDate)
+        external
+        view
+        returns (uint256[] memory ids)
+    {
+        MedicalRecord[] storage all = _petRecords[petId];
+        uint256 total = all.length;
+
+        uint256 count;
+        for (uint256 i = 0; i < total; i++) {
+            uint256 ts = all[i].timestamp;
+            if (ts >= startDate && ts <= endDate) count++;
+        }
+
+        ids = new uint256[](count);
+        uint256 j;
+        for (uint256 i = 0; i < total; i++) {
+            uint256 ts = all[i].timestamp;
+            if (ts >= startDate && ts <= endDate) {
+                ids[j] = all[i].recordId;
+                j++;
+            }
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Paginated view functions (issue #918)
     // -------------------------------------------------------------------------

--- a/celo-contracts/test/PetChainRegistry.test.js
+++ b/celo-contracts/test/PetChainRegistry.test.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const { ethers, network } = require("hardhat");
 
 describe("PetChainRegistry", function () {
   let registry;
@@ -30,6 +30,41 @@ describe("PetChainRegistry", function () {
     );
     return event.args.petId;
   }
+
+  // ---------------------------------------------------------------------------
+  // Issue #923 — getPetRecordsByDateRange
+  // ---------------------------------------------------------------------------
+  describe("#923 — getPetRecordsByDateRange", function () {
+    let petId, t0, t1, t2;
+
+    beforeEach(async function () {
+      petId = await registerPet();
+      const base = (await ethers.provider.getBlock("latest")).timestamp;
+      t0 = base + 1000;
+      t1 = base + 2000;
+      t2 = base + 3000;
+      for (const ts of [t0, t1, t2]) {
+        await network.provider.send("evm_setNextBlockTimestamp", [ts]);
+        await registry.connect(vet).addMedicalRecord(petId, "diag", "treat", "");
+      }
+    });
+
+    it("returns all record IDs for a full-history range", async function () {
+      const ids = await registry.getPetRecordsByDateRange(petId, 0, t2);
+      expect(ids.length).to.equal(3);
+    });
+
+    it("returns only the records inside a partial-overlap range", async function () {
+      const ids = await registry.getPetRecordsByDateRange(petId, t1, t1);
+      expect(ids.length).to.equal(1);
+      expect(ids[0]).to.equal(2); // second record added
+    });
+
+    it("returns an empty array for a range with no records", async function () {
+      const ids = await registry.getPetRecordsByDateRange(petId, t2 + 1000, t2 + 2000);
+      expect(ids.length).to.equal(0);
+    });
+  });
 
   // ---------------------------------------------------------------------------
   // Issue #916 — VetRevoked event


### PR DESCRIPTION
## Summary

- Add `getPetRecordsByDateRange(petId, startDate, endDate)` returning only the record IDs whose timestamp falls within the inclusive range
- Tests cover an empty range, a partial-overlap range, and a full-history range

## Validation

- `npx hardhat test` — 35 passing

Closes #923