### PR TITLE
feat: add functionality to revoke vaccination certificates with autho…

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -846,6 +846,9 @@ pub struct Vaccination {
     pub encrypted_batch_number: EncryptedData, // Encrypted value
 
     pub created_at: u64,
+
+    pub revoked: bool,
+    pub revocation_reason: Option<String>,
 }
 
 /// Certificate anchor for vaccination PDF metadata
@@ -976,6 +979,7 @@ pub enum EventType {
     TreatmentAdded,
     MedicalRecordAdded,
     VaccinationAdded,
+    VaccinationRevoked,
     AccessGranted,
     AccessRevoked,
     InsuranceClaimSubmitted,
@@ -2061,6 +2065,17 @@ pub struct VaccinationAddedEvent {
     pub next_due_date: u64,
     pub timestamp: u64,
     pub subscription_ids: Vec<u64>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaccinationRevokedEvent {
+    pub version: u32,
+    pub pet_id: u64,
+    pub vaccination_id: u64,
+    pub vet_or_admin: Address,
+    pub reason: String,
+    pub timestamp: u64,
 }
 
 #[contracttype]
@@ -5798,6 +5813,8 @@ impl PetChainContract {
             batch_number: None,
             encrypted_batch_number,
             created_at: now,
+            revoked: false,
+            revocation_reason: None,
         };
 
         PetChainContract::update_vet_stats(&env, &veterinarian, pet_id, 1, 1, 0);
@@ -5862,6 +5879,54 @@ impl PetChainContract {
         PetChainContract::check_and_emit_expiry_events(env, pet_id, 30);
 
         vaccine_id
+    }
+
+    pub fn revoke_vaccination_certificate(
+        env: Env,
+        vet_or_admin: Address,
+        pet_id: u64,
+        cert_id: u64,
+        reason: String,
+    ) {
+        vet_or_admin.require_auth();
+
+        // Must exist
+        let mut vax: Vaccination = env
+            .storage()
+            .instance()
+            .get(&MedicalKey::Vaccination(cert_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::VaccinationNotFound));
+
+        // Must match pet
+        if vax.pet_id != pet_id {
+            panic_with_error!(&env, ContractError::VaccinationNotFound);
+        }
+
+        // Verify authorization: must be issuing vet OR admin
+        let is_admin = PetChainContract::is_admin(&env, &vet_or_admin);
+        if !is_admin && vax.veterinarian != vet_or_admin {
+            panic_with_error!(&env, ContractError::Unauthorized);
+        }
+
+        vax.revoked = true;
+        vax.revocation_reason = Some(reason.clone());
+
+        env.storage()
+            .instance()
+            .set(&MedicalKey::Vaccination(cert_id), &vax);
+
+        // Emit event
+        env.events().publish(
+            (String::from_str(&env, "VaccinationRevoked"), pet_id),
+            VaccinationRevokedEvent {
+                version: EVENT_SCHEMA_VERSION,
+                pet_id,
+                vaccination_id: cert_id,
+                vet_or_admin,
+                reason,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -6131,7 +6196,7 @@ impl PetChainContract {
         let mut most_recent: Option<Vaccination> = None;
 
         for vax in history.iter() {
-            if vax.vaccine_type == vaccine_type {
+            if vax.vaccine_type == vaccine_type && !vax.revoked {
                 match most_recent.clone() {
                     Some(current) => {
                         if vax.administered_at > current.administered_at {

--- a/stellar-contracts/src/test_vaccination_certificate.rs
+++ b/stellar-contracts/src/test_vaccination_certificate.rs
@@ -461,3 +461,72 @@ fn test_anchor_timestamp_recorded() {
     assert!(anchor.anchored_at >= before_time);
     assert!(anchor.anchored_at <= after_time);
 }
+
+#[test]
+fn test_revoke_vaccination_certificate_by_issuing_vet() {
+    let (env, client, _admin) = setup();
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+
+    let pet_id = register_pet(&client, &env, &owner);
+    register_and_verify_vet(&client, &env, &vet);
+    let vax_id = add_vaccination(&client, &env, pet_id, &vet);
+
+    // Verify it's current
+    assert!(client.is_vaccination_current(&pet_id, &VaccineType::Rabies));
+
+    let reason = String::from_str(&env, "Issued in error");
+    client.revoke_vaccination_certificate(&vet, &pet_id, &vax_id, &reason);
+
+    // Verify it's revoked
+    let vax = client.get_vaccinations(&vax_id).unwrap();
+    assert!(vax.revoked);
+    assert_eq!(vax.revocation_reason.unwrap(), reason);
+
+    // Verify it's no longer current
+    assert!(!client.is_vaccination_current(&pet_id, &VaccineType::Rabies));
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_revoke_vaccination_certificate_by_third_party_vet() {
+    let (env, client, _admin) = setup();
+    let owner = Address::generate(&env);
+    let vet1 = Address::generate(&env);
+    let vet2 = Address::generate(&env);
+
+    let pet_id = register_pet(&client, &env, &owner);
+    register_and_verify_vet(&client, &env, &vet1);
+    client.register_vet(
+        &vet2,
+        &String::from_str(&env, "Dr. Other"),
+        &String::from_str(&env, "VET444"),
+        &String::from_str(&env, "General Practice"),
+    );
+    client.verify_vet_license(&vet2, &String::from_str(&env, "VET444"));
+
+    let vax_id = add_vaccination(&client, &env, pet_id, &vet1);
+
+    // Vet 2 tries to revoke Vet 1's certificate
+    let reason = String::from_str(&env, "Should fail");
+    client.revoke_vaccination_certificate(&vet2, &pet_id, &vax_id, &reason);
+}
+
+#[test]
+fn test_revoke_vaccination_certificate_by_admin() {
+    let (env, client, admin) = setup();
+    let owner = Address::generate(&env);
+    let vet = Address::generate(&env);
+
+    let pet_id = register_pet(&client, &env, &owner);
+    register_and_verify_vet(&client, &env, &vet);
+    let vax_id = add_vaccination(&client, &env, pet_id, &vet);
+
+    let reason = String::from_str(&env, "Admin revocation");
+    client.revoke_vaccination_certificate(&admin, &pet_id, &vax_id, &reason);
+
+    let vax = client.get_vaccinations(&vax_id).unwrap();
+    assert!(vax.revoked);
+    assert_eq!(vax.revocation_reason.unwrap(), reason);
+}
+


### PR DESCRIPTION
# Description

Closes #784 

This PR introduces the ability to revoke a vaccination certificate. This provides a necessary safety mechanism for certificates that were issued in error or invalidated by a follow-up health check.

## Changes Made

- **Struct Updates**: Added `revoked: bool` and `revocation_reason: Option<String>` to the `Vaccination` struct in `stellar-contracts/src/lib.rs`. Existing certificates are preserved without deletion.
- **Revocation Logic**: Implemented a new `revoke_vaccination_certificate(vet_or_admin, pet_id, cert_id, reason)` function.
- **Authorization**: The contract enforces that only the exact issuing veterinarian or a recognized multisig admin can execute the revocation, throwing an `Unauthorized` error otherwise.
- **Validity Check**: Updated `is_vaccination_current` to proactively filter out revoked certificates so they are no longer treated as active.
- **Events**: Added and emitted a new `VaccinationRevokedEvent` upon successful revocation.

## Testing

Added three new tests in `test_vaccination_certificate.rs` covering all required scenarios:
1. `test_revoke_vaccination_certificate_by_issuing_vet`: Verifies the issuing vet can successfully revoke a certificate and that it is no longer considered current.
2. `test_revoke_vaccination_certificate_by_third_party_vet`: Ensures attempting revocation by a different vet appropriately panics with an `Unauthorized` error.
3. `test_revoke_vaccination_certificate_by_admin`: Verifies that a system admin has the authority to safely revoke a certificate.
