### PR TITLE
Tenant-scoped rate limits, photo storage quota, WS auth, log redaction

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -3,7 +3,7 @@ use crate::db::PostgresTwoFactorStore;
 use crate::error::ApiError;
 use crate::leaderboard::{leaderboard_ws_endpoint, FlaggedScoreStore, FlaggedScoreSubmission};
 use crate::rate_limiter::{
-    InMemoryRateLimiter, RateLimitResult, RateLimiter, TenantRateLimitKey, UserQuotaStore,
+    InMemoryRateLimiter, RateLimitResult, RateLimiter, UserQuotaStore,
 };
 use crate::two_factor::{
     AuditLogEntry, HmacAlgorithm, InMemoryStore, LockedUserSummary, TenantConfig, TenantRegistry,
@@ -1298,12 +1298,11 @@ impl MultiTenantHandlers {
         caller.authorize(user_id).map_err(|e| e.to_string())?;
 
         let max_failures = self.store.config.rate_limit_max_failures;
-        let key = TenantRateLimitKey::new(
-            &self.store.config.tenant_id,
-            "verify",
-            user_id,
-        );
-        if let RateLimitResult::Blocked { retry_after_secs, .. } = self.limiter.record_failure(key.as_str()) {
+        let tenant_id = self.store.config.tenant_id.clone();
+        let key = format!("verify:{user_id}");
+        if let RateLimitResult::Blocked { retry_after_secs, .. } =
+            self.limiter.check(Some(&tenant_id), &key)
+        {
             return Err(ApiError::rate_limited(
                 format!(
                     "Too many failed attempts. Retry after {} seconds.",
@@ -1322,7 +1321,7 @@ impl MultiTenantHandlers {
         )?;
         if result {
             self.store.update_enabled(user_id, true)?;
-            self.limiter.record_success(key.as_str());
+            self.limiter.record(Some(&tenant_id), &key);
         }
         Ok(result)
     }
@@ -1335,12 +1334,11 @@ impl MultiTenantHandlers {
     ) -> Result<bool, String> {
         caller.authorize(user_id).map_err(|e| e.to_string())?;
 
-        let key = TenantRateLimitKey::new(
-            &self.store.config.tenant_id,
-            "disable",
-            user_id,
-        );
-        if let RateLimitResult::Blocked { retry_after_secs, .. } = self.limiter.record_failure(key.as_str()) {
+        let tenant_id = self.store.config.tenant_id.clone();
+        let key = format!("disable:{user_id}");
+        if let RateLimitResult::Blocked { retry_after_secs, .. } =
+            self.limiter.check(Some(&tenant_id), &key)
+        {
             return Err(ApiError::rate_limited(
                 format!(
                     "Too many failed attempts. Retry after {} seconds.",
@@ -1361,7 +1359,7 @@ impl MultiTenantHandlers {
         )?;
         if result {
             self.store.update_enabled(user_id, false)?;
-            self.limiter.record_success(key.as_str());
+            self.limiter.record(Some(&tenant_id), &key);
         }
         Ok(result)
     }

--- a/backend-2fa/src/leaderboard.rs
+++ b/backend-2fa/src/leaderboard.rs
@@ -483,34 +483,118 @@ pub fn broadcast_score_update(user_id: impl Into<String>, new_score: u64, rank: 
     });
 }
 
-/// Validate the `Authorization: Bearer <token>` header for the leaderboard
-/// WebSocket endpoint.
+/// Environment variable holding the HMAC-SHA256 secret used to verify
+/// leaderboard WebSocket JWTs.
+const LEADERBOARD_WS_JWT_SECRET_ENV: &str = "LEADERBOARD_WS_JWT_SECRET";
+
+/// Result of validating the leaderboard WebSocket bearer token.
+enum WsAuth {
+    /// A legacy opaque shared-secret token was accepted. No per-user
+    /// identity is available for this form.
+    LegacyToken,
+    /// A JWT was verified; carries the authenticated caller derived from
+    /// the `sub` claim.
+    Jwt(crate::handlers::AuthenticatedUser),
+}
+
+fn current_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Validate the raw bearer token used to authenticate the leaderboard
+/// WebSocket upgrade handshake (already stripped of any `Bearer ` prefix).
 ///
-/// * If `LEADERBOARD_WS_AUTH_TOKEN` is set, the provided token must match it exactly.
-/// * If the env var is unset, any non-empty Bearer token is accepted (development mode).
-/// * A missing or empty token always returns `false`.
+/// Accepts two forms:
+/// * A three-segment JWT (`header.payload.signature`) — verified via
+///   HMAC-SHA256 against `LEADERBOARD_WS_JWT_SECRET` and rejected if the
+///   signature is invalid or the `exp` claim has passed.
+/// * A legacy opaque token — compared against `LEADERBOARD_WS_AUTH_TOKEN`,
+///   or accepted as-is when that variable is unset (development mode).
+///
+/// A missing or empty token always returns `None`.
+fn authenticate_ws_token(token: &str) -> Option<WsAuth> {
+    if token.is_empty() {
+        return None;
+    }
+
+    if token.matches('.').count() == 2 {
+        let secret = std::env::var(LEADERBOARD_WS_JWT_SECRET_ENV).unwrap_or_default();
+        if secret.is_empty() {
+            return None;
+        }
+        let claims =
+            crate::two_factor::verify_jwt(token, secret.as_bytes(), current_unix_secs()).ok()?;
+        return Some(WsAuth::Jwt(crate::handlers::AuthenticatedUser::new(
+            claims.sub,
+        )));
+    }
+
+    let expected = std::env::var("LEADERBOARD_WS_AUTH_TOKEN").unwrap_or_default();
+    if expected.is_empty() || token == expected {
+        Some(WsAuth::LegacyToken)
+    } else {
+        None
+    }
+}
+
+/// Validate the `Authorization: Bearer <token>` header for the leaderboard
+/// WebSocket endpoint. Kept for backward compatibility with existing
+/// callers/tests; new code should use [`authenticate_ws_token`] directly.
 pub(crate) fn validate_ws_auth_token(authorization_header: Option<&str>) -> bool {
     let provided = match authorization_header.and_then(|v| v.strip_prefix("Bearer ")) {
         Some(t) if !t.is_empty() => t,
         _ => return false,
     };
+    authenticate_ws_token(provided).is_some()
+}
 
-    let expected = std::env::var("LEADERBOARD_WS_AUTH_TOKEN").unwrap_or_default();
-    expected.is_empty() || provided == expected
+/// Extract the bearer token for the leaderboard WS handshake from either the
+/// `Authorization: Bearer <token>` header or a `token` query parameter.
+/// Browser `WebSocket` clients cannot set custom headers during the
+/// handshake, so the query parameter is accepted as a fallback.
+fn extract_ws_token(req: &HttpRequest) -> Option<String> {
+    if let Some(token) = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .filter(|t| !t.is_empty())
+    {
+        return Some(token.to_string());
+    }
+
+    req.query_string().split('&').find_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        if key == "token" && !value.is_empty() {
+            Some(value.to_string())
+        } else {
+            None
+        }
+    })
 }
 
 /// Actix-web websocket endpoint for `GET /leaderboard/ws`.
+///
+/// The upgrade handshake requires a valid Bearer JWT (or, for browser
+/// clients that cannot set headers on a WebSocket handshake, a `token`
+/// query parameter). Missing, malformed, unsigned, or expired tokens are
+/// rejected with `401 Unauthorized` before the WebSocket handshake
+/// completes.
 pub async fn leaderboard_ws_endpoint(
     req: HttpRequest,
     stream: Payload,
 ) -> Result<HttpResponse, Error> {
-    let auth_header = req
-        .headers()
-        .get("Authorization")
-        .and_then(|v| v.to_str().ok());
+    let token = extract_ws_token(&req);
+    let auth = token
+        .as_deref()
+        .and_then(authenticate_ws_token)
+        .ok_or_else(|| ErrorUnauthorized("Authentication required"))?;
 
-    if !validate_ws_auth_token(auth_header) {
-        return Err(ErrorUnauthorized("Authentication required"));
+    if let WsAuth::Jwt(caller) = &auth {
+        tracing::debug!(user_id = %caller.user_id, "Leaderboard WebSocket authenticated");
     }
 
     let peer_ip = req

--- a/backend-2fa/src/rate_limiter.rs
+++ b/backend-2fa/src/rate_limiter.rs
@@ -55,10 +55,38 @@ impl RateLimitResult {
     }
 }
 
+/// Build a rate-limit key optionally namespaced by tenant.
+///
+/// When `tenant_id` is `Some` and non-empty, the key becomes
+/// `"{tenant_id}:{key}"` so that two tenants sharing the same
+/// `user_id`/`endpoint` never share a rate-limit bucket. Returns `key`
+/// unchanged when `tenant_id` is `None` (or empty), preserving existing
+/// single-tenant behavior.
+pub fn tenant_scoped_key(tenant_id: Option<&str>, key: &str) -> String {
+    match tenant_id {
+        Some(tid) if !tid.is_empty() => format!("{tid}:{key}"),
+        _ => key.to_string(),
+    }
+}
+
 /// A pluggable rate limiter interface.
 pub trait RateLimiter: Send + Sync {
     fn record_failure(&self, key: &str) -> RateLimitResult;
     fn record_success(&self, key: &str);
+
+    /// Tenant-scoped variant of `record_failure`. When `tenant_id` is
+    /// `Some`, the underlying key is namespaced per-tenant (see
+    /// [`tenant_scoped_key`]) so a noisy tenant cannot exhaust another
+    /// tenant's rate-limit budget. Falls back to unscoped `record_failure`
+    /// when `tenant_id` is `None`.
+    fn check(&self, tenant_id: Option<&str>, key: &str) -> RateLimitResult {
+        self.record_failure(&tenant_scoped_key(tenant_id, key))
+    }
+
+    /// Tenant-scoped variant of `record_success` (see [`RateLimiter::check`]).
+    fn record(&self, tenant_id: Option<&str>, key: &str) {
+        self.record_success(&tenant_scoped_key(tenant_id, key))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -645,6 +673,14 @@ impl RateLimiter for InMemoryRateLimiter {
         let mut records = self.records.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         records.remove(key);
     }
+
+    fn check(&self, tenant_id: Option<&str>, key: &str) -> RateLimitResult {
+        self.record_failure(&tenant_scoped_key(tenant_id, key))
+    }
+
+    fn record(&self, tenant_id: Option<&str>, key: &str) {
+        self.record_success(&tenant_scoped_key(tenant_id, key))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -828,6 +864,14 @@ impl RateLimiter for RedisRateLimiter {
     }
     fn record_success(&self, key: &str) {
         self.inner.record_success(key)
+    }
+
+    fn check(&self, tenant_id: Option<&str>, key: &str) -> RateLimitResult {
+        self.inner.check(tenant_id, key)
+    }
+
+    fn record(&self, tenant_id: Option<&str>, key: &str) {
+        self.inner.record(tenant_id, key)
     }
 }
 

--- a/backend-2fa/src/tracing_middleware.rs
+++ b/backend-2fa/src/tracing_middleware.rs
@@ -75,14 +75,17 @@ impl TraceContext {
     }
 }
 
-/// List of sensitive fields that should be redacted in logs
+/// List of sensitive fields that should be redacted in logs, regardless of
+/// nesting depth. Add new field names here to extend redaction coverage.
 const SENSITIVE_FIELDS: &[&str] = &[
     "totp_code",
+    "totp_token",
     "secret",
     "recovery_code",
     "password",
     "token",
     "backup_code",
+    "backup_codes",
 ];
 
 /// Sanitize JSON by redacting sensitive fields

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -1,7 +1,9 @@
+use hmac::{Hmac, Mac};
 use rand::distributions::{Distribution, Uniform};
 use rand::thread_rng;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -1197,4 +1199,90 @@ impl TenantRegistry {
     pub fn get_config(&self, tenant_id: &str) -> Option<TenantConfig> {
         self.tenants.lock().unwrap().get(tenant_id).cloned()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight JWT verification (Issue #783 — leaderboard WebSocket auth)
+// ---------------------------------------------------------------------------
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Claims extracted from a verified leaderboard-WS JWT.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JwtClaims {
+    /// Subject — the authenticated user's ID.
+    pub sub: String,
+    /// Expiry, in unix seconds. The token is rejected once `now >= exp`.
+    pub exp: u64,
+}
+
+/// Decode a base64url (no padding) string into bytes, per RFC 4648 §5.
+fn base64url_decode(input: &str) -> Result<Vec<u8>, String> {
+    fn value(byte: u8) -> Option<u8> {
+        match byte {
+            b'A'..=b'Z' => Some(byte - b'A'),
+            b'a'..=b'z' => Some(byte - b'a' + 26),
+            b'0'..=b'9' => Some(byte - b'0' + 52),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None,
+        }
+    }
+
+    let mut out = Vec::with_capacity(input.len() * 3 / 4 + 3);
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+
+    for &byte in input.as_bytes() {
+        let v = value(byte).ok_or_else(|| "invalid base64url character".to_string())?;
+        buffer = (buffer << 6) | v as u32;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((buffer >> bits) & 0xFF) as u8);
+        }
+    }
+
+    Ok(out)
+}
+
+/// Verify an HS256-signed JWT and return its claims.
+///
+/// Returns `Err` if the token is malformed, uses an unsupported algorithm,
+/// has an invalid signature, or is expired (`exp <= now_unix_secs`).
+/// `now_unix_secs` is passed in explicitly so callers can test expiry
+/// without depending on wall-clock time.
+pub fn verify_jwt(token: &str, secret: &[u8], now_unix_secs: u64) -> Result<JwtClaims, String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return Err("malformed token".to_string());
+    }
+    let header_b64 = parts[0];
+    let payload_b64 = parts[1];
+    let sig_b64 = parts[2];
+
+    let header_bytes = base64url_decode(header_b64)?;
+    let header: serde_json::Value =
+        serde_json::from_slice(&header_bytes).map_err(|_| "invalid header".to_string())?;
+    if header.get("alg").and_then(|v| v.as_str()) != Some("HS256") {
+        return Err("unsupported algorithm".to_string());
+    }
+
+    let signature = base64url_decode(sig_b64)?;
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let mut mac =
+        HmacSha256::new_from_slice(secret).map_err(|_| "invalid secret".to_string())?;
+    mac.update(signing_input.as_bytes());
+    mac.verify_slice(&signature)
+        .map_err(|_| "invalid signature".to_string())?;
+
+    let payload_bytes = base64url_decode(payload_b64)?;
+    let claims: JwtClaims =
+        serde_json::from_slice(&payload_bytes).map_err(|_| "invalid claims".to_string())?;
+
+    if claims.exp <= now_unix_secs {
+        return Err("token expired".to_string());
+    }
+
+    Ok(claims)
 }

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -4955,6 +4955,10 @@ impl PetChainContract {
             if let Err(err) = PetChainContract::validate_ipfs_hash(&env, &photo_hash) {
                 env.panic_with_error(err);
             }
+
+            // Check storage quota (Issue #782)
+            Self::increment_pet_storage(&env, pet_id);
+
             pet.photo_hashes.push_back(photo_hash);
             pet.updated_at = env.ledger().timestamp();
             env.storage().instance().set(&DataKey::Pet(pet_id), &pet);


### PR DESCRIPTION
## Summary

Four fixes bundled into this PR:

- **Tenant-scoped rate limiting (#777):** `RateLimiter` gains `check()`/`record()` methods that accept an optional `tenant_id: Option<&str>` and namespace the underlying key as `"{tenant_id}:{key}"`, so two tenants sharing a `user_id`/`endpoint` no longer share a rate-limit bucket. Falls back to the existing unscoped key when `tenant_id` is `None`. Implemented as default trait methods, explicitly overridden in `InMemoryRateLimiter` and `RedisRateLimiter`, and wired into `MultiTenantHandlers::verify_and_activate`/`disable_two_factor`.

- **Storage quota enforcement for pet photos (#782):** `add_pet_photo` now calls the existing `increment_pet_storage` quota check/decrement (the same helper used by medical/vaccination records) before appending a photo hash, so each photo counts as 1 storage unit against the pet's quota and the call panics with `ContractError::StorageQuotaExceeded` once the quota is exhausted. Quota admin functions are untouched.

- **WebSocket leaderboard authentication (#783):** the `/leaderboard/ws` upgrade handshake now verifies a real Bearer JWT (HS256, checked against `LEADERBOARD_WS_JWT_SECRET`, expiry enforced via the `exp` claim), accepted from the `Authorization` header or a `token` query parameter for browser clients that can't set custom headers on a WebSocket handshake. Missing, malformed, unsigned, or expired tokens are rejected with `401` before the WebSocket handshake completes. The legacy opaque shared-secret token path is preserved for backward compatibility. `LeaderboardWsHub` broadcast logic is unchanged.

- **Redact sensitive fields from request logs (#787):** `sanitize_json_body`'s const redaction list now also covers `totp_token` and `backup_codes` (previously only the singular `totp_code`/`backup_code` were listed), redacted regardless of nesting depth via the existing recursive traversal.

## Test plan
- [ ] `cargo test -p petchain-2fa`
- [ ] `cargo test -p stellar-contracts`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`

Closes #777
Closes #782
Closes #783
Closes #787