### PR TITLE
feat(escrow): replace assert! with typed panic_with_error errors

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/src/escrow.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/escrow.rs
@@ -14,7 +14,20 @@
 //!   DataKey::PlatformFeeBps          → u32
 //!   DataKey::PlatformFeeRecipient    → Address
 
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracterror, contracttype, panic_with_error, Address, Env};
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EscrowError {
+    FeeBpsTooHigh = 1,
+    InvalidAmount = 2,
+    EscrowAlreadyExists = 3,
+    EscrowNotFound = 4,
+    InvalidEscrowState = 5,
+    Unauthorized = 6,
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -59,7 +72,9 @@ pub fn compute_seller_amount(amount: i128, fee_bps: u32) -> i128 {
 // ─── Config ───────────────────────────────────────────────────────────────────
 
 pub fn init_escrow_config(env: &Env, fee_bps: u32, fee_recipient: Address) {
-    assert!(fee_bps <= 10_000, "fee_bps must be <= 10000");
+    if fee_bps > 10_000 {
+        panic_with_error!(env, EscrowError::FeeBpsTooHigh);
+    }
     env.storage().instance().set(&EscrowDataKey::FeeBps, &fee_bps);
     env.storage().instance().set(&EscrowDataKey::FeeRecipient, &fee_recipient);
     // Store the initial caller as Admin (first call sets the admin)
@@ -97,7 +112,9 @@ pub fn get_fee_recipient(env: &Env) -> Option<Address> {
 /// Existing in-flight escrows are NOT retroactively updated (they capture fee_bps at deposit time).
 /// Closes issue #1005.
 pub fn update_fee_config(env: &Env, new_fee_bps: u32, new_fee_recipient: Address) {
-    assert!(new_fee_bps <= 10_000, "fee_bps must be <= 10000");
+    if new_fee_bps > 10_000 {
+        panic_with_error!(env, EscrowError::FeeBpsTooHigh);
+    }
 
     // Require admin auth
     let admin: Address = env
@@ -124,9 +141,13 @@ pub fn update_fee_config(env: &Env, new_fee_bps: u32, new_fee_recipient: Address
 /// Buyer deposits adoption fee into escrow.
 pub fn deposit_fee(env: &Env, transfer_id: u64, buyer: Address, seller: Address, amount: i128) {
     buyer.require_auth();
-    assert!(amount > 0, "amount must be positive");
+    if amount <= 0 {
+        panic_with_error!(env, EscrowError::InvalidAmount);
+    }
     let key = EscrowDataKey::Entry(transfer_id);
-    assert!(!env.storage().persistent().has(&key), "escrow already exists");
+    if env.storage().persistent().has(&key) {
+        panic_with_error!(env, EscrowError::EscrowAlreadyExists);
+    }
     let entry = EscrowEntry {
         transfer_id,
         buyer:            buyer.clone(),
@@ -145,8 +166,13 @@ pub fn deposit_fee(env: &Env, transfer_id: u64, buyer: Address, seller: Address,
 /// Releases escrowed fee to seller minus platform fee.
 pub fn finalize_transfer(env: &Env, transfer_id: u64) {
     let key = EscrowDataKey::Entry(transfer_id);
-    let mut entry: EscrowEntry = env.storage().persistent().get(&key).expect("escrow not found");
-    assert!(entry.status == EscrowStatus::Held, "cannot finalize: not in Held state");
+    let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
+        Some(entry) => entry,
+        None => panic_with_error!(env, EscrowError::EscrowNotFound),
+    };
+    if entry.status != EscrowStatus::Held {
+        panic_with_error!(env, EscrowError::InvalidEscrowState);
+    }
     let platform_fee  = compute_platform_fee(entry.amount, entry.platform_fee_bps);
     let seller_amount = entry.amount - platform_fee;
     // Wire-up: token_client.transfer(&contract, &entry.seller, &seller_amount);
@@ -162,11 +188,13 @@ pub fn finalize_transfer(env: &Env, transfer_id: u64) {
 /// Refunds the full fee to the buyer (from Held or Disputed state).
 pub fn refund_fee(env: &Env, transfer_id: u64) {
     let key = EscrowDataKey::Entry(transfer_id);
-    let mut entry: EscrowEntry = env.storage().persistent().get(&key).expect("escrow not found");
-    assert!(
-        entry.status == EscrowStatus::Held || entry.status == EscrowStatus::Disputed,
-        "cannot refund: invalid state"
-    );
+    let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
+        Some(entry) => entry,
+        None => panic_with_error!(env, EscrowError::EscrowNotFound),
+    };
+    if entry.status != EscrowStatus::Held && entry.status != EscrowStatus::Disputed {
+        panic_with_error!(env, EscrowError::InvalidEscrowState);
+    }
     // Wire-up: token_client.transfer(&contract, &entry.buyer, &entry.amount);
     entry.status = EscrowStatus::Refunded;
     env.storage().persistent().set(&key, &entry);
@@ -180,9 +208,16 @@ pub fn refund_fee(env: &Env, transfer_id: u64) {
 pub fn dispute_transfer(env: &Env, transfer_id: u64, initiator: Address) {
     initiator.require_auth();
     let key = EscrowDataKey::Entry(transfer_id);
-    let mut entry: EscrowEntry = env.storage().persistent().get(&key).expect("escrow not found");
-    assert!(entry.status == EscrowStatus::Held, "cannot dispute: not in Held state");
-    assert!(initiator == entry.buyer || initiator == entry.seller, "only buyer or seller may dispute");
+    let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
+        Some(entry) => entry,
+        None => panic_with_error!(env, EscrowError::EscrowNotFound),
+    };
+    if entry.status != EscrowStatus::Held {
+        panic_with_error!(env, EscrowError::InvalidEscrowState);
+    }
+    if initiator != entry.buyer && initiator != entry.seller {
+        panic_with_error!(env, EscrowError::Unauthorized);
+    }
     entry.status = EscrowStatus::Disputed;
     env.storage().persistent().set(&key, &entry);
 }
@@ -196,35 +231,43 @@ pub fn get_escrow(env: &Env, transfer_id: u64) -> Option<EscrowEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PetOwnershipContract;
     use soroban_sdk::{testutils::Address as _, Address, Env};
 
-    fn setup() -> (Env, Address, Address, Address) {
+    /// Escrow config lives in instance storage, so every test body must run
+    /// inside a contract frame — `setup` returns the registered contract id.
+    fn setup() -> (Env, Address, Address, Address, Address) {
         let env      = Env::default();
         env.mock_all_auths();
+        let contract = env.register_contract(None, PetOwnershipContract);
         let buyer    = Address::generate(&env);
         let seller   = Address::generate(&env);
         let platform = Address::generate(&env);
-        (env, buyer, seller, platform)
+        (env, contract, buyer, seller, platform)
     }
 
     #[test]
     fn deposit_creates_held_entry() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 250, platform);
-        deposit_fee(&env, 1, buyer.clone(), seller, 10_000_000);
-        let e = get_escrow(&env, 1).unwrap();
-        assert_eq!(e.status, EscrowStatus::Held);
-        assert_eq!(e.amount, 10_000_000);
-        assert_eq!(e.buyer,  buyer);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 1, buyer.clone(), seller, 10_000_000);
+            let e = get_escrow(&env, 1).unwrap();
+            assert_eq!(e.status, EscrowStatus::Held);
+            assert_eq!(e.amount, 10_000_000);
+            assert_eq!(e.buyer,  buyer);
+        });
     }
 
     #[test]
     fn finalize_sets_released() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 250, platform);
-        deposit_fee(&env, 2, buyer, seller, 10_000_000);
-        finalize_transfer(&env, 2);
-        assert_eq!(get_escrow(&env, 2).unwrap().status, EscrowStatus::Released);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 2, buyer, seller, 10_000_000);
+            finalize_transfer(&env, 2);
+            assert_eq!(get_escrow(&env, 2).unwrap().status, EscrowStatus::Released);
+        });
     }
 
     #[test]
@@ -235,50 +278,64 @@ mod tests {
 
     #[test]
     fn refund_sets_refunded() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 100, platform);
-        deposit_fee(&env, 3, buyer, seller, 5_000_000);
-        refund_fee(&env, 3);
-        assert_eq!(get_escrow(&env, 3).unwrap().status, EscrowStatus::Refunded);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 100, platform);
+            deposit_fee(&env, 3, buyer, seller, 5_000_000);
+            refund_fee(&env, 3);
+            assert_eq!(get_escrow(&env, 3).unwrap().status, EscrowStatus::Refunded);
+        });
     }
 
     #[test]
     #[should_panic]
     fn cannot_finalize_twice() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 100, platform);
-        deposit_fee(&env, 4, buyer, seller, 1_000_000);
-        finalize_transfer(&env, 4);
-        finalize_transfer(&env, 4);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 100, platform);
+            deposit_fee(&env, 4, buyer, seller, 1_000_000);
+            finalize_transfer(&env, 4);
+            finalize_transfer(&env, 4);
+        });
     }
 
     #[test]
     #[should_panic]
     fn cannot_refund_after_release() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 100, platform);
-        deposit_fee(&env, 5, buyer, seller, 1_000_000);
-        finalize_transfer(&env, 5);
-        refund_fee(&env, 5);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 100, platform);
+            deposit_fee(&env, 5, buyer, seller, 1_000_000);
+            finalize_transfer(&env, 5);
+            refund_fee(&env, 5);
+        });
     }
 
     #[test]
     fn dispute_freezes_escrow() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 100, platform);
-        deposit_fee(&env, 6, buyer.clone(), seller, 2_000_000);
-        dispute_transfer(&env, 6, buyer);
-        assert_eq!(get_escrow(&env, 6).unwrap().status, EscrowStatus::Disputed);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 100, platform);
+            deposit_fee(&env, 6, buyer.clone(), seller, 2_000_000);
+        });
+        env.as_contract(&cid, || {
+            dispute_transfer(&env, 6, buyer);
+            assert_eq!(get_escrow(&env, 6).unwrap().status, EscrowStatus::Disputed);
+        });
     }
 
     #[test]
     fn refund_works_from_disputed() {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 100, platform);
-        deposit_fee(&env, 7, buyer.clone(), seller, 3_000_000);
-        dispute_transfer(&env, 7, buyer);
-        refund_fee(&env, 7);
-        assert_eq!(get_escrow(&env, 7).unwrap().status, EscrowStatus::Refunded);
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 100, platform);
+            deposit_fee(&env, 7, buyer.clone(), seller, 3_000_000);
+        });
+        env.as_contract(&cid, || {
+            dispute_transfer(&env, 7, buyer);
+            refund_fee(&env, 7);
+            assert_eq!(get_escrow(&env, 7).unwrap().status, EscrowStatus::Refunded);
+        });
     }
 
     #[test]
@@ -291,117 +348,211 @@ mod tests {
 
     /// finalize_transfer panics with "escrow not found" when no entry exists.
     #[test]
-    #[should_panic(expected = "escrow not found")]
+    #[should_panic(expected = "Error(Contract, #4)")]
     fn finalize_transfer_panics_on_missing_entry() {
-        let (env, _buyer, _seller, platform) = setup();
-        init_escrow_config(&env, 250, platform);
-        // transfer_id 999 was never deposited
-        finalize_transfer(&env, 999);
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            // transfer_id 999 was never deposited
+            finalize_transfer(&env, 999);
+        });
     }
 
     /// refund_fee panics with "escrow not found" when no entry exists.
     #[test]
-    #[should_panic(expected = "escrow not found")]
+    #[should_panic(expected = "Error(Contract, #4)")]
     fn refund_fee_panics_on_missing_entry() {
-        let (env, _buyer, _seller, platform) = setup();
-        init_escrow_config(&env, 250, platform);
-        // transfer_id 999 was never deposited
-        refund_fee(&env, 999);
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            // transfer_id 999 was never deposited
+            refund_fee(&env, 999);
+        });
     }
 
     /// dispute_transfer panics with "escrow not found" when no entry exists.
     #[test]
-    #[should_panic(expected = "escrow not found")]
+    #[should_panic(expected = "Error(Contract, #4)")]
     fn dispute_transfer_panics_on_missing_entry() {
-        let (env, buyer, _seller, platform) = setup();
-        init_escrow_config(&env, 250, platform);
-        // transfer_id 999 was never deposited
-        dispute_transfer(&env, 999, buyer);
+        let (env, cid, buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            // transfer_id 999 was never deposited
+            dispute_transfer(&env, 999, buyer);
+        });
     }
 
     // ── Issue #1004: get_fee_bps and get_fee_recipient view functions ─────────
 
     #[test]
     fn get_fee_bps_returns_configured_value() {
-        let (env, _buyer, _seller, platform) = setup();
-        init_escrow_config(&env, 300, platform);
-        assert_eq!(get_fee_bps(&env), 300);
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 300, platform);
+            assert_eq!(get_fee_bps(&env), 300);
+        });
     }
 
     #[test]
     fn get_fee_bps_returns_zero_when_not_configured() {
-        let env = Env::default();
-        assert_eq!(get_fee_bps(&env), 0);
+        let (env, cid, _buyer, _seller, _platform) = setup();
+        env.as_contract(&cid, || {
+            assert_eq!(get_fee_bps(&env), 0);
+        });
     }
 
     #[test]
     fn get_fee_recipient_returns_configured_address() {
-        let (env, _buyer, _seller, platform) = setup();
-        init_escrow_config(&env, 150, platform.clone());
-        assert_eq!(get_fee_recipient(&env), Some(platform));
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 150, platform.clone());
+            assert_eq!(get_fee_recipient(&env), Some(platform));
+        });
     }
 
     #[test]
     fn get_fee_recipient_returns_none_when_not_configured() {
-        let env = Env::default();
-        assert_eq!(get_fee_recipient(&env), None);
+        let (env, cid, _buyer, _seller, _platform) = setup();
+        env.as_contract(&cid, || {
+            assert_eq!(get_fee_recipient(&env), None);
+        });
     }
 
     // ── Issue #1005: update_fee_config admin-only update ─────────────────────
 
     #[test]
     fn update_fee_config_changes_fee_bps_and_recipient() {
-        let (env, _buyer, _seller, platform) = setup();
-        env.mock_all_auths();
-        let new_recipient = Address::generate(&env);
-        init_escrow_config(&env, 250, platform.clone());
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            let new_recipient = Address::generate(&env);
+            init_escrow_config(&env, 250, platform.clone());
 
-        update_fee_config(&env, 100, new_recipient.clone());
+            update_fee_config(&env, 100, new_recipient.clone());
 
-        assert_eq!(get_fee_bps(&env), 100);
-        assert_eq!(get_fee_recipient(&env), Some(new_recipient));
+            assert_eq!(get_fee_bps(&env), 100);
+            assert_eq!(get_fee_recipient(&env), Some(new_recipient));
+        });
     }
 
     #[test]
     fn new_escrow_uses_updated_fee_rate() {
-        let (env, buyer, seller, platform) = setup();
-        env.mock_all_auths();
-        let new_recipient = Address::generate(&env);
-        init_escrow_config(&env, 250, platform.clone());
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            let new_recipient = Address::generate(&env);
+            init_escrow_config(&env, 250, platform.clone());
 
-        // Update fee to 500 bps (5%)
-        update_fee_config(&env, 500, new_recipient.clone());
+            // Update fee to 500 bps (5%)
+            update_fee_config(&env, 500, new_recipient.clone());
 
-        // New deposit captures the updated rate
-        deposit_fee(&env, 10, buyer.clone(), seller.clone(), 10_000_000);
-        let entry = get_escrow(&env, 10).unwrap();
-        assert_eq!(entry.platform_fee_bps, 500);
+            // New deposit captures the updated rate
+            deposit_fee(&env, 10, buyer.clone(), seller.clone(), 10_000_000);
+            let entry = get_escrow(&env, 10).unwrap();
+            assert_eq!(entry.platform_fee_bps, 500);
+        });
     }
 
     #[test]
     fn existing_escrow_keeps_original_fee_rate_after_update() {
-        let (env, buyer, seller, platform) = setup();
-        env.mock_all_auths();
-        let new_recipient = Address::generate(&env);
-        init_escrow_config(&env, 250, platform.clone());
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            let new_recipient = Address::generate(&env);
+            init_escrow_config(&env, 250, platform.clone());
 
-        // Deposit before update — captures 250 bps
-        deposit_fee(&env, 20, buyer.clone(), seller.clone(), 10_000_000);
+            // Deposit before update — captures 250 bps
+            deposit_fee(&env, 20, buyer.clone(), seller.clone(), 10_000_000);
 
-        // Update fee to 500 bps
-        update_fee_config(&env, 500, new_recipient.clone());
+            // Update fee to 500 bps
+            update_fee_config(&env, 500, new_recipient.clone());
 
-        // Existing escrow is unchanged
-        let entry = get_escrow(&env, 20).unwrap();
-        assert_eq!(entry.platform_fee_bps, 250);
+            // Existing escrow is unchanged
+            let entry = get_escrow(&env, 20).unwrap();
+            assert_eq!(entry.platform_fee_bps, 250);
+        });
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Error(Contract, #1)")]
     fn update_fee_config_rejects_fee_bps_over_10000() {
-        let (env, _buyer, _seller, platform) = setup();
-        env.mock_all_auths();
-        init_escrow_config(&env, 250, platform.clone());
-        update_fee_config(&env, 10_001, platform);
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform.clone());
+            update_fee_config(&env, 10_001, platform);
+        });
+    }
+
+    // ── Issue #1002: typed EscrowError variants ──────────────────────────────
+
+    /// init_escrow_config rejects a fee above 100% with FeeBpsTooHigh.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn init_escrow_config_rejects_fee_bps_over_10000() {
+        let (env, cid, _buyer, _seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 10_001, platform);
+        });
+    }
+
+    /// deposit_fee rejects a non-positive amount with InvalidAmount.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn deposit_fee_rejects_non_positive_amount() {
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 30, buyer, seller, 0);
+        });
+    }
+
+    /// A second deposit under the same transfer_id fails with EscrowAlreadyExists.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn deposit_fee_rejects_duplicate_transfer_id() {
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 31, buyer.clone(), seller.clone(), 1_000_000);
+        });
+        env.as_contract(&cid, || {
+            deposit_fee(&env, 31, buyer, seller, 1_000_000);
+        });
+    }
+
+    /// Finalizing an already-released escrow fails with InvalidEscrowState.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn finalize_transfer_rejects_non_held_state() {
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 32, buyer, seller, 1_000_000);
+            finalize_transfer(&env, 32);
+            finalize_transfer(&env, 32);
+        });
+    }
+
+    /// Refunding an already-released escrow fails with InvalidEscrowState.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn refund_fee_rejects_non_refundable_state() {
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 33, buyer, seller, 1_000_000);
+            finalize_transfer(&env, 33);
+            refund_fee(&env, 33);
+        });
+    }
+
+    /// A third party cannot dispute an escrow — Unauthorized.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #6)")]
+    fn dispute_transfer_rejects_third_party() {
+        let (env, cid, buyer, seller, platform) = setup();
+        env.as_contract(&cid, || {
+            let stranger = Address::generate(&env);
+            init_escrow_config(&env, 250, platform);
+            deposit_fee(&env, 34, buyer, seller, 1_000_000);
+            dispute_transfer(&env, 34, stranger);
+        });
     }
 }


### PR DESCRIPTION
## Summary

- Added `EscrowError` `#[contracterror]` enum (`FeeBpsTooHigh`, `InvalidAmount`, `EscrowAlreadyExists`, `EscrowNotFound`, `InvalidEscrowState`, `Unauthorized`) following the `vet_registry.rs` pattern
- Replaced every `assert!` and the `expect("escrow not found")` lookups in `escrow.rs` with `panic_with_error!`, so clients get typed contract error codes
- Added a test per error variant asserting the exact code
- Escrow tests now run inside a registered contract frame; escrow config lives in instance storage, which is unavailable outside one (these tests were failing on `main` before this change)

## Validation

- `cargo test` — 85 passed, 0 failed

Closes #1002