### PR TITLE
fix(pet-transfer-adoption): resolve issues #1004 #1005 #1006 #1007

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/src/escrow.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/escrow.rs
@@ -43,6 +43,7 @@ pub enum EscrowDataKey {
     Entry(u64),
     FeeBps,
     FeeRecipient,
+    Admin,
 }
 
 // ─── Fee helpers ──────────────────────────────────────────────────────────────
@@ -61,6 +62,10 @@ pub fn init_escrow_config(env: &Env, fee_bps: u32, fee_recipient: Address) {
     assert!(fee_bps <= 10_000, "fee_bps must be <= 10000");
     env.storage().instance().set(&EscrowDataKey::FeeBps, &fee_bps);
     env.storage().instance().set(&EscrowDataKey::FeeRecipient, &fee_recipient);
+    // Store the initial caller as Admin (first call sets the admin)
+    if !env.storage().instance().has(&EscrowDataKey::Admin) {
+        env.storage().instance().set(&EscrowDataKey::Admin, &fee_recipient);
+    }
 }
 
 pub fn get_platform_fee_bps(env: &Env) -> u32 {
@@ -68,6 +73,50 @@ pub fn get_platform_fee_bps(env: &Env) -> u32 {
         .instance()
         .get::<EscrowDataKey, u32>(&EscrowDataKey::FeeBps)
         .unwrap_or(0)
+}
+
+/// Returns the stored fee_bps (or 0 if unset). View-only, no auth required.
+/// Closes issue #1004.
+pub fn get_fee_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get::<EscrowDataKey, u32>(&EscrowDataKey::FeeBps)
+        .unwrap_or(0)
+}
+
+/// Returns the stored fee recipient address, or None if unset. View-only, no auth required.
+/// Closes issue #1004.
+pub fn get_fee_recipient(env: &Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get::<EscrowDataKey, Address>(&EscrowDataKey::FeeRecipient)
+}
+
+/// Updates the platform fee configuration. Only callable by the stored Admin.
+/// Validates new_fee_bps <= 10_000 and emits a CONFIG_UPDATED event with old and new values.
+/// Existing in-flight escrows are NOT retroactively updated (they capture fee_bps at deposit time).
+/// Closes issue #1005.
+pub fn update_fee_config(env: &Env, new_fee_bps: u32, new_fee_recipient: Address) {
+    assert!(new_fee_bps <= 10_000, "fee_bps must be <= 10000");
+
+    // Require admin auth
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&EscrowDataKey::Admin)
+        .expect("escrow config not initialised");
+    admin.require_auth();
+
+    let old_fee_bps: u32 = get_platform_fee_bps(env);
+    let old_fee_recipient: Option<Address> = get_fee_recipient(env);
+
+    env.storage().instance().set(&EscrowDataKey::FeeBps, &new_fee_bps);
+    env.storage().instance().set(&EscrowDataKey::FeeRecipient, &new_fee_recipient);
+
+    env.events().publish(
+        (soroban_sdk::symbol_short!("CFG_UPD"),),
+        (old_fee_bps, new_fee_bps, old_fee_recipient, new_fee_recipient),
+    );
 }
 
 // ─── Operations ───────────────────────────────────────────────────────────────
@@ -236,5 +285,123 @@ mod tests {
     fn zero_fee_bps_full_amount_to_seller() {
         assert_eq!(compute_platform_fee(10_000_000, 0), 0);
         assert_eq!(compute_seller_amount(10_000_000, 0), 10_000_000);
+    }
+
+    // ── Issue #1006: missing-entry error-path tests ───────────────────────────
+
+    /// finalize_transfer panics with "escrow not found" when no entry exists.
+    #[test]
+    #[should_panic(expected = "escrow not found")]
+    fn finalize_transfer_panics_on_missing_entry() {
+        let (env, _buyer, _seller, platform) = setup();
+        init_escrow_config(&env, 250, platform);
+        // transfer_id 999 was never deposited
+        finalize_transfer(&env, 999);
+    }
+
+    /// refund_fee panics with "escrow not found" when no entry exists.
+    #[test]
+    #[should_panic(expected = "escrow not found")]
+    fn refund_fee_panics_on_missing_entry() {
+        let (env, _buyer, _seller, platform) = setup();
+        init_escrow_config(&env, 250, platform);
+        // transfer_id 999 was never deposited
+        refund_fee(&env, 999);
+    }
+
+    /// dispute_transfer panics with "escrow not found" when no entry exists.
+    #[test]
+    #[should_panic(expected = "escrow not found")]
+    fn dispute_transfer_panics_on_missing_entry() {
+        let (env, buyer, _seller, platform) = setup();
+        init_escrow_config(&env, 250, platform);
+        // transfer_id 999 was never deposited
+        dispute_transfer(&env, 999, buyer);
+    }
+
+    // ── Issue #1004: get_fee_bps and get_fee_recipient view functions ─────────
+
+    #[test]
+    fn get_fee_bps_returns_configured_value() {
+        let (env, _buyer, _seller, platform) = setup();
+        init_escrow_config(&env, 300, platform);
+        assert_eq!(get_fee_bps(&env), 300);
+    }
+
+    #[test]
+    fn get_fee_bps_returns_zero_when_not_configured() {
+        let env = Env::default();
+        assert_eq!(get_fee_bps(&env), 0);
+    }
+
+    #[test]
+    fn get_fee_recipient_returns_configured_address() {
+        let (env, _buyer, _seller, platform) = setup();
+        init_escrow_config(&env, 150, platform.clone());
+        assert_eq!(get_fee_recipient(&env), Some(platform));
+    }
+
+    #[test]
+    fn get_fee_recipient_returns_none_when_not_configured() {
+        let env = Env::default();
+        assert_eq!(get_fee_recipient(&env), None);
+    }
+
+    // ── Issue #1005: update_fee_config admin-only update ─────────────────────
+
+    #[test]
+    fn update_fee_config_changes_fee_bps_and_recipient() {
+        let (env, _buyer, _seller, platform) = setup();
+        env.mock_all_auths();
+        let new_recipient = Address::generate(&env);
+        init_escrow_config(&env, 250, platform.clone());
+
+        update_fee_config(&env, 100, new_recipient.clone());
+
+        assert_eq!(get_fee_bps(&env), 100);
+        assert_eq!(get_fee_recipient(&env), Some(new_recipient));
+    }
+
+    #[test]
+    fn new_escrow_uses_updated_fee_rate() {
+        let (env, buyer, seller, platform) = setup();
+        env.mock_all_auths();
+        let new_recipient = Address::generate(&env);
+        init_escrow_config(&env, 250, platform.clone());
+
+        // Update fee to 500 bps (5%)
+        update_fee_config(&env, 500, new_recipient.clone());
+
+        // New deposit captures the updated rate
+        deposit_fee(&env, 10, buyer.clone(), seller.clone(), 10_000_000);
+        let entry = get_escrow(&env, 10).unwrap();
+        assert_eq!(entry.platform_fee_bps, 500);
+    }
+
+    #[test]
+    fn existing_escrow_keeps_original_fee_rate_after_update() {
+        let (env, buyer, seller, platform) = setup();
+        env.mock_all_auths();
+        let new_recipient = Address::generate(&env);
+        init_escrow_config(&env, 250, platform.clone());
+
+        // Deposit before update — captures 250 bps
+        deposit_fee(&env, 20, buyer.clone(), seller.clone(), 10_000_000);
+
+        // Update fee to 500 bps
+        update_fee_config(&env, 500, new_recipient.clone());
+
+        // Existing escrow is unchanged
+        let entry = get_escrow(&env, 20).unwrap();
+        assert_eq!(entry.platform_fee_bps, 250);
+    }
+
+    #[test]
+    #[should_panic]
+    fn update_fee_config_rejects_fee_bps_over_10000() {
+        let (env, _buyer, _seller, platform) = setup();
+        env.mock_all_auths();
+        init_escrow_config(&env, 250, platform.clone());
+        update_fee_config(&env, 10_001, platform);
     }
 }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Env, Map, String, Symbol, Vec,
+    Env, String, Symbol, Vec,
 };
 
 /// Expiry policy: a pending transfer that has not been accepted within
@@ -37,15 +37,6 @@ pub struct PetOwnershipContract;
 pub struct Pet {
     pub pet_id: u64,
     pub current_owner: Address,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PendingTransfer {
-    pub pet_id: u64,
-    pub from: Address,
-    pub to: Address,
-    pub initiated_at: u64,
 }
 
 /// A transfer that has been accepted by both parties and is now in the
@@ -159,30 +150,6 @@ pub struct CustodyEntry {
     pub transfer_type: TransferType,
 }
 
-TransferNotExpired = 8,
-    StaleCancellation = 9,
-    EmptyBatch = 10,
-    BatchOwnerMismatch = 11,
-    NoEscrowedTransfer = 12,
-    DisputeWindowNotElapsed = 13,
-    TransferAlreadyDisputed = 14,
-    AlreadyInitialized = 15,
-    InvalidThreshold = 16,
-    NotMultisigAdmin = 17,
-    ThresholdNotMet = 18,
-    UntrustedContract = 19,
-    NoPendingAdoption = 20,
-    WaitingPeriodNotElapsed = 21,
-    AdoptionAlreadyCompleted = 22,
-    AdoptionNotConfigurable = 23,
-    InvalidWaitingPeriod = 24,
-    AdoptionConfigNotFound = 25,
-    BatchTooLarge = 26,
-    InvalidBatch = 27,
-    OrganizationApprovalRequired = 28,
-    AdoptionRejected = 29,
-    InvalidApprover = 30,
-    InvalidTimeoutDays = 31,
 /// ======================================================
 /// STORAGE KEYS
 /// ======================================================
@@ -207,18 +174,8 @@ enum DataKey {
     AdoptionWaitingPeriod(u64),   // pet_id -> waiting_period_days (per-pet override, optional)
     SpeciesAdoptionConfig(String), // species -> waiting_period_days
     JurisdictionAdoptionConfig(String), // jurisdiction -> AdoptionConfig
+    Admin,                        // adoption contract admin set on first set_adoption_config call
 }
-
-/// ======================================================
-/// EVENTS
-/// ======================================================
-
-const EVT_TRANSFER_INITIATED: Symbol = symbol_short!("xfer_init");
-const EVT_TRANSFER_CANCELLED: Symbol = symbol_short!("xfer_cncl");
-const EVT_TRANSFER_ESCROWED: Symbol = symbol_short!("xfer_escr");
-const EVT_TRANSFER_FINALIZED: Symbol = symbol_short!("xfer_fin");
-const EVT_TRANSFER_DISPUTED: Symbol = symbol_short!("xfer_disp");
-const EVT_TRUSTED_UPDATED: Symbol = symbol_short!("trust_upd");
 
 /// ======================================================
 /// ERRORS
@@ -259,6 +216,7 @@ pub enum ContractError {
     OrganizationApprovalRequired = 28,
     AdoptionRejected = 29,
     InvalidApprover = 30,
+    InvalidTimeoutDays = 31,
 }
 
 /// ======================================================
@@ -314,6 +272,10 @@ fn append_custody_entry(
         .set(&DataKey::CustodyChain(pet_id), &chain);
 }
 
+
+/// ======================================================
+/// EVENTS
+/// ======================================================
 
 const EVT_TRANSFER_INITIATED: Symbol = symbol_short!("xfer_init");
 const EVT_TRANSFER_CANCELLED: Symbol = symbol_short!("xfer_cncl");
@@ -418,12 +380,42 @@ impl PetOwnershipContract {
 
     /// Set the global adoption waiting period (in days).
     /// Only configurable if no default config has been set yet.
-    pub fn set_adoption_config(env: Env, waiting_period_days: u32) {
+    /// The caller is stored as the adoption admin for future `update_adoption_config` calls.
+    pub fn set_adoption_config(env: Env, waiting_period_days: u32, admin: Address) {
         if env.storage().persistent().has(&DataKey::AdoptionConfig) {
             panic_with_error!(&env, ContractError::AdoptionNotConfigurable);
         }
+        admin.require_auth();
         let config = AdoptionConfig { waiting_period_days };
         env.storage().persistent().set(&DataKey::AdoptionConfig, &config);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Update the global adoption waiting period (in days).
+    /// Only callable by the admin stored during `set_adoption_config`.
+    /// Emits an `AdoptionConfigUpdated` event with old and new values.
+    /// Closes issue #1007.
+    pub fn update_adoption_config(env: Env, waiting_period_days: u32) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::AdoptionConfigNotFound));
+        admin.require_auth();
+
+        let old_config: AdoptionConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AdoptionConfig)
+            .unwrap_or(AdoptionConfig { waiting_period_days: 0 });
+
+        let new_config = AdoptionConfig { waiting_period_days };
+        env.storage().persistent().set(&DataKey::AdoptionConfig, &new_config);
+
+        env.events().publish(
+            (Symbol::new(&env, "cfg_adoption"),),
+            (old_config.waiting_period_days, waiting_period_days),
+        );
     }
 
     /// Get the current adoption config.
@@ -524,7 +516,7 @@ impl PetOwnershipContract {
 
 
     pub fn initiate_transfer(env: Env, pet_id: u64, to: Address) {
-        Self::initiate_transfer_with_timeout(env, pet_id, to, DEFAULT_TRANSFER_TIMEOUT_SECONDS / 86400);
+        Self::initiate_transfer_with_timeout(env, pet_id, to, (DEFAULT_TRANSFER_TIMEOUT_SECONDS / 86400) as u32);
     }
 
     /// Same as [`initiate_transfer`] but allows the caller to specify a
@@ -594,30 +586,6 @@ impl PetOwnershipContract {
 
         env.events().publish(
             (EVT_TRANSFER_EXPIRED, pet_id),
-            (transfer.from, transfer.to),
-        );
-    }
-
-    pub fn reclaim_transfer(env: Env, pet_id: u64) {
-        let transfer: PendingTransfer = env
-            .storage()
-            .persistent()
-            .get(&DataKey::PendingTransfer(pet_id))
-            .unwrap_or_else(|| panic_with_error!(env, ContractError::NoPendingTransfer));
-
-        transfer.from.require_auth();
-
-        let now = env.ledger().timestamp();
-        if now.saturating_sub(transfer.initiated_at) < TRANSFER_EXPIRY_SECONDS {
-            panic_with_error!(env, ContractError::TransferNotExpired);
-        }
-
-        env.storage()
-            .persistent()
-            .remove(&DataKey::PendingTransfer(pet_id));
-
-        env.events().publish(
-            (EVT_TRANSFER_CANCELLED, pet_id),
             (transfer.from, transfer.to),
         );
     }
@@ -831,37 +799,6 @@ impl PetOwnershipContract {
         save_pet(&env, &pet);
         save_history(&env, pet_id, &history);
         add_pet_to_owner(&env, &owner, pet_id);
-    }
-
-    /// ----------------------------------
-    /// INITIATE TRANSFER
-    /// ----------------------------------
-
-    pub fn initiate_transfer(env: Env, pet_id: u64, to: Address) {
-        let pet = get_pet(&env, pet_id);
-        pet.current_owner.require_auth();
-
-        if env
-            .storage()
-            .persistent()
-            .has(&DataKey::PendingTransfer(pet_id))
-        {
-            panic_with_error!(env, ContractError::TransferAlreadyPending);
-        }
-
-        let transfer = PendingTransfer {
-            pet_id,
-            from: pet.current_owner.clone(),
-            to: to.clone(),
-            initiated_at: env.ledger().timestamp(),
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::PendingTransfer(pet_id), &transfer);
-
-        env.events()
-            .publish((EVT_TRANSFER_INITIATED, pet_id), (pet.current_owner, to));
     }
 
     /// ----------------------------------
@@ -1145,6 +1082,7 @@ impl PetOwnershipContract {
                 from: owner.clone(),
                 to: to.clone(),
                 initiated_at: now,
+                timeout_secs: DEFAULT_TRANSFER_TIMEOUT_SECONDS,
             };
 
             env.storage()
@@ -1273,5 +1211,79 @@ impl PetOwnershipContract {
         env.storage()
             .persistent()
             .get(&DataKey::EscrowedTransfer(pet_id))
+    }
+
+    /// Returns the timeout_secs for the pending transfer of `pet_id`, or `None`.
+    pub fn get_transfer_timeout_secs(env: Env, pet_id: u64) -> Option<u64> {
+        let transfer: Option<PendingTransfer> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingTransfer(pet_id));
+        transfer.map(|t| t.timeout_secs)
+    }
+
+    // ----------------------------------
+    // TRUSTED CONTRACT / MULTISIG ADMIN
+    // ----------------------------------
+
+    /// Initialise the trusted contract address and multisig admin list.
+    /// Can only be called once.
+    pub fn init_trusted_contract(
+        env: Env,
+        trusted: Address,
+        admins: Vec<Address>,
+        threshold: u32,
+    ) {
+        if env.storage().instance().has(&DataKey::TrustedContract) {
+            panic_with_error!(env, ContractError::AlreadyInitialized);
+        }
+        if threshold == 0 || threshold > admins.len() {
+            panic_with_error!(env, ContractError::InvalidThreshold);
+        }
+        env.storage().instance().set(&DataKey::TrustedContract, &trusted);
+        env.storage().instance().set(&DataKey::TrustedAdmins, &admins);
+        env.storage().instance().set(&DataKey::TrustedThreshold, &threshold);
+    }
+
+    /// Returns `true` if `callee` equals the stored trusted contract address.
+    /// Panics with `UntrustedContract` otherwise.
+    pub fn validate_trusted_contract(env: Env, callee: Address) -> bool {
+        require_trusted_contract(&env, &callee);
+        true
+    }
+
+    /// Returns the currently stored trusted contract address.
+    pub fn get_trusted_contract_address(env: Env) -> Address {
+        get_trusted_contract(&env)
+    }
+
+    /// Cast a multisig vote to update the trusted contract address.
+    /// Returns `true` when the threshold is met and the address is updated.
+    pub fn update_trusted_contract(env: Env, new_address: Address, signer: Address) -> bool {
+        let (admins, threshold) = require_trusted_multisig_admin(&env, &signer);
+
+        let key = DataKey::TrustedUpdateApprovals((new_address.clone(), signer.clone()));
+        env.storage().instance().set(&key, &true);
+
+        // Count approvals
+        let mut count: u32 = 0;
+        for admin in admins.iter() {
+            let k = DataKey::TrustedUpdateApprovals((new_address.clone(), admin.clone()));
+            if env.storage().instance().has(&k) {
+                count += 1;
+            }
+        }
+
+        if count >= threshold {
+            env.storage().instance().set(&DataKey::TrustedContract, &new_address);
+            clear_trusted_update_approvals(&env, &admins, &new_address);
+            env.events().publish(
+                (EVT_TRUSTED_UPDATED,),
+                (new_address,),
+            );
+            return true;
+        }
+
+        false
     }
 }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -1,6 +1,6 @@
 use super::{
-    ContractError, CustodyEntry, DataKey, EscrowedTransfer, OwnershipRecord, PetOwnershipContract,
-    PetOwnershipContractClient, TransferType, DISPUTE_WINDOW_SECONDS,
+    AdoptionState, ContractError, CustodyEntry, DataKey, EscrowedTransfer, OwnershipRecord,
+    PetOwnershipContract, PetOwnershipContractClient, TransferType, DISPUTE_WINDOW_SECONDS,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -907,4 +907,101 @@ fn custody_chain_is_append_only_no_delete_path() {
 
     let chain = client.get_custody_chain(&pet_id);
     assert_eq!(chain.len(), 2);
+}
+
+// ======================================================
+// update_adoption_config tests (Issue #1007)
+// ======================================================
+
+#[test]
+fn set_adoption_config_stores_waiting_period_and_admin() {
+    let (env, owner, _, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.set_adoption_config(&7u32, &owner);
+
+    let config = client.get_adoption_config();
+    assert_eq!(config.waiting_period_days, 7);
+}
+
+#[test]
+fn set_adoption_config_is_one_shot_second_call_is_rejected() {
+    let (env, owner, _, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.set_adoption_config(&7u32, &owner);
+
+    // Second call must be rejected
+    let result = client.try_set_adoption_config(&14u32, &owner);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::AdoptionNotConfigurable as u32,
+        )))
+    );
+    // Value must remain unchanged
+    assert_eq!(client.get_adoption_config().waiting_period_days, 7);
+}
+
+#[test]
+fn update_adoption_config_changes_waiting_period() {
+    let (env, owner, _, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.set_adoption_config(&7u32, &owner);
+    client.update_adoption_config(&14u32);
+
+    assert_eq!(client.get_adoption_config().waiting_period_days, 14);
+}
+
+#[test]
+fn update_adoption_config_emits_event_with_old_and_new_values() {
+    let (env, owner, _, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.set_adoption_config(&7u32, &owner);
+    let events_before = env.events().all().len();
+
+    client.update_adoption_config(&14u32);
+
+    // At least one new event must have been emitted
+    assert!(env.events().all().len() > events_before);
+}
+
+#[test]
+fn update_adoption_config_new_adoption_uses_new_period() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    // Set initial period to 7 days and then update to 0 (instant)
+    client.set_adoption_config(&7u32, &owner);
+    client.update_adoption_config(&0u32);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+
+    // With 0-day waiting period, complete_adoption should succeed immediately
+    client.complete_adoption(&pet_id);
+    assert_eq!(client.get_current_owner(&pet_id), adopter);
+}
+
+#[test]
+fn update_adoption_config_fails_without_prior_set() {
+    let (env, _, _, _) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    // No set_adoption_config called — update must fail
+    let result = client.try_update_adoption_config(&14u32);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::AdoptionConfigNotFound as u32,
+        )))
+    );
 }


### PR DESCRIPTION
Closes #1004 -- Add get_fee_bps and get_fee_recipient view functions Closes #1005 -- Add update_fee_config with admin auth and CONFIG_UPDATED event Closes #1006 -- Add missing-entry error-path tests for escrow functions Closes #1007 -- Add update_adoption_config with admin auth and AdoptionConfigUpdated event

=== Issue #1004 [pet-transfer-adoption] get_fee_bps and get_fee_recipient view functions ===

Problem:
escrow.rs stored EscrowDataKey::FeeBps and EscrowDataKey::FeeRecipient in instance storage but provided no public read-only accessor. Off-chain clients could not query the current platform fee or recipient without reading raw contract storage.

How it was fixed:
- Added pub fn get_fee_bps(env: &Env) -> u32 in escrow.rs that reads FeeBps from instance storage and returns 0 if unset.
- Added pub fn get_fee_recipient(env: &Env) -> Option<Address> in escrow.rs that reads FeeRecipient from instance storage and returns None if unset.
- Both functions require no auth (view-only).
- Added tests: get_fee_bps_returns_configured_value, get_fee_bps_returns_zero_when_not_configured, get_fee_recipient_returns_configured_address, get_fee_recipient_returns_none_when_not_configured.

=== Issue #1005 [pet-transfer-adoption] update_fee_config with admin auth ===

Problem:
init_escrow_config() set the platform fee and recipient once with no way to change them without a full contract redeploy, disrupting all in-flight transfers. Platform fee adjustments (promotions, treasury address changes) were impossible.

How it was fixed:
- Added EscrowDataKey::Admin variant to store the initial caller of init_escrow_config.
- Updated init_escrow_config() to store fee_recipient as Admin in instance storage on first call (if Admin not already set).
- Added pub fn update_fee_config(env: &Env, new_fee_bps: u32, new_fee_recipient: Address) which: (1) asserts new_fee_bps <= 10_000, (2) loads Admin and calls admin.require_auth(), (3) reads old values, (4) writes new values, (5) emits a CFG_UPD event with (old_fee_bps, new_fee_bps, old_fee_recipient, new_fee_recipient).
- Existing in-flight escrows are NOT retroactively updated — EscrowEntry captures platform_fee_bps at deposit time, so old entries keep their original rate.
- Added tests: update_fee_config_changes_fee_bps_and_recipient, new_escrow_uses_updated_fee_rate, existing_escrow_keeps_original_fee_rate_after_update, update_fee_config_rejects_fee_bps_over_10000.

=== Issue #1006 [pet-transfer-adoption] Missing-entry error-path tests for escrow ===

Problem:
finalize_transfer(), refund_fee(), and dispute_transfer() in escrow.rs all call .expect('escrow not found') when the entry is missing. The existing test suite only covered valid state transitions; missing-entry error paths had no test coverage, meaning a typo in transfer_id would produce an opaque panic with no regression detection.

How it was fixed:
- Added three #[test] #[should_panic(expected = 'escrow not found')] tests to the existing escrow.rs test module:
    * finalize_transfer_panics_on_missing_entry: calls finalize_transfer() with transfer_id 999 that was never deposited.
    * refund_fee_panics_on_missing_entry: calls refund_fee() with a missing entry.
    * dispute_transfer_panics_on_missing_entry: calls dispute_transfer() with a missing entry.
- Each test calls init_escrow_config() first to ensure the config is set, then calls the function under test with a non-existent transfer_id.

=== Issue #1007 [pet-transfer-adoption] update_adoption_config admin-only update path ===

Problem:
set_adoption_config() in lib.rs panicked with AdoptionNotConfigurable if called a second time. The global waiting period could never be changed without a full contract redeploy, losing all existing escrow state. No mechanism existed to update the waiting period in-contract.

How it was fixed:
- Added DataKey::Admin variant to lib.rs to store the adoption admin address.
- Updated set_adoption_config() signature to accept an dmin: Address parameter. The admin calls admin.require_auth(), config is stored, and admin address is saved under DataKey::Admin. The one-shot guard (AdoptionNotConfigurable) is preserved.
- Added pub fn update_adoption_config(env: Env, waiting_period_days: u32) which: (1) loads DataKey::Admin, panics with AdoptionConfigNotFound if missing, (2) calls admin.require_auth(), (3) reads old config, (4) writes new config, (5) emits a cfg_adoption event with (old_waiting_period_days, waiting_period_days).
- Added tests in test.rs: set_adoption_config_stores_waiting_period_and_admin, set_adoption_config_is_one_shot_second_call_is_rejected, update_adoption_config_changes_waiting_period, update_adoption_config_emits_event_with_old_and_new_values, update_adoption_config_new_adoption_uses_new_period, update_adoption_config_fails_without_prior_set.

=== Additional cleanup performed ===
- Removed orphaned floating error variant fragment between CustodyEntry and DataKey.
- Removed duplicate PendingTransfer struct definition (kept the version with timeout_secs).
- Removed duplicate initiate_transfer() function (kept initiate_transfer_with_timeout delegation version).
- Removed first duplicate reclaim_transfer() (kept the fully documented version).
- Removed duplicate EVT_TRANSFER_* constants block (kept the block with EVT_TRANSFER_EXPIRED).
- Added InvalidTimeoutDays = 31 to ContractError enum (was missing, used in code).
- Fixed batch_initiate_transfer to include timeout_secs in PendingTransfer construction.
- Fixed initiate_transfer DEFAULT_TRANSFER_TIMEOUT_SECONDS / 86400 u64-to-u32 cast.
- Added missing contract entrypoints: init_trusted_contract, validate_trusted_contract, get_trusted_contract_address, update_trusted_contract, get_transfer_timeout_secs (called in test.rs but not defined in lib.rs).
- Removed unused Map import from lib.rs.
- Updated test.rs imports to include AdoptionState.

# Pull Request

## Related Issue

Closes #[issue_id]

## Description of Changes

<!-- Provide a clear and concise description of what this PR does. -->
<!-- Explain the problem this PR solves and how it addresses it. -->

## Type of Change

<!-- Please check the relevant option(s) by replacing [ ] with [x]. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Testing Done

<!-- Describe the tests you ran and how to reproduce them. -->
<!-- Include details of your testing environment. -->

- [ ] All existing tests pass (`cargo test`)
- [ ] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [ ] Manually verified expected behavior

### Test Environment

- Rust version:
- Stellar CLI version:
- OS:

## Checklist

<!-- Please check all that apply by replacing [ ] with [x]. -->

- [ ] My code follows the project's code style guidelines (`cargo fmt`)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] No hardcoded secrets, keys, or credentials are included in this PR
- [ ] No plaintext encryption keys or sensitive data are exposed in the code
- [ ] Input validation is properly implemented for all public functions
- [ ] Authentication checks are in place for state-changing operations
- [ ] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

<!-- If this PR touches security-sensitive code, describe the security implications. -->
<!-- For encryption, access control, or authentication changes, detail your approach. -->

## Screenshots / Logs (if applicable)

<!-- Add any relevant screenshots, logs, or output to help illustrate the changes. -->

## Additional Notes

<!-- Add any other context or notes about the PR here. -->
