### PR TITLE
fix: enforce Content-Type JSON, add DB connect timeout, guard TenantR…

### DIFF
--- a/backend-2fa/examples/example_integration.rs
+++ b/backend-2fa/examples/example_integration.rs
@@ -38,7 +38,7 @@ use petchain_2fa::handlers::{
     AuthenticatedUser, DisableTwoFactorRequest, EnableTwoFactorRequest, LoginWithTwoFactorRequest,
     RecoverWithBackupRequest, TwoFactorHandlers, VerifyTwoFactorRequest,
 };
-use petchain_2fa::{ApiError, ErrorResponseMiddleware};
+use petchain_2fa::{ApiError, ContentTypeGuard, ErrorResponseMiddleware};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -291,10 +291,19 @@ async fn main() -> std::io::Result<()> {
             // gets the Access-Control-* headers.
             .wrap(cors)
             .route("/api/auth/login", web::post().to(login))
-            .route("/api/2fa/enable", web::post().to(enable_2fa))
-            .route("/api/2fa/verify", web::post().to(verify_2fa))
-            .route("/api/2fa/disable", web::post().to(disable_2fa))
-            .route("/api/2fa/recover", web::post().to(recover_2fa))
+            // Scope the 2FA endpoints under ContentTypeGuard so every POST to
+            // these routes is rejected with 415 Unsupported Media Type if the
+            // caller does not send Content-Type: application/json.
+            // The guard passes GET/HEAD/OPTIONS through unmolested, so CORS
+            // preflight requests are unaffected. (Closes #1047)
+            .service(
+                web::scope("/api")
+                    .wrap(ContentTypeGuard)
+                    .route("/2fa/enable",  web::post().to(enable_2fa))
+                    .route("/2fa/verify",  web::post().to(verify_2fa))
+                    .route("/2fa/disable", web::post().to(disable_2fa))
+                    .route("/2fa/recover", web::post().to(recover_2fa)),
+            )
     })
     .bind("127.0.0.1:8080")?
     .run()

--- a/backend-2fa/src/content_type_guard.rs
+++ b/backend-2fa/src/content_type_guard.rs
@@ -1,0 +1,310 @@
+//! Content-Type enforcement middleware for JSON endpoints.
+//!
+//! # Overview
+//!
+//! [`ContentTypeGuard`] is an actix-web middleware that rejects any request
+//! whose `Content-Type` header is not `application/json` (or a compatible
+//! sub-type such as `application/json; charset=utf-8`).
+//!
+//! Without this guard actix-web's default JSON extractor will attempt to
+//! deserialise whatever bytes arrive in the body regardless of the declared
+//! media type.  A client that accidentally sends
+//! `application/x-www-form-urlencoded` receives a confusing 400 parse error
+//! instead of a clear protocol-level rejection.
+//!
+//! # Behaviour
+//!
+//! | Situation | Result |
+//! |---|---|
+//! | `Content-Type: application/json` | Forwarded to the inner handler |
+//! | `Content-Type: application/json; charset=utf-8` | Forwarded (params ignored) |
+//! | `Content-Type: text/plain` | **415 Unsupported Media Type** |
+//! | `Content-Type` header absent | **415 Unsupported Media Type** |
+//! | Request method has no body (GET / HEAD / OPTIONS) | Forwarded (guard skipped) |
+//!
+//! # Usage
+//!
+//! Wrap the scope (or individual routes) that must receive JSON:
+//!
+//! ```rust,ignore
+//! use petchain_2fa::ContentTypeGuard;
+//!
+//! App::new()
+//!     .service(
+//!         web::scope("/api")
+//!             .wrap(ContentTypeGuard)   // ← enforces Content-Type on every route
+//!             .route("/2fa/enable",  web::post().to(enable_2fa))
+//!             .route("/2fa/verify",  web::post().to(verify_2fa))
+//!             .route("/2fa/disable", web::post().to(disable_2fa))
+//!             .route("/2fa/recover", web::post().to(recover_2fa))
+//!     )
+//! ```
+//!
+//! Alternatively apply it globally via `App::wrap(ContentTypeGuard)` if every
+//! route in your application accepts only JSON.  The guard automatically
+//! passes through body-less requests (GET / HEAD / OPTIONS) so you do not need
+//! to exclude those routes manually.
+//!
+//! # Closes
+//!
+//! Issue #1047 – "Add Content-Type: application/json Enforcement Middleware
+//! to 2FA JSON Endpoints".
+
+use actix_web::{
+    body::BoxBody,
+    dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
+    http::{Method, StatusCode},
+    Error, HttpResponse,
+};
+use futures_util::future::{ok, LocalBoxFuture, Ready};
+use serde_json::json;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Middleware factory.  Register with [`actix_web::App::wrap`] or
+/// [`actix_web::web::Scope::wrap`].
+///
+/// See the [module-level documentation](self) for usage examples.
+pub struct ContentTypeGuard;
+
+impl<S, B> Transform<S, ServiceRequest> for ContentTypeGuard
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: actix_web::body::MessageBody + 'static,
+{
+    type Response = ServiceResponse<BoxBody>;
+    type Error = Error;
+    type Transform = ContentTypeGuardService<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ok(ContentTypeGuardService { service })
+    }
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+/// The per-request service produced by [`ContentTypeGuard`].
+pub struct ContentTypeGuardService<S> {
+    service: S,
+}
+
+impl<S, B> Service<ServiceRequest> for ContentTypeGuardService<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: actix_web::body::MessageBody + 'static,
+{
+    type Response = ServiceResponse<BoxBody>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        // Skip enforcement for methods that conventionally carry no request body.
+        // This avoids false positives on GET / HEAD / OPTIONS (e.g. CORS preflight).
+        let method = req.method().clone();
+        if method == Method::GET
+            || method == Method::HEAD
+            || method == Method::OPTIONS
+            || method == Method::DELETE
+        {
+            let fut = self.service.call(req);
+            return Box::pin(async move { Ok(fut.await?.map_into_boxed_body()) });
+        }
+
+        // Validate the Content-Type header.
+        let is_json = req
+            .headers()
+            .get(actix_web::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|ct| {
+                // Accept "application/json" and "application/json; charset=..."
+                // Use case-insensitive prefix matching per RFC 7231 §3.1.1.1.
+                ct.trim()
+                    .to_ascii_lowercase()
+                    .starts_with("application/json")
+            })
+            .unwrap_or(false);
+
+        if !is_json {
+            let http_req = req.request().clone();
+            let body = json!({
+                "code": "UNSUPPORTED_MEDIA_TYPE",
+                "message": "Content-Type must be application/json",
+            })
+            .to_string();
+
+            let response = HttpResponse::build(StatusCode::UNSUPPORTED_MEDIA_TYPE)
+                .content_type("application/json")
+                .body(body)
+                .map_into_boxed_body();
+
+            return Box::pin(async move { Ok(ServiceResponse::new(http_req, response)) });
+        }
+
+        // Content-Type is acceptable — forward to the inner service.
+        let fut = self.service.call(req);
+        Box::pin(async move { Ok(fut.await?.map_into_boxed_body()) })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{http::StatusCode, test, web, App, HttpResponse};
+
+    async fn dummy_handler() -> HttpResponse {
+        HttpResponse::Ok().json(serde_json::json!({ "ok": true }))
+    }
+
+    fn build_app() -> impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    > {
+        App::new()
+            .wrap(ContentTypeGuard)
+            .route("/json-only", web::post().to(dummy_handler))
+            .route("/get-route", web::get().to(dummy_handler))
+    }
+
+    // ── POST with correct Content-Type → 200 ─────────────────────────────────
+
+    #[actix_web::test]
+    async fn test_json_content_type_is_allowed() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .insert_header(("content-type", "application/json"))
+            .set_payload("{}")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── POST with charset parameter → 200 ────────────────────────────────────
+
+    #[actix_web::test]
+    async fn test_json_content_type_with_charset_is_allowed() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .insert_header(("content-type", "application/json; charset=utf-8"))
+            .set_payload("{}")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── POST with wrong Content-Type → 415 ───────────────────────────────────
+
+    #[actix_web::test]
+    async fn test_form_encoded_content_type_returns_415() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .insert_header(("content-type", "application/x-www-form-urlencoded"))
+            .set_payload("field=value")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    // ── POST with text/plain Content-Type → 415 ──────────────────────────────
+
+    #[actix_web::test]
+    async fn test_text_plain_content_type_returns_415() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .insert_header(("content-type", "text/plain"))
+            .set_payload("hello")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    // ── POST with no Content-Type header → 415 ───────────────────────────────
+
+    #[actix_web::test]
+    async fn test_missing_content_type_returns_415() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .set_payload("{}")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    // ── 415 response body is valid JSON with expected error code ─────────────
+
+    #[actix_web::test]
+    async fn test_415_response_body_is_json_with_error_code() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .insert_header(("content-type", "text/plain"))
+            .set_payload("oops")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        let body = test::read_body(resp).await;
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&body).expect("415 body must be valid JSON");
+        assert_eq!(parsed["code"], "UNSUPPORTED_MEDIA_TYPE");
+        assert!(parsed["message"].as_str().unwrap().contains("application/json"));
+    }
+
+    // ── GET requests bypass the guard (no body expected) ─────────────────────
+
+    #[actix_web::test]
+    async fn test_get_request_bypasses_content_type_guard() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::get()
+            .uri("/get-route")
+            // No Content-Type header at all.
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── OPTIONS (CORS preflight) bypasses the guard ───────────────────────────
+
+    #[actix_web::test]
+    async fn test_options_request_bypasses_content_type_guard() {
+        let app = test::init_service(
+            App::new()
+                .wrap(ContentTypeGuard)
+                .route("/json-only", web::method(Method::OPTIONS).to(dummy_handler)),
+        )
+        .await;
+        let req = test::TestRequest::default()
+            .method(Method::OPTIONS)
+            .uri("/json-only")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // ── Case-insensitive Content-Type matching ────────────────────────────────
+
+    #[actix_web::test]
+    async fn test_content_type_matching_is_case_insensitive() {
+        let app = test::init_service(build_app()).await;
+        let req = test::TestRequest::post()
+            .uri("/json-only")
+            .insert_header(("content-type", "Application/JSON"))
+            .set_payload("{}")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -145,6 +145,15 @@ impl PostgresTwoFactorStore {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(30);
+        // Issue #1042: cap the initial TCP connection handshake so that a
+        // misconfigured DATABASE_URL (unreachable host, firewall drop, slow
+        // container startup) produces a descriptive Err within a bounded time
+        // rather than hanging the OnceLock initialisation forever.
+        // Configurable via DB_CONNECT_TIMEOUT_SECS; defaults to 10 seconds.
+        let connect_timeout_secs: u64 = std::env::var("DB_CONNECT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10);
 
         let pool = runtime
             .block_on(
@@ -152,9 +161,18 @@ impl PostgresTwoFactorStore {
                     .min_connections(min_conns)
                     .max_connections(max_conns)
                     .acquire_timeout(Duration::from_secs(acquire_timeout_secs))
+                    // connect_timeout governs each individual TCP connection
+                    // attempt, distinct from acquire_timeout which governs
+                    // waiting for a free slot in an already-built pool.
+                    .connect_timeout(Duration::from_secs(connect_timeout_secs))
                     .connect(database_url),
             )
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| format!(
+                "Failed to connect to database within {}s: {}. \
+                 Check DATABASE_URL and network reachability. \
+                 Falling back to in-memory store.",
+                connect_timeout_secs, e
+            ))?;
 
         Ok(Self { pool, runtime, enc_key: None })
     }
@@ -1295,4 +1313,49 @@ mod tests {
         // Must round-trip correctly
         assert_eq!(decrypt_secret(&encrypted, &key).unwrap(), secret);
     }
+
+    /// Issue #1042 — `connect()` must time out quickly on an unreachable host
+    /// rather than hanging the process indefinitely.
+    ///
+    /// We use a non-routable IP address (RFC 5737 TEST-NET-1: 192.0.2.1) and
+    /// a 1-second timeout so the test completes well within the default test
+    /// runner timeout.  A successful `Err` return with a descriptive message
+    /// proves the timeout fired.
+    #[test]
+    fn connect_returns_err_when_host_unreachable_within_timeout() {
+        // Point at a non-routable address: this will never respond.
+        // RFC 5737 documentation addresses are guaranteed to be unreachable.
+        let unreachable_url = "postgres://user:pass@192.0.2.1:5432/db";
+
+        // Override the connect timeout to 1 second so the test is fast.
+        std::env::set_var("DB_CONNECT_TIMEOUT_SECS", "1");
+
+        let start = std::time::Instant::now();
+        let result = PostgresTwoFactorStore::connect(unreachable_url);
+        let elapsed = start.elapsed();
+
+        // Restore env variable.
+        std::env::remove_var("DB_CONNECT_TIMEOUT_SECS");
+
+        // Must return Err — not hang.
+        assert!(
+            result.is_err(),
+            "connect() must return Err on an unreachable host, got Ok"
+        );
+
+        // The error message must be descriptive (includes timeout and original error).
+        let err_msg = result.unwrap_err();
+        assert!(
+            err_msg.contains("Failed to connect to database within 1s"),
+            "error message must mention the timeout: {err_msg}"
+        );
+
+        // Must not have taken more than 10 seconds (generous headroom above 1s timeout).
+        assert!(
+            elapsed.as_secs() < 10,
+            "connect() took {}s — timeout was not applied",
+            elapsed.as_secs()
+        );
+    }
 }
+

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod content_type_guard;
 pub mod db;
 pub mod error;
 pub mod handlers;
@@ -15,6 +16,7 @@ pub mod migrations;
 #[cfg(test)]
 mod tests;
 
+pub use content_type_guard::ContentTypeGuard;
 pub use db::PostgresTwoFactorStore;
 pub use db::{
     select_secret_provider, AwsSecretsManagerProvider, EnvSecretProvider, PoolStats,

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -1165,9 +1165,18 @@ impl TenantRegistry {
     /// returned. If it already exists, the existing config is returned
     /// unchanged along with `(existing_config, true)` — the caller can use
     /// the `bool` to signal `already_existed` without treating this as an
-    /// error. The check-and-insert happens under a single lock acquisition
-    /// (via `Entry`), so concurrent calls for the same `tenant_id` cannot
-    /// race past each other and create duplicates.
+    /// error.
+    ///
+    /// # Concurrency guarantee (closes issue #1054)
+    ///
+    /// The check-and-insert is performed atomically under a **single**
+    /// `Mutex` lock acquisition using [`HashMap::entry`].  There is no
+    /// TOCTOU window between "check if tenant exists" and "insert new
+    /// tenant": both operations happen while the lock is held.  Parallel
+    /// first-requests for the same `tenant_id` therefore cannot each see
+    /// "tenant not found" and both proceed to create a new store instance.
+    /// Exactly one caller will win the `Vacant` arm; all racing callers
+    /// will receive the same `TenantConfig` that the winner inserted.
     pub fn provision(&self, config: TenantConfig) -> Result<(TenantConfig, bool), String> {
         let mut map = self.tenants.lock().unwrap();
         match map.entry(config.tenant_id.clone()) {
@@ -1285,4 +1294,109 @@ pub fn verify_jwt(token: &str, secret: &[u8], now_unix_secs: u64) -> Result<JwtC
     }
 
     Ok(claims)
+}
+
+// ---------------------------------------------------------------------------
+// Issue #1054 — TenantRegistry::provision concurrent-initialisation tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tenant_registry_concurrency_tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    fn make_config(tenant_id: &str) -> TenantConfig {
+        TenantConfig {
+            tenant_id: tenant_id.to_string(),
+            totp_issuer: format!("{}-issuer", tenant_id),
+            lockout_threshold: 5,
+            rate_limit_max_failures: 5,
+        }
+    }
+
+    /// Two threads calling `provision` for the same brand-new tenant
+    /// simultaneously must both get back the *same* `TenantConfig` and
+    /// exactly one must observe `already_existed = false`.
+    ///
+    /// This verifies that the `HashMap::entry` check-and-insert is atomic
+    /// under the `Mutex` and that no TOCTOU race can create duplicate
+    /// store instances. (Closes issue #1054.)
+    #[test]
+    fn test_concurrent_provision_same_tenant_returns_identical_config() {
+        let registry = Arc::new(TenantRegistry::default());
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let reg = Arc::clone(&registry);
+            handles.push(thread::spawn(move || {
+                reg.provision(make_config("race-tenant")).unwrap()
+            }));
+        }
+
+        let results: Vec<(TenantConfig, bool)> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // All returned configs must be identical — only one winner inserts.
+        let first_config = &results[0].0;
+        for (cfg, _) in &results {
+            assert_eq!(
+                cfg.tenant_id, first_config.tenant_id,
+                "All threads must observe the same tenant_id"
+            );
+            assert_eq!(
+                cfg.totp_issuer, first_config.totp_issuer,
+                "All threads must observe the same totp_issuer — no duplicate was created"
+            );
+        }
+
+        // Exactly one thread saw `already_existed = false` (the creator).
+        let created: Vec<_> = results.iter().filter(|(_, existed)| !existed).collect();
+        assert_eq!(
+            created.len(),
+            1,
+            "Exactly one thread must have created the tenant; got {} creators",
+            created.len()
+        );
+
+        // All other threads observed it as already existing.
+        let existed: Vec<_> = results.iter().filter(|(_, existed)| *existed).collect();
+        assert_eq!(existed.len(), 31);
+    }
+
+    /// Independent tenant IDs must never interfere with each other even
+    /// under concurrent access.
+    #[test]
+    fn test_concurrent_provision_different_tenants_are_isolated() {
+        let registry = Arc::new(TenantRegistry::default());
+
+        let tenant_ids: Vec<String> = (0..16).map(|i| format!("tenant-{}", i)).collect();
+        let mut handles = Vec::new();
+
+        for tid in &tenant_ids {
+            let reg = Arc::clone(&registry);
+            let tid = tid.clone();
+            handles.push(thread::spawn(move || {
+                reg.provision(make_config(&tid)).unwrap()
+            }));
+        }
+
+        let results: Vec<(TenantConfig, bool)> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // Each tenant was provisioned exactly once.
+        let created_count = results.iter().filter(|(_, existed)| !existed).count();
+        assert_eq!(
+            created_count,
+            16,
+            "Each of the 16 unique tenants must have been created exactly once"
+        );
+
+        // Every tenant is retrievable from the registry.
+        for tid in &tenant_ids {
+            let cfg = registry
+                .get_config(tid)
+                .unwrap_or_else(|| panic!("Tenant '{}' missing from registry", tid));
+            assert_eq!(cfg.tenant_id, *tid);
+        }
+    }
 }


### PR DESCRIPTION


Closes #1047 — Content-Type: application/json enforcement middleware Closes #1042 — PostgresTwoFactorStore::connect() startup connect timeout Closes #1054 — TenantRegistry::get_or_create concurrent initialisation guard

═══════════════════════════════════════════════════════════════════════════ ISSUE #1047 — Content-Type: application/json Enforcement Middleware ═══════════════════════════════════════════════════════════════════════════

Problem:
  actix-web's JSON extractor accepted requests without a Content-Type header
  or with wrong types (e.g. application/x-www-form-urlencoded). Clients
  sending the wrong content type received a confusing 400 Bad Request (JSON
  parse error) instead of the semantically correct 415 Unsupported Media Type.

Solution:
  Created backend-2fa/src/content_type_guard.rs implementing the
  ContentTypeGuard middleware using the standard actix-web Transform + Service
  pattern (same as RateLimitMiddleware and ErrorResponseMiddleware).

  How it works:
  - Inspects the Content-Type header on every incoming request
  - Allows requests whose Content-Type starts with 'application/json' (case-insensitive, so 'Application/JSON' and 'application/json; charset=utf-8' are both accepted per RFC 7231 §3.1.1.1)
  - Short-circuits with HTTP 415 Unsupported Media Type + JSON error body {code: 'UNSUPPORTED_MEDIA_TYPE', message: '...'} for all other types
  - Skips enforcement for GET, HEAD, OPTIONS, DELETE (body-less methods) so CORS preflight (OPTIONS) requests are never blocked

  Wiring:
  - Exported from lib.rs as pub use content_type_guard::ContentTypeGuard
  - Applied in example_integration.rs as .wrap(ContentTypeGuard) on the /api scope covering /2fa/enable, /2fa/verify, /2fa/disable, /2fa/recover
  - Login endpoint left outside the scope (could have different requirements)

  Tests added in content_type_guard.rs:
  - test_json_content_type_is_allowed
  - test_json_content_type_with_charset_is_allowed
  - test_form_encoded_content_type_returns_415
  - test_text_plain_content_type_returns_415
  - test_missing_content_type_returns_415
  - test_415_response_body_is_json_with_error_code
  - test_get_request_bypasses_content_type_guard
  - test_options_request_bypasses_content_type_guard
  - test_content_type_matching_is_case_insensitive

Files changed:
  + backend-2fa/src/content_type_guard.rs  (new file, 310 lines)
  M backend-2fa/src/lib.rs                  (add mod + pub use)
  M backend-2fa/examples/example_integration.rs  (wrap /api scope)

═══════════════════════════════════════════════════════════════════════════ ISSUE #1042 — PostgresTwoFactorStore::connect() Startup Connect Timeout ═══════════════════════════════════════════════════════════════════════════

Problem:
  PostgresTwoFactorStore::connect() had acquire_timeout (controls how long
  to wait for a free slot in an already-built pool) but no connect_timeout
  (controls the initial TCP connection handshake duration). On a misconfigured
  DATABASE_URL — unreachable host, DNS failure, firewall drop, slow container
  startup — the connect() call would block indefinitely, hanging the OnceLock
  initialisation in two_factor_store() and preventing the actix-web server
  from ever starting. Container restart policies and health checks could never
  fire because the process was stuck, not crashed.

  Note: acquire_timeout and connect_timeout are distinct sqlx pool options.
  acquire_timeout = how long a caller waits for a free connection from an
                    existing pool.
  connect_timeout = how long each individual TCP connection attempt may take
                    when the pool is being built or replenished.

Solution:
  Added .connect_timeout(Duration::from_secs(connect_timeout_secs)) to the
  PgPoolOptions builder in PostgresTwoFactorStore::connect().

  The timeout is configurable via the DB_CONNECT_TIMEOUT_SECS environment
  variable (default: 10 seconds), so operators can tune it for their
  environment without recompiling.

  On timeout the method returns a descriptive Err that includes the timeout
  value and the underlying sqlx error message, e.g.:
    'Failed to connect to database within 10s: <sqlx error>.
     Check DATABASE_URL and network reachability.
     Falling back to in-memory store.'

  The Err propagates to the OnceLock initialiser in two_factor_store() which
  already falls back to InMemoryStore on any connect failure, so the server
  starts (degraded) rather than hanging.

Test added:
  connect_returns_err_when_host_unreachable_within_timeout
  - Targets RFC 5737 TEST-NET-1 address 192.0.2.1 (guaranteed non-routable)
  - Sets DB_CONNECT_TIMEOUT_SECS=1 for a fast test
  - Asserts result is Err, error message contains the timeout duration, and the call completed in under 10 seconds

Files changed:
  M backend-2fa/src/db.rs  (connect_timeout + descriptive error + test)

═══════════════════════════════════════════════════════════════════════════ ISSUE #1054 — TenantRegistry::get_or_create Concurrent Initialisation Guard ═══════════════════════════════════════════════════════════════════════════

Problem:
  The issue identified a potential TOCTOU (time-of-check / time-of-use) race
  in TenantRegistry where two simultaneous first-requests for a new tenant
  could both observe 'tenant not found' and both proceed to initialise a new
  store instance, causing state divergence — each request gets a different
  Arc<TwoFactorStore> for the same tenant.

  Review of the existing code confirmed the implementation already used
  HashMap::entry(...) with Occupied/Vacant arms under a single Mutex lock
  acquisition, which is the correct atomic pattern. The fix therefore
  focuses on two things:

  1. Documentation: The provision() doc comment was rewritten to explicitly state the concurrency guarantee in unambiguous terms — that the check-and-insert is atomic under a single lock, there is no TOCTOU window, and exactly one racing caller wins the Vacant arm while all others observe the same inserted config.

  2. Tests: A dedicated test module (tenant_registry_concurrency_tests) was added directly in two_factor.rs to exercise TenantRegistry at the unit level (not just indirectly through TenantProvisioningHandlers):

     test_concurrent_provision_same_tenant_returns_identical_config - Spawns 32 threads all calling provision() for the same tenant simultaneously - Asserts all 32 receive identical TenantConfig values - Asserts exactly 1 thread observed already_existed=false (the creator) - Asserts the remaining 31 observed already_existed=true Proves the HashMap::entry guard prevents duplicate creation.

     test_concurrent_provision_different_tenants_are_isolated
       - Spawns 16 threads each provisioning a unique tenant simultaneously
       - Asserts all 16 tenants were created (created_count=16, no collisions) - Asserts every tenant is retrievable from the registry post-test Proves independent tenants do not interfere under concurrent access.

