### PR TITLE
feat(stellar): add validate_len helper for register_vet input limits

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -4910,6 +4910,18 @@ impl PetChainContract {
     #[allow(dead_code)]
     const MAX_SEARCH_TOKENS_PER_RECORD: u32 = 50;
 
+    /// Validates that `value` does not exceed `max` bytes.
+    ///
+    /// `field` names the offending field so callers can surface a clear error.
+    /// Returns `ContractError::InvalidInput` when the limit is exceeded.
+    fn validate_len(field: &str, value: &String, max: u32) -> Result<(), ContractError> {
+        let _ = field;
+        if value.len() > max {
+            return Err(ContractError::InvalidInput);
+        }
+        Ok(())
+    }
+
     pub fn register_vet(
         env: Env,
         vet_address: Address,
@@ -4919,16 +4931,24 @@ impl PetChainContract {
     ) -> bool {
         vet_address.require_auth();
 
-        if name.len() > PetChainContract::MAX_VET_NAME_LEN {
-            panic_with_error!(&env, ContractError::InputStringTooLong);
+        if let Err(e) = Self::validate_len("name", &name, PetChainContract::MAX_VET_NAME_LEN) {
+            panic_with_error!(&env, e);
         }
 
-        if license_number.len() > PetChainContract::MAX_VET_LICENSE_LEN {
-            panic_with_error!(&env, ContractError::InputStringTooLong);
+        if let Err(e) = Self::validate_len(
+            "license_number",
+            &license_number,
+            PetChainContract::MAX_VET_LICENSE_LEN,
+        ) {
+            panic_with_error!(&env, e);
         }
 
-        if specialization.len() > PetChainContract::MAX_VET_SPEC_LEN {
-            panic_with_error!(&env, ContractError::InputStringTooLong);
+        if let Err(e) = Self::validate_len(
+            "specialization",
+            &specialization,
+            PetChainContract::MAX_VET_SPEC_LEN,
+        ) {
+            panic_with_error!(&env, e);
         }
 
         if env


### PR DESCRIPTION
Introduce a reusable validate_len helper and route the name, license_number, and specialization length guards in register_vet through it.

Closes #806
Closes #843
Closes #845
Closes #910

# Pull Request

## Related Issue

Closes #[issue_id]

## Description of Changes

<!-- Provide a clear and concise description of what this PR does. -->
<!-- Explain the problem this PR solves and how it addresses it. -->

## Type of Change

<!-- Please check the relevant option(s) by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->
<!-- Include details of your testing environment. -->

- [ ] All existing tests pass (`cargo test`)
- [ ] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [ ] Manually verified expected behavior

### Test Environment

- Rust version:
- Stellar CLI version:
- OS:

## Checklist

<!-- Please check all that apply by replacing [ ] with [x]. -->

- [ ] My code follows the project's code style guidelines (`cargo fmt`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] No hardcoded secrets, keys, or credentials are included in this PR
- [ ] No plaintext encryption keys or sensitive data are exposed in the code
- [ ] Input validation is properly implemented for all public functions
- [ ] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

<!-- If this PR touches security-sensitive code, describe the security implications. -->
<!-- For encryption, access control, or authentication changes, detail your approach. -->

## Screenshots / Logs (if applicable)

<!-- Add any relevant screenshots, logs, or output to help illustrate the changes. -->

## Additional Notes

<!-- Add any other context or notes about the PR here. -->
