### PR TITLE
feat(adoption): add pending adoption expiry and cancel_expired_adoption

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
@@ -12,6 +12,9 @@ use soroban_sdk::{
 /// so it is independent of ledger sequence numbers.
 pub const TRANSFER_EXPIRY_SECONDS: u64 = 7 * 24 * 60 * 60; // 604 800 s
 
+/// Default lifetime of a `PendingAdoption` before anyone may cancel it: 30 days.
+pub const ADOPTION_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60; // 2 592 000 s
+
 /// Dispute window: after both parties sign, either party has 48 hours to raise
 /// a dispute before [`finalize_transfer`] may be called.
 pub const DISPUTE_WINDOW_SECONDS: u64 = 48 * 60 * 60; // 172 800 s
@@ -95,6 +98,9 @@ pub enum TransferType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AdoptionConfig {
     pub waiting_period_days: u32,
+    /// Seconds after `signed_at` at which a pending adoption may be cancelled
+    /// by anyone. `0` means the default [`ADOPTION_EXPIRY_SECONDS`] applies.
+    pub expiry_seconds: u64,
 }
 
 /// An adoption that has been signed but is still in the waiting period.
@@ -217,6 +223,7 @@ pub enum ContractError {
     AdoptionRejected = 29,
     InvalidApprover = 30,
     InvalidTimeoutDays = 31,
+    AdoptionNotExpired = 32,
 }
 
 /// ======================================================
@@ -284,6 +291,7 @@ const EVT_TRANSFER_FINALIZED: Symbol = symbol_short!("xfer_fin");
 const EVT_TRANSFER_DISPUTED: Symbol = symbol_short!("xfer_disp");
 const EVT_TRUSTED_UPDATED: Symbol = symbol_short!("trust_upd");
 const EVT_TRANSFER_EXPIRED: Symbol = symbol_short!("xfer_exp");
+const EVT_ADOPTION_EXPIRED: Symbol = symbol_short!("adopt_exp");
 
 
 fn get_owner_pet_ids(env: &Env, owner: &Address) -> Vec<u64> {
@@ -386,7 +394,7 @@ impl PetOwnershipContract {
             panic_with_error!(&env, ContractError::AdoptionNotConfigurable);
         }
         admin.require_auth();
-        let config = AdoptionConfig { waiting_period_days };
+        let config = AdoptionConfig { waiting_period_days, expiry_seconds: ADOPTION_EXPIRY_SECONDS };
         env.storage().persistent().set(&DataKey::AdoptionConfig, &config);
         env.storage().persistent().set(&DataKey::Admin, &admin);
     }
@@ -407,9 +415,12 @@ impl PetOwnershipContract {
             .storage()
             .persistent()
             .get(&DataKey::AdoptionConfig)
-            .unwrap_or(AdoptionConfig { waiting_period_days: 0 });
+            .unwrap_or(AdoptionConfig { waiting_period_days: 0, expiry_seconds: ADOPTION_EXPIRY_SECONDS });
 
-        let new_config = AdoptionConfig { waiting_period_days };
+        let new_config = AdoptionConfig {
+            waiting_period_days,
+            expiry_seconds: old_config.expiry_seconds,
+        };
         env.storage().persistent().set(&DataKey::AdoptionConfig, &new_config);
 
         env.events().publish(
@@ -421,7 +432,7 @@ impl PetOwnershipContract {
     /// Get the current adoption config.
     pub fn get_adoption_config(env: Env) -> AdoptionConfig {
         env.storage().persistent().get(&DataKey::AdoptionConfig)
-            .unwrap_or(AdoptionConfig { waiting_period_days: 0 })
+            .unwrap_or(AdoptionConfig { waiting_period_days: 0, expiry_seconds: ADOPTION_EXPIRY_SECONDS })
     }
 
     /// Set a per-species adoption waiting period override.
@@ -1022,6 +1033,45 @@ impl PetOwnershipContract {
         env.events().publish(
             (EVT_TRANSFER_CANCELLED, pet_id),
             (transfer.from, transfer.to),
+        );
+    }
+
+    /// Cancels a pending adoption whose expiry window has elapsed.
+    ///
+    /// Callable by anyone once `now > signed_at + expiry_seconds`, so an
+    /// abandoned adoption can never block the owner from re-listing the pet.
+    /// Mirrors [`Self::reclaim_transfer`] for direct transfers.
+    pub fn cancel_expired_adoption(env: Env, pet_id: u64) {
+        let adoption: PendingAdoption = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdoption(pet_id))
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::NoPendingAdoption));
+
+        let config: AdoptionConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AdoptionConfig)
+            .unwrap_or(AdoptionConfig { waiting_period_days: 0, expiry_seconds: ADOPTION_EXPIRY_SECONDS });
+
+        let expiry_seconds = if config.expiry_seconds == 0 {
+            ADOPTION_EXPIRY_SECONDS
+        } else {
+            config.expiry_seconds
+        };
+
+        let now = env.ledger().timestamp();
+        if now.saturating_sub(adoption.signed_at) <= expiry_seconds {
+            panic_with_error!(env, ContractError::AdoptionNotExpired);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingAdoption(pet_id));
+
+        env.events().publish(
+            (EVT_ADOPTION_EXPIRED, pet_id),
+            (adoption.from, adoption.to),
         );
     }
 

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -1005,3 +1005,69 @@ fn update_adoption_config_fails_without_prior_set() {
         )))
     );
 }
+
+// ======================================================
+// cancel_expired_adoption tests (Issue #1009)
+// ======================================================
+
+#[test]
+fn cancel_expired_adoption_before_expiry_is_rejected() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+
+    // Well within the 30-day window — must fail
+    env.ledger().with_mut(|l| {
+        l.timestamp += 29 * 24 * 60 * 60;
+    });
+
+    let result = client.try_cancel_expired_adoption(&pet_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::AdoptionNotExpired as u32,
+        )))
+    );
+    assert!(client.get_pending_adoption(&pet_id).is_some());
+}
+
+#[test]
+fn cancel_expired_adoption_after_expiry_succeeds() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += 30 * 24 * 60 * 60 + 1;
+    });
+
+    client.cancel_expired_adoption(&pet_id);
+
+    // Pending adoption is cleared and the owner can re-list the pet
+    assert!(client.get_pending_adoption(&pet_id).is_none());
+    assert_eq!(client.get_current_owner(&pet_id), owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+}
+
+#[test]
+fn cancel_expired_adoption_without_pending_adoption_is_rejected() {
+    let (env, owner, _adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+
+    let result = client.try_cancel_expired_adoption(&pet_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::NoPendingAdoption as u32,
+        )))
+    );
+}


### PR DESCRIPTION
## Summary

- Added `ADOPTION_EXPIRY_SECONDS` (30 days) and an `expiry_seconds: u64` field on `AdoptionConfig`; `0` falls back to the default so existing stored configs keep working
- Added `cancel_expired_adoption(env, pet_id)`, callable by anyone once `now > signed_at + expiry_seconds`, mirroring `reclaim_transfer`
- Emits an `adopt_exp` event and clears `DataKey::PendingAdoption` so an abandoned adoption no longer blocks the owner from re-listing the pet
- Added `ContractError::AdoptionNotExpired = 32`
- Tests: cancel before expiry rejected, cancel after expiry succeeds (and the pet can be re-listed), and missing pending adoption rejected

## Validation

- `cargo test` — the 3 new tests pass; the 15 failing `escrow::tests` are pre-existing on `main` (they touch instance storage outside a contract frame) and are untouched by this change

Closes #1009