### PR TITLE
fix: restore missing test_book_slot module declaration

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -178,6 +178,8 @@ mod test_verify_claim_document;
 #[cfg(test)]
 mod test_vet_pagination;
 mod test_upgrade_proposal;
+#[cfg(test)]
+mod test_book_slot;
 
 const DEFAULT_NONCE_MAX_USES: u32 = 1;
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
Investigated the reported duplicate `mod test_book_slot;` declaration in `stellar-contracts/src/lib.rs`. On current `main`, an earlier large refactor already removed both declarations entirely — `stellar-contracts/src/test_book_slot.rs` still exists on disk but is no longer wired into the crate, so its tests are not compiled or run. This PR restores a single, clean `#[cfg(test)] mod test_book_slot;` declaration (matching the sibling test modules), which satisfies the original goal: exactly one clean declaration, with no coverage silently dropped.

## Before/After
Before: no `test_book_slot` declaration anywhere in `lib.rs` (file orphaned, zero test coverage).
After: single `#[cfg(test)] mod test_book_slot;` declaration alongside the other test modules.

## Testing
Confirmed via `grep -n "test_book_slot" stellar-contracts/src/lib.rs` that exactly one declaration now exists. Full `cargo test` was not run in this environment (no toolchain/network available here); please confirm the module compiles with no duplicate-module warnings in CI before merge.

Closes #1025