### PR TITLE
test: cover get_vet_by_license behavior after license revocation

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs
@@ -593,4 +593,27 @@ mod tests {
             )))
         );
     }
+
+    // ---- get_vet_by_license after revocation ----
+
+    // Chosen semantics: `revoke_vet_license` only flips `verified` to false
+    // and does NOT remove the `VetByLicense` mapping, so `get_vet_by_license`
+    // keeps resolving to the revoked vet's record (with `verified == false`)
+    // rather than returning `None`. Callers must check `verified` themselves.
+    #[test]
+    fn test_get_vet_by_license_after_revocation() {
+        let (env, _, _, client) = setup();
+
+        let vet = soroban_sdk::Address::generate(&env);
+        let license = str(&env, "LIC-REVOKED-001");
+        client.register_vet(&vet, &str(&env, "Dr. Revoked"), &license, &str(&env, "General"));
+        client.verify_vet(&vet);
+        client.revoke_vet_license(&vet);
+
+        let found = client.get_vet_by_license(&license);
+        assert!(found.is_some());
+        let record = found.unwrap();
+        assert_eq!(record.address, vet);
+        assert_eq!(record.verified, false);
+    }
 }


### PR DESCRIPTION
## Summary
Adds `test_get_vet_by_license_after_revocation` in `stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs`, covering the previously untested register → verify → revoke → get_vet_by_license flow, and documents the chosen semantics in a code comment.

## Context / behavior
Reading `revoke_vet_license`, it only flips the vet's `verified` field to `false` via `save_vet`; it does not remove the `VetByLicense` mapping entry. So `get_vet_by_license` after revocation still resolves and returns `Some(Vet { verified: false, .. })` rather than `None`. The new test locks in this behavior and a comment above it explains callers must check `verified` themselves rather than relying on the lookup returning `None`.

## Testing
Added test follows the existing `setup()` pattern already used by neighboring tests in the same module (e.g. `test_verify_vet_twice_fails_with_vet_already_verified`). Full `cargo test` was not run in this environment (no toolchain/network available here); please confirm it passes in CI.

Closes #1024