### PR TITLE
fix/868: read per-IP connection limit and broadcast capacity from env…

### DIFF
--- a/backend-2fa/src/leaderboard.rs
+++ b/backend-2fa/src/leaderboard.rs
@@ -231,11 +231,26 @@ pub struct LeaderboardWsHub {
     connections_by_ip: Mutex<HashMap<IpAddr, usize>>,
 }
 
+fn get_max_conn_per_ip() -> usize {
+    std::env::var("LEADERBOARD_MAX_CONN_PER_IP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5)
+}
+
+fn get_broadcast_capacity() -> usize {
+    std::env::var("LEADERBOARD_BROADCAST_CAPACITY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(256)
+}
+
 impl LeaderboardWsHub {
     pub fn global() -> Arc<Self> {
         static HUB: OnceLock<Arc<LeaderboardWsHub>> = OnceLock::new();
         HUB.get_or_init(|| {
-            let (broadcaster, _) = broadcast::channel(256);
+            let capacity = get_broadcast_capacity();
+            let (broadcaster, _) = broadcast::channel(capacity);
             Arc::new(Self {
                 broadcaster,
                 connections_by_ip: Mutex::new(HashMap::new()),
@@ -254,9 +269,10 @@ impl LeaderboardWsHub {
         // inside the same lock acquisition.  Do NOT introduce an await point
         // or any other unlock between the read and the write; doing so would
         // reintroduce a TOCTOU race where two concurrent callers could both
-        // pass the `>= 5` check before either increments the counter.
+        // pass the limit check before either increments the counter.
+        let max_conn = get_max_conn_per_ip();
         let count = connections.entry(ip).or_insert(0);
-        if *count >= 5 {
+        if *count >= max_conn {
             return Err(format!("Connection limit exceeded for IP {}", ip));
         }
         *count += 1;
@@ -1042,6 +1058,57 @@ mod tests {
             "connection limit exceeded: {}",
             success_count
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #868 – Configurable per-IP connection limit and broadcast capacity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn custom_max_conn_per_ip_from_env_is_respected() {
+        // Isolate from other tests by using a unique IP.
+        std::env::set_var("LEADERBOARD_MAX_CONN_PER_IP", "2");
+
+        let hub = {
+            let (broadcaster, _) = broadcast::channel(16);
+            Arc::new(LeaderboardWsHub {
+                broadcaster,
+                connections_by_ip: Mutex::new(HashMap::new()),
+            })
+        };
+        let ip: IpAddr = "172.16.0.1".parse().unwrap();
+
+        let g1 = hub.connect(ip).expect("first connection must succeed");
+        let g2 = hub.connect(ip).expect("second connection must succeed");
+        let g3 = hub.connect(ip);
+        assert!(
+            g3.is_err(),
+            "third connection must be rejected when limit is 2"
+        );
+
+        drop(g1);
+        drop(g2);
+        std::env::remove_var("LEADERBOARD_MAX_CONN_PER_IP");
+    }
+
+    #[test]
+    fn default_max_conn_per_ip_is_five() {
+        // Ensure the env var is unset so we exercise the default path.
+        std::env::remove_var("LEADERBOARD_MAX_CONN_PER_IP");
+        assert_eq!(get_max_conn_per_ip(), 5);
+    }
+
+    #[test]
+    fn default_broadcast_capacity_is_256() {
+        std::env::remove_var("LEADERBOARD_BROADCAST_CAPACITY");
+        assert_eq!(get_broadcast_capacity(), 256);
+    }
+
+    #[test]
+    fn custom_broadcast_capacity_from_env() {
+        std::env::set_var("LEADERBOARD_BROADCAST_CAPACITY", "512");
+        assert_eq!(get_broadcast_capacity(), 512);
+        std::env::remove_var("LEADERBOARD_BROADCAST_CAPACITY");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
… vars

LEADERBOARD_MAX_CONN_PER_IP (default 5) and LEADERBOARD_BROADCAST_CAPACITY (default 256) are now read at runtime, allowing operators to tune both values without recompilation.

Adds tests for custom env-var values and default fallbacks.

# Pull Request

## Related Issue

Closes #868 

## Description of Changes

<!-- Provide a clear and concise description of what this PR does. -->
<!-- Explain the problem this PR solves and how it addresses it. -->

## Type of Change

<!-- Please check the relevant option(s) by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->
<!-- Include details of your testing environment. -->

- [ ] All existing tests pass (`cargo test`)
- [ ] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [ ] Manually verified expected behavior

### Test Environment

- Rust version:
- Stellar CLI version:
- OS:

## Checklist

<!-- Please check all that apply by replacing [ ] with [x]. -->

- [ ] My code follows the project's code style guidelines (`cargo fmt`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] No hardcoded secrets, keys, or credentials are included in this PR
- [ ] No plaintext encryption keys or sensitive data are exposed in the code
- [ ] Input validation is properly implemented for all public functions
- [ ] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

<!-- If this PR touches security-sensitive code, describe the security implications. -->
<!-- For encryption, access control, or authentication changes, detail your approach. -->

## Screenshots / Logs (if applicable)

<!-- Add any relevant screenshots, logs, or output to help illustrate the changes. -->

## Additional Notes

<!-- Add any other context or notes about the PR here. -->
