### PR TITLE
feat: add public dry_run method to MigrationRunner for inspecting pending migrations without applying them

### DIFF
--- a/backend-2fa/src/migrations.rs
+++ b/backend-2fa/src/migrations.rs
@@ -170,6 +170,12 @@ impl MigrationRunner {
         let pending = self.pending_migrations(executor)?;
         Ok(pending.is_empty())
     }
+
+    /// Returns the list of pending migrations (version + name) without executing any up_script.
+    pub fn dry_run(&self, executor: &dyn SqlExecutor) -> Result<Vec<(u32, String)>, MigrationError> {
+        let pending = self.pending_migrations(executor)?;
+        Ok(pending.iter().map(|m| (m.version, m.name.clone())).collect())
+    }
 }
 
 #[cfg(test)]
@@ -249,6 +255,41 @@ mod tests {
         let runner = MigrationRunner::new(vec![]);
         let result = runner.rollback_last(&executor);
         assert!(matches!(result, Err(MigrationError::NoMigrationsToRollback)));
+    }
+
+    #[test]
+    fn test_dry_run_reports_pending_without_mutation() {
+        let executor = MockExecutor::new();
+        let migrations = vec![
+            Migration {
+                version: 1,
+                name: "create_users".to_string(),
+                up_script: "CREATE TABLE users (id INT);".to_string(),
+                down_script: "DROP TABLE IF EXISTS users;".to_string(),
+                checksum: "abc".to_string(),
+            },
+            Migration {
+                version: 2,
+                name: "add_email".to_string(),
+                up_script: "ALTER TABLE users ADD COLUMN email TEXT;".to_string(),
+                down_script: String::new(),
+                checksum: "def".to_string(),
+            },
+        ];
+        let runner = MigrationRunner::new(migrations);
+
+        // Both migrations should be reported as pending
+        let pending = runner.dry_run(&executor).unwrap();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0], (1, "create_users".to_string()));
+        assert_eq!(pending[1], (2, "add_email".to_string()));
+
+        // State must be unchanged: is_up_to_date still false, apply still finds both
+        assert!(!runner.is_up_to_date(&executor).unwrap());
+        assert_eq!(runner.apply_pending(&executor).unwrap(), 2);
+
+        // After applying, dry_run reports nothing pending
+        assert!(runner.dry_run(&executor).unwrap().is_empty());
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #889

## Description of Changes

Adds `MigrationRunner::dry_run(executor)`, a public method that returns the list of pending migrations (version + name) without executing any `up_script`. Deploy tooling can now gate a release on pending migration state without applying them for real or reimplementing discovery logic externally.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

- [x] All existing tests pass (`cargo test`)
- [x] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [x] Manually verified expected behavior

`test_dry_run_reports_pending_without_mutation` verifies that:
- Both pending migrations are reported before any apply
- State is unchanged after calling `dry_run` (apply still finds both)
- After apply, `dry_run` returns empty

### Test Environment

- Rust version: 1.86.0
- Stellar CLI version: N/A
- OS: Windows 11 Pro

## Checklist

- [x] My code follows the project's code style guidelines (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] No hardcoded secrets, keys, or credentials are included in this PR
- [x] No plaintext encryption keys or sensitive data are exposed in the code
- [x] Input validation is properly implemented for all public functions
- [x] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

No security-sensitive code touched. `dry_run` is read-only — it queries the tracking table but never writes to it or executes any migration script.

## Screenshots / Logs (if applicable)

