### PR TITLE
fix: gate test_upgrade_proposal module behind #[cfg(test)]

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -177,6 +177,7 @@ mod test_remove_admin;
 mod test_verify_claim_document;
 #[cfg(test)]
 mod test_vet_pagination;
+#[cfg(test)]
 mod test_upgrade_proposal;
 
 const DEFAULT_NONCE_MAX_USES: u32 = 1;


### PR DESCRIPTION
## Summary
Investigated the reported dead-comment/duplicate declaration for `test_upgrade_proposal` in `stellar-contracts/src/lib.rs`. On current `main` that specific duplicate/commented block no longer exists (an earlier refactor already cleaned it up) — there is exactly one `mod test_upgrade_proposal;` declaration. However, unlike every sibling test module in that block, it was missing the `#[cfg(test)]` attribute, so it was being compiled into non-test builds too. This PR adds the missing attribute for consistency with the rest of the block and to keep test-only code out of production builds.

## Before/After
Before: `mod test_upgrade_proposal;` (no cfg gate)
After: `#[cfg(test)] mod test_upgrade_proposal;` (matches all neighboring test modules)

## Testing
Verified via `grep -n "test_upgrade_proposal" stellar-contracts/src/lib.rs` that only one declaration remains, now correctly gated. Full `cargo test` was not run in this environment (no toolchain/network available here); please confirm in CI.

Closes #1027