### PR TITLE
feat: implement recovery code rotation after successful use

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -186,6 +186,7 @@ pub struct RecoverWithBackupResponse {
     pub new_secret: String,
     pub new_otpauth_uri: String,
     pub new_backup_codes: Vec<String>,
+    pub new_recovery_codes: Vec<String>,
     pub enabled: bool,
 }
 
@@ -631,10 +632,12 @@ impl TwoFactorHandlers {
             .unlock_two_fa_account(&req.user_id, "recovery_code")
             .map_err(|e| ApiError::internal_error(e, None))?;
 
+        let new_codes = setup.backup_codes.clone();
         Ok(RecoverWithBackupResponse {
             new_secret: setup.secret,
             new_otpauth_uri: setup.otpauth_uri,
-            new_backup_codes: setup.backup_codes,
+            new_backup_codes: new_codes.clone(),
+            new_recovery_codes: new_codes,
             enabled: true,
         })
     }

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -1896,6 +1896,123 @@ mod integration_tests {
     }
 
     // -----------------------------------------------------------------------
+    // Flow 2b: recovery code rotation atomicity
+    // -----------------------------------------------------------------------
+
+    /// After a successful recovery-code login, ALL old backup codes (both
+    /// the consumed one and the unused ones) must be invalidated atomically,
+    /// and a fresh set of recovery codes must be returned.
+    #[test]
+    fn test_recovery_code_rotation_atomicity() {
+        let user_id = "integration-rotation-atomicity-user";
+        let handlers = TwoFactorHandlers::new();
+
+        // Enable 2FA
+        let enable_resp = TwoFactorHandlers::enable_two_factor(
+            &caller(user_id),
+            EnableTwoFactorRequest {
+                idempotency_key: None,
+                user_id: user_id.to_string(),
+                email: "rotation@petchain.com".to_string(),
+            },
+        )
+        .unwrap();
+
+        // Activate
+        handlers
+            .verify_and_activate(
+                &caller(user_id),
+                VerifyTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    token: generate_token(&enable_resp.secret),
+                },
+            )
+            .unwrap();
+
+        let old_backup_codes = enable_resp.backup_codes.clone();
+        assert_eq!(old_backup_codes.len(), 8);
+
+        // Recover using the first backup code
+        let recovery_resp = TwoFactorHandlers::recover_with_backup(
+            &caller(user_id),
+            RecoverWithBackupRequest {
+                user_id: user_id.to_string(),
+                backup_code: old_backup_codes[0].clone(),
+            },
+        )
+        .expect("recovery should succeed");
+
+        // New recovery codes are returned in the response
+        assert_eq!(recovery_resp.new_recovery_codes.len(), 8);
+        assert_eq!(
+            recovery_resp.new_backup_codes,
+            recovery_resp.new_recovery_codes,
+            "new_backup_codes and new_recovery_codes must match"
+        );
+        assert_ne!(
+            recovery_resp.new_recovery_codes, old_backup_codes,
+            "new recovery codes must differ from old ones"
+        );
+
+        // The consumed old code must be invalid
+        let reuse_consumed = TwoFactorHandlers::recover_with_backup(
+            &caller(user_id),
+            RecoverWithBackupRequest {
+                user_id: user_id.to_string(),
+                backup_code: old_backup_codes[0].clone(),
+            },
+        );
+        assert!(
+            reuse_consumed.is_err(),
+            "consumed backup code must not be reusable after rotation"
+        );
+
+        // UNUSED old codes must also be invalid (this is the atomicity check)
+        for i in 1..old_backup_codes.len() {
+            let reuse_unused = TwoFactorHandlers::recover_with_backup(
+                &caller(user_id),
+                RecoverWithBackupRequest {
+                    user_id: user_id.to_string(),
+                    backup_code: old_backup_codes[i].clone(),
+                },
+            );
+            assert!(
+                reuse_unused.is_err(),
+                "unused old backup code [{}] must also be invalidated after rotation",
+                i
+            );
+        }
+
+        // Login with the new secret must succeed
+        let logged_in = handlers
+            .verify_login_token(
+                &caller(user_id),
+                LoginWithTwoFactorRequest {
+                    user_id: user_id.to_string(),
+                    token: generate_token(&recovery_resp.new_secret),
+                },
+            )
+            .expect("login with new secret after rotation should not error");
+        assert!(
+            logged_in,
+            "login must succeed with the new secret after rotation"
+        );
+
+        // A new recovery code from the rotated set must be usable
+        let second_recovery = TwoFactorHandlers::recover_with_backup(
+            &caller(user_id),
+            RecoverWithBackupRequest {
+                user_id: user_id.to_string(),
+                backup_code: recovery_resp.new_recovery_codes[0].clone(),
+            },
+        );
+        assert!(
+            second_recovery.is_ok(),
+            "a fresh recovery code from the rotated set must be valid"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Flow 3: rate limit exhaustion on login
     // -----------------------------------------------------------------------
 

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -114,6 +114,7 @@ pub struct TwoFactorData {
 pub struct RecoveryResult {
     pub new_secret: String,
     pub new_backup_codes: Vec<String>,
+    pub new_recovery_codes: Vec<String>,
     pub enabled: bool,
 }
 


### PR DESCRIPTION
Closes #779

**Changes:**
- Added `new_recovery_codes: Vec<String>` field to `RecoverWithBackupResponse` (handlers.rs) and `RecoveryResult` (two_factor.rs) per issue requirements
- Populated `new_recovery_codes` alongside `new_backup_codes` in the recovery handler
- Wrote atomicity test (`test_recovery_code_rotation_atomicity`) verifying:
  - Recovery succeeds and returns 8 new recovery codes
  - The consumed old backup code is invalidated
  - **All unused old backup codes are also invalidated** (atomicity guarantee)
  - New secret works for subsequent login
  - A fresh recovery code from the rotated set is usable

**Design:**
- Code generation uses the same `TwoFactorAuth::setup` CSPRNG path as initial enrollment
- Atomicity is inherent: the single `store.save()` call atomically replaces the old `TwoFactorData` (which contained the old codes) with new data containing only the fresh codes — there is no window where both old and new codes are simultaneously valid

**Verification:**
- `cargo test --lib` — 378 passed, 4 ignored (Redis, no server), 0 failed