### PR TITLE
fix/867: require Authorization: Bearer token before leaderboard WebSo…

### DIFF
--- a/backend-2fa/src/leaderboard.rs
+++ b/backend-2fa/src/leaderboard.rs
@@ -1,5 +1,5 @@
 use actix::{Actor, ActorContext, AsyncContext, StreamHandler};
-use actix_web::error::{ErrorBadRequest, ErrorTooManyRequests};
+use actix_web::error::{ErrorBadRequest, ErrorTooManyRequests, ErrorUnauthorized};
 use actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use serde::{Deserialize, Serialize};
@@ -451,11 +451,36 @@ pub fn broadcast_score_update(user_id: impl Into<String>, new_score: u64, rank: 
     });
 }
 
+/// Validate the `Authorization: Bearer <token>` header for the leaderboard
+/// WebSocket endpoint.
+///
+/// * If `LEADERBOARD_WS_AUTH_TOKEN` is set, the provided token must match it exactly.
+/// * If the env var is unset, any non-empty Bearer token is accepted (development mode).
+/// * A missing or empty token always returns `false`.
+pub(crate) fn validate_ws_auth_token(authorization_header: Option<&str>) -> bool {
+    let provided = match authorization_header.and_then(|v| v.strip_prefix("Bearer ")) {
+        Some(t) if !t.is_empty() => t,
+        _ => return false,
+    };
+
+    let expected = std::env::var("LEADERBOARD_WS_AUTH_TOKEN").unwrap_or_default();
+    expected.is_empty() || provided == expected
+}
+
 /// Actix-web websocket endpoint for `GET /leaderboard/ws`.
 pub async fn leaderboard_ws_endpoint(
     req: HttpRequest,
     stream: Payload,
 ) -> Result<HttpResponse, Error> {
+    let auth_header = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok());
+
+    if !validate_ws_auth_token(auth_header) {
+        return Err(ErrorUnauthorized("Authentication required"));
+    }
+
     let peer_ip = req
         .peer_addr()
         .map(|addr| addr.ip())
@@ -1010,6 +1035,57 @@ mod tests {
         );
 
         std::env::remove_var("LEADERBOARD_DECAY_LAMBDA");
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #867 – Authentication for leaderboard WebSocket endpoint
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn auth_passes_with_correct_token() {
+        std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
+        assert!(validate_ws_auth_token(Some("Bearer supersecret")));
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+    }
+
+    #[test]
+    fn auth_fails_with_wrong_token() {
+        std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
+        assert!(!validate_ws_auth_token(Some("Bearer wrongtoken")));
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+    }
+
+    #[test]
+    fn auth_fails_with_missing_header() {
+        std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
+        assert!(!validate_ws_auth_token(None));
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+    }
+
+    #[test]
+    fn auth_fails_with_empty_bearer_value() {
+        std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
+        assert!(!validate_ws_auth_token(Some("Bearer ")));
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+    }
+
+    #[test]
+    fn auth_fails_with_non_bearer_scheme() {
+        std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
+        assert!(!validate_ws_auth_token(Some("Basic supersecret")));
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+    }
+
+    #[test]
+    fn auth_passes_any_non_empty_token_when_env_unset() {
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+        assert!(validate_ws_auth_token(Some("Bearer anytoken")));
+    }
+
+    #[test]
+    fn auth_fails_missing_header_even_when_env_unset() {
+        std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
+        assert!(!validate_ws_auth_token(None));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
…cket upgrade

leaderboard_ws_endpoint now validates the Authorization header before calling ws::start, returning 401 Unauthorized for unauthenticated requests. The expected token is read from LEADERBOARD_WS_AUTH_TOKEN; if the env var is unset any non-empty Bearer token is accepted (dev mode).

Adds unit tests for authenticated, unauthenticated, wrong-token, and missing-header paths via the extracted validate_ws_auth_token helper.

# Pull Request

## Related Issue

Closes #867 

## Description of Changes

<!-- Provide a clear and concise description of what this PR does. -->
<!-- Explain the problem this PR solves and how it addresses it. -->

## Type of Change

<!-- Please check the relevant option(s) by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->
<!-- Include details of your testing environment. -->

- [ ] All existing tests pass (`cargo test`)
- [ ] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [ ] Manually verified expected behavior

### Test Environment

- Rust version:
- Stellar CLI version:
- OS:

## Checklist

<!-- Please check all that apply by replacing [ ] with [x]. -->

- [ ] My code follows the project's code style guidelines (`cargo fmt`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] No hardcoded secrets, keys, or credentials are included in this PR
- [ ] No plaintext encryption keys or sensitive data are exposed in the code
- [ ] Input validation is properly implemented for all public functions
- [ ] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

<!-- If this PR touches security-sensitive code, describe the security implications. -->
<!-- For encryption, access control, or authentication changes, detail your approach. -->

## Screenshots / Logs (if applicable)

<!-- Add any relevant screenshots, logs, or output to help illustrate the changes. -->

## Additional Notes

<!-- Add any other context or notes about the PR here. -->
