### PR TITLE
Add admin dispute resolution to escrow contract

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/Cargo.toml
+++ b/stellar-contracts/contracts/pet-transfer-adoption/Cargo.toml
@@ -13,6 +13,12 @@ soroban-sdk = "21.7.7"
 
 [dev-dependencies]
 soroban-sdk = { version = "21.7.7", features = ["testutils"] }
+# soroban-env-host's own manifest allows ed25519-dalek >=2.0.0 with no upper
+# bound, so without this constraint Cargo resolves it to a newer major (3.x)
+# that's incompatible with the 2.x version soroban-sdk itself resolves to,
+# and the two copies can't interoperate in testutils. Cap it so the whole
+# graph unifies on one 2.x release.
+ed25519-dalek = "2"
 
 [profile.release]
 opt-level = "z"

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/escrow.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/escrow.rs
@@ -4,6 +4,7 @@
 //!   1. Buyer calls `deposit_fee()` — XLM (in stroops) held in contract storage
 //!   2. `finalize_transfer()` — platform fee deducted; remainder released to seller
 //!   3. `refund_fee()` — full amount back to buyer (Held or Disputed state)
+//!   4. `admin_resolve_dispute()` — admin ruling from Disputed state (buyer, seller, or split)
 //!
 //! Platform fee: configurable basis points (e.g. 250 = 2.50%)
 //!   platform_fee   = amount * fee_bps / 10_000
@@ -14,8 +15,7 @@
 //!   DataKey::PlatformFeeBps          → u32
 //!   DataKey::PlatformFeeRecipient    → Address
 
-use soroban_sdk::{contracttype, token, Address, Env};
-use soroban_sdk::{contracterror, contracttype, panic_with_error, Address, Env};
+use soroban_sdk::{contracterror, contracttype, panic_with_error, token, Address, Env, Symbol};
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
@@ -39,6 +39,15 @@ pub enum EscrowStatus {
     Released,
     Refunded,
     Disputed,
+    Resolved,
+}
+
+#[contracttype]
+#[derive(Debug, Clone, PartialEq)]
+pub enum DisputeDecision {
+    RefundBuyer,
+    PaySeller,
+    Split(u32), // basis points of the escrowed amount awarded to the seller
 }
 
 #[contracttype]
@@ -74,19 +83,16 @@ pub fn compute_seller_amount(amount: i128, fee_bps: u32) -> i128 {
 // ─── Config ───────────────────────────────────────────────────────────────────
 
 pub fn init_escrow_config(env: &Env, fee_bps: u32, fee_recipient: Address, token_address: Address) {
-    assert!(fee_bps <= 10_000, "fee_bps must be <= 10000");
-    env.storage()
-        .instance()
-        .set(&EscrowDataKey::FeeBps, &fee_bps);
-    env.storage()
-        .instance()
-        .set(&EscrowDataKey::FeeRecipient, &fee_recipient);
     if fee_bps > 10_000 {
         panic_with_error!(env, EscrowError::FeeBpsTooHigh);
     }
     env.storage().instance().set(&EscrowDataKey::FeeBps, &fee_bps);
-    env.storage().instance().set(&EscrowDataKey::FeeRecipient, &fee_recipient);
-    env.storage().instance().set(&EscrowDataKey::TokenAddress, &token_address);
+    env.storage()
+        .instance()
+        .set(&EscrowDataKey::FeeRecipient, &fee_recipient);
+    env.storage()
+        .instance()
+        .set(&EscrowDataKey::TokenAddress, &token_address);
     // Store the initial caller as Admin (first call sets the admin)
     if !env.storage().instance().has(&EscrowDataKey::Admin) {
         env.storage()
@@ -178,10 +184,6 @@ pub fn deposit_fee(env: &Env, transfer_id: u64, buyer: Address, seller: Address,
         panic_with_error!(env, EscrowError::InvalidAmount);
     }
     let key = EscrowDataKey::Entry(transfer_id);
-    assert!(
-        !env.storage().persistent().has(&key),
-        "escrow already exists"
-    );
     if env.storage().persistent().has(&key) {
         panic_with_error!(env, EscrowError::EscrowAlreadyExists);
     }
@@ -204,16 +206,6 @@ pub fn deposit_fee(env: &Env, transfer_id: u64, buyer: Address, seller: Address,
 /// Releases escrowed fee to seller minus platform fee.
 pub fn finalize_transfer(env: &Env, transfer_id: u64) {
     let key = EscrowDataKey::Entry(transfer_id);
-    let mut entry: EscrowEntry = env
-        .storage()
-        .persistent()
-        .get(&key)
-        .expect("escrow not found");
-    assert!(
-        entry.status == EscrowStatus::Held,
-        "cannot finalize: not in Held state"
-    );
-    let platform_fee = compute_platform_fee(entry.amount, entry.platform_fee_bps);
     let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
         Some(entry) => entry,
         None => panic_with_error!(env, EscrowError::EscrowNotFound),
@@ -221,10 +213,10 @@ pub fn finalize_transfer(env: &Env, transfer_id: u64) {
     if entry.status != EscrowStatus::Held {
         panic_with_error!(env, EscrowError::InvalidEscrowState);
     }
-    let platform_fee  = compute_platform_fee(entry.amount, entry.platform_fee_bps);
+    let platform_fee = compute_platform_fee(entry.amount, entry.platform_fee_bps);
     let seller_amount = entry.amount - platform_fee;
     let contract = env.current_contract_address();
-    let client   = token_client(env);
+    let client = token_client(env);
     client.transfer(&contract, &entry.seller, &seller_amount);
     if platform_fee > 0 {
         let fee_recipient = get_fee_recipient(env).expect("fee recipient not configured");
@@ -241,16 +233,6 @@ pub fn finalize_transfer(env: &Env, transfer_id: u64) {
 /// Refunds the full fee to the buyer (from Held or Disputed state).
 pub fn refund_fee(env: &Env, transfer_id: u64) {
     let key = EscrowDataKey::Entry(transfer_id);
-    let mut entry: EscrowEntry = env
-        .storage()
-        .persistent()
-        .get(&key)
-        .expect("escrow not found");
-    assert!(
-        entry.status == EscrowStatus::Held || entry.status == EscrowStatus::Disputed,
-        "cannot refund: invalid state"
-    );
-    token_client(env).transfer(&env.current_contract_address(), &entry.buyer, &entry.amount);
     let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
         Some(entry) => entry,
         None => panic_with_error!(env, EscrowError::EscrowNotFound),
@@ -258,7 +240,7 @@ pub fn refund_fee(env: &Env, transfer_id: u64) {
     if entry.status != EscrowStatus::Held && entry.status != EscrowStatus::Disputed {
         panic_with_error!(env, EscrowError::InvalidEscrowState);
     }
-    // Wire-up: token_client.transfer(&contract, &entry.buyer, &entry.amount);
+    token_client(env).transfer(&env.current_contract_address(), &entry.buyer, &entry.amount);
     entry.status = EscrowStatus::Refunded;
     env.storage().persistent().set(&key, &entry);
     env.events().publish(
@@ -271,19 +253,6 @@ pub fn refund_fee(env: &Env, transfer_id: u64) {
 pub fn dispute_transfer(env: &Env, transfer_id: u64, initiator: Address) {
     initiator.require_auth();
     let key = EscrowDataKey::Entry(transfer_id);
-    let mut entry: EscrowEntry = env
-        .storage()
-        .persistent()
-        .get(&key)
-        .expect("escrow not found");
-    assert!(
-        entry.status == EscrowStatus::Held,
-        "cannot dispute: not in Held state"
-    );
-    assert!(
-        initiator == entry.buyer || initiator == entry.seller,
-        "only buyer or seller may dispute"
-    );
     let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
         Some(entry) => entry,
         None => panic_with_error!(env, EscrowError::EscrowNotFound),
@@ -296,6 +265,54 @@ pub fn dispute_transfer(env: &Env, transfer_id: u64, initiator: Address) {
     }
     entry.status = EscrowStatus::Disputed;
     env.storage().persistent().set(&key, &entry);
+}
+
+/// Admin-controlled ruling on a disputed escrow. Only the configured `FeeRecipient`
+/// (platform admin) may call this. Unlike `refund_fee`, which always returns the full
+/// amount to the buyer, this allows the admin to pay the seller in full or split the
+/// escrowed amount between buyer and seller when the dispute is resolved in the
+/// seller's favour (in whole or in part).
+pub fn admin_resolve_dispute(env: &Env, transfer_id: u64, decision: DisputeDecision) {
+    let admin = get_fee_recipient(env).unwrap_or_else(|| panic_with_error!(env, EscrowError::Unauthorized));
+    admin.require_auth();
+
+    let key = EscrowDataKey::Entry(transfer_id);
+    let mut entry: EscrowEntry = match env.storage().persistent().get(&key) {
+        Some(entry) => entry,
+        None => panic_with_error!(env, EscrowError::EscrowNotFound),
+    };
+    if entry.status != EscrowStatus::Disputed {
+        panic_with_error!(env, EscrowError::InvalidEscrowState);
+    }
+
+    let (seller_amount, buyer_amount): (i128, i128) = match decision {
+        DisputeDecision::RefundBuyer => (0, entry.amount),
+        DisputeDecision::PaySeller => (entry.amount, 0),
+        DisputeDecision::Split(seller_bps) => {
+            if seller_bps > 10_000 {
+                panic_with_error!(env, EscrowError::FeeBpsTooHigh);
+            }
+            let seller_amount = entry.amount * seller_bps as i128 / 10_000;
+            (seller_amount, entry.amount - seller_amount)
+        }
+    };
+
+    let contract = env.current_contract_address();
+    let client = token_client(env);
+    if seller_amount > 0 {
+        client.transfer(&contract, &entry.seller, &seller_amount);
+    }
+    if buyer_amount > 0 {
+        client.transfer(&contract, &entry.buyer, &buyer_amount);
+    }
+
+    entry.status = EscrowStatus::Resolved;
+    env.storage().persistent().set(&key, &entry);
+
+    env.events().publish(
+        (Symbol::new(env, "DISPUTE_RESOLVED"), transfer_id),
+        (entry.buyer.clone(), entry.seller.clone(), seller_amount, buyer_amount),
+    );
 }
 
 pub fn get_escrow(env: &Env, transfer_id: u64) -> Option<EscrowEntry> {
@@ -344,31 +361,9 @@ mod tests {
         let platform     = Address::generate(&env);
         StellarAssetClient::new(&env, &token).mint(&buyer, &1_000_000_000);
         Ctx { env, contract, token, buyer, seller, platform }
-    use soroban_sdk::{testutils::Address as _, Address, Env};
-
-    // Storage access requires a contract context in tests, so setup
-    // registers a contract and tests run inside env.as_contract.
-    fn setup() -> (Env, Address, Address, Address, Address) {
-        let env      = Env::default();
-        env.mock_all_auths();
-        let contract = env.register_contract(None, crate::PetOwnershipContract);
-    fn setup() -> (Env, Address, Address, Address) {
-        let env = Env::default();
-        env.mock_all_auths();
-        let buyer = Address::generate(&env);
-        let seller = Address::generate(&env);
-    /// Escrow config lives in instance storage, so every test body must run
-    /// inside a contract frame — `setup` returns the registered contract id.
-    fn setup() -> (Env, Address, Address, Address, Address) {
-        let env      = Env::default();
-        env.mock_all_auths();
-        let contract = env.register_contract(None, PetOwnershipContract);
-        let buyer    = Address::generate(&env);
-        let seller   = Address::generate(&env);
-        let platform = Address::generate(&env);
-        (env, contract, buyer, seller, platform)
     }
 
+    #[test]
     fn deposit_creates_held_entry() {
         let c = setup();
         c.run(|| {
@@ -378,23 +373,6 @@ mod tests {
             assert_eq!(e.status, EscrowStatus::Held);
             assert_eq!(e.amount, 10_000_000);
             assert_eq!(e.buyer, c.buyer);
-        let (env, contract, buyer, seller, platform) = setup();
-        env.as_contract(&contract, || {
-        let (env, buyer, seller, platform) = setup();
-        init_escrow_config(&env, 250, platform);
-        deposit_fee(&env, 1, buyer.clone(), seller, 10_000_000);
-        let e = get_escrow(&env, 1).unwrap();
-        assert_eq!(e.status, EscrowStatus::Held);
-        assert_eq!(e.amount, 10_000_000);
-        assert_eq!(e.buyer, buyer);
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 1, buyer.clone(), seller, 10_000_000);
-            let e = get_escrow(&env, 1).unwrap();
-            assert_eq!(e.status, EscrowStatus::Held);
-            assert_eq!(e.amount, 10_000_000);
-            assert_eq!(e.buyer,  buyer);
         });
     }
 
@@ -406,14 +384,6 @@ mod tests {
             deposit_fee(&c.env, 2, c.buyer.clone(), c.seller.clone(), 10_000_000);
             finalize_transfer(&c.env, 2);
             assert_eq!(get_escrow(&c.env, 2).unwrap().status, EscrowStatus::Released);
-        let (env, contract, buyer, seller, platform) = setup();
-        env.as_contract(&contract, || {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 2, buyer, seller, 10_000_000);
-            finalize_transfer(&env, 2);
-            assert_eq!(get_escrow(&env, 2).unwrap().status, EscrowStatus::Released);
         });
     }
 
@@ -431,19 +401,11 @@ mod tests {
             deposit_fee(&c.env, 3, c.buyer.clone(), c.seller.clone(), 5_000_000);
             refund_fee(&c.env, 3);
             assert_eq!(get_escrow(&c.env, 3).unwrap().status, EscrowStatus::Refunded);
-        let (env, contract, buyer, seller, platform) = setup();
-        env.as_contract(&contract, || {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 3, buyer, seller, 5_000_000);
-            refund_fee(&env, 3);
-            assert_eq!(get_escrow(&env, 3).unwrap().status, EscrowStatus::Refunded);
         });
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Error(Contract, #5)")]
     fn cannot_finalize_twice() {
         let c = setup();
         c.run(|| {
@@ -451,19 +413,11 @@ mod tests {
             deposit_fee(&c.env, 4, c.buyer.clone(), c.seller.clone(), 1_000_000);
             finalize_transfer(&c.env, 4);
             finalize_transfer(&c.env, 4);
-        let (env, contract, buyer, seller, platform) = setup();
-        env.as_contract(&contract, || {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 4, buyer, seller, 1_000_000);
-            finalize_transfer(&env, 4);
-            finalize_transfer(&env, 4);
         });
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Error(Contract, #5)")]
     fn cannot_refund_after_release() {
         let c = setup();
         c.run(|| {
@@ -471,14 +425,6 @@ mod tests {
             deposit_fee(&c.env, 5, c.buyer.clone(), c.seller.clone(), 1_000_000);
             finalize_transfer(&c.env, 5);
             refund_fee(&c.env, 5);
-        let (env, contract, buyer, seller, platform) = setup();
-        env.as_contract(&contract, || {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 5, buyer, seller, 1_000_000);
-            finalize_transfer(&env, 5);
-            refund_fee(&env, 5);
         });
     }
 
@@ -492,21 +438,6 @@ mod tests {
         c.run(|| {
             dispute_transfer(&c.env, 6, c.buyer.clone());
             assert_eq!(get_escrow(&c.env, 6).unwrap().status, EscrowStatus::Disputed);
-        let (env, contract, buyer, seller, platform) = setup();
-        // require_auth may only run once per frame; each call gets its own.
-        env.as_contract(&contract, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 6, buyer.clone(), seller, 2_000_000);
-        });
-        env.as_contract(&contract, || {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 6, buyer.clone(), seller, 2_000_000);
-        });
-        env.as_contract(&cid, || {
-            dispute_transfer(&env, 6, buyer);
-            assert_eq!(get_escrow(&env, 6).unwrap().status, EscrowStatus::Disputed);
         });
     }
 
@@ -521,21 +452,6 @@ mod tests {
             dispute_transfer(&c.env, 7, c.buyer.clone());
             refund_fee(&c.env, 7);
             assert_eq!(get_escrow(&c.env, 7).unwrap().status, EscrowStatus::Refunded);
-        let (env, contract, buyer, seller, platform) = setup();
-        env.as_contract(&contract, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 7, buyer.clone(), seller, 3_000_000);
-        });
-        env.as_contract(&contract, || {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 100, platform);
-            deposit_fee(&env, 7, buyer.clone(), seller, 3_000_000);
-        });
-        env.as_contract(&cid, || {
-            dispute_transfer(&env, 7, buyer);
-            refund_fee(&env, 7);
-            assert_eq!(get_escrow(&env, 7).unwrap().status, EscrowStatus::Refunded);
         });
     }
 
@@ -614,11 +530,6 @@ mod tests {
             init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
             // transfer_id 999 was never deposited
             finalize_transfer(&c.env, 999);
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            // transfer_id 999 was never deposited
-            finalize_transfer(&env, 999);
         });
     }
 
@@ -631,11 +542,6 @@ mod tests {
             init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
             // transfer_id 999 was never deposited
             refund_fee(&c.env, 999);
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            // transfer_id 999 was never deposited
-            refund_fee(&env, 999);
         });
     }
 
@@ -648,11 +554,6 @@ mod tests {
             init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
             // transfer_id 999 was never deposited
             dispute_transfer(&c.env, 999, c.buyer.clone());
-        let (env, cid, buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            // transfer_id 999 was never deposited
-            dispute_transfer(&env, 999, buyer);
         });
     }
 
@@ -664,10 +565,6 @@ mod tests {
         c.run(|| {
             init_escrow_config(&c.env, 300, c.platform.clone(), c.token.clone());
             assert_eq!(get_fee_bps(&c.env), 300);
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 300, platform);
-            assert_eq!(get_fee_bps(&env), 300);
         });
     }
 
@@ -675,10 +572,6 @@ mod tests {
     fn get_fee_bps_returns_zero_when_not_configured() {
         let c = setup();
         c.run(|| assert_eq!(get_fee_bps(&c.env), 0));
-        let (env, cid, _buyer, _seller, _platform) = setup();
-        env.as_contract(&cid, || {
-            assert_eq!(get_fee_bps(&env), 0);
-        });
     }
 
     #[test]
@@ -687,10 +580,6 @@ mod tests {
         c.run(|| {
             init_escrow_config(&c.env, 150, c.platform.clone(), c.token.clone());
             assert_eq!(get_fee_recipient(&c.env), Some(c.platform.clone()));
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 150, platform.clone());
-            assert_eq!(get_fee_recipient(&env), Some(platform));
         });
     }
 
@@ -698,10 +587,6 @@ mod tests {
     fn get_fee_recipient_returns_none_when_not_configured() {
         let c = setup();
         c.run(|| assert_eq!(get_fee_recipient(&c.env), None));
-        let (env, cid, _buyer, _seller, _platform) = setup();
-        env.as_contract(&cid, || {
-            assert_eq!(get_fee_recipient(&env), None);
-        });
     }
 
     // ── Issue #1005: update_fee_config admin-only update ─────────────────────
@@ -715,15 +600,6 @@ mod tests {
             update_fee_config(&c.env, 100, new_recipient.clone());
             assert_eq!(get_fee_bps(&c.env), 100);
             assert_eq!(get_fee_recipient(&c.env), Some(new_recipient.clone()));
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            let new_recipient = Address::generate(&env);
-            init_escrow_config(&env, 250, platform.clone());
-
-            update_fee_config(&env, 100, new_recipient.clone());
-
-            assert_eq!(get_fee_bps(&env), 100);
-            assert_eq!(get_fee_recipient(&env), Some(new_recipient));
         });
     }
 
@@ -740,18 +616,6 @@ mod tests {
             // New deposit captures the updated rate
             deposit_fee(&c.env, 10, c.buyer.clone(), c.seller.clone(), 10_000_000);
             assert_eq!(get_escrow(&c.env, 10).unwrap().platform_fee_bps, 500);
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            let new_recipient = Address::generate(&env);
-            init_escrow_config(&env, 250, platform.clone());
-
-            // Update fee to 500 bps (5%)
-            update_fee_config(&env, 500, new_recipient.clone());
-
-            // New deposit captures the updated rate
-            deposit_fee(&env, 10, buyer.clone(), seller.clone(), 10_000_000);
-            let entry = get_escrow(&env, 10).unwrap();
-            assert_eq!(entry.platform_fee_bps, 500);
         });
     }
 
@@ -770,20 +634,6 @@ mod tests {
 
             // Existing escrow is unchanged
             assert_eq!(get_escrow(&c.env, 20).unwrap().platform_fee_bps, 250);
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            let new_recipient = Address::generate(&env);
-            init_escrow_config(&env, 250, platform.clone());
-
-            // Deposit before update — captures 250 bps
-            deposit_fee(&env, 20, buyer.clone(), seller.clone(), 10_000_000);
-
-            // Update fee to 500 bps
-            update_fee_config(&env, 500, new_recipient.clone());
-
-            // Existing escrow is unchanged
-            let entry = get_escrow(&env, 20).unwrap();
-            assert_eq!(entry.platform_fee_bps, 250);
         });
     }
 
@@ -794,10 +644,6 @@ mod tests {
         c.run(|| {
             init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
             update_fee_config(&c.env, 10_001, c.platform.clone());
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform.clone());
-            update_fee_config(&env, 10_001, platform);
         });
     }
 
@@ -807,9 +653,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #1)")]
     fn init_escrow_config_rejects_fee_bps_over_10000() {
-        let (env, cid, _buyer, _seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 10_001, platform);
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 10_001, c.platform.clone(), c.token.clone());
         });
     }
 
@@ -817,10 +663,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #2)")]
     fn deposit_fee_rejects_non_positive_amount() {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 30, buyer, seller, 0);
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 30, c.buyer.clone(), c.seller.clone(), 0);
         });
     }
 
@@ -828,13 +674,15 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #3)")]
     fn deposit_fee_rejects_duplicate_transfer_id() {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 31, buyer.clone(), seller.clone(), 1_000_000);
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 31, c.buyer.clone(), c.seller.clone(), 1_000_000);
         });
-        env.as_contract(&cid, || {
-            deposit_fee(&env, 31, buyer, seller, 1_000_000);
+        // A fresh top-level call is needed since `buyer.require_auth()` can only
+        // be satisfied once per invocation frame under `mock_all_auths`.
+        c.run(|| {
+            deposit_fee(&c.env, 31, c.buyer.clone(), c.seller.clone(), 1_000_000);
         });
     }
 
@@ -842,12 +690,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #5)")]
     fn finalize_transfer_rejects_non_held_state() {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 32, buyer, seller, 1_000_000);
-            finalize_transfer(&env, 32);
-            finalize_transfer(&env, 32);
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 32, c.buyer.clone(), c.seller.clone(), 1_000_000);
+            finalize_transfer(&c.env, 32);
+            finalize_transfer(&c.env, 32);
         });
     }
 
@@ -855,12 +703,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #5)")]
     fn refund_fee_rejects_non_refundable_state() {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 33, buyer, seller, 1_000_000);
-            finalize_transfer(&env, 33);
-            refund_fee(&env, 33);
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 33, c.buyer.clone(), c.seller.clone(), 1_000_000);
+            finalize_transfer(&c.env, 33);
+            refund_fee(&c.env, 33);
         });
     }
 
@@ -868,12 +716,89 @@ mod tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #6)")]
     fn dispute_transfer_rejects_third_party() {
-        let (env, cid, buyer, seller, platform) = setup();
-        env.as_contract(&cid, || {
-            let stranger = Address::generate(&env);
-            init_escrow_config(&env, 250, platform);
-            deposit_fee(&env, 34, buyer, seller, 1_000_000);
-            dispute_transfer(&env, 34, stranger);
+        let c = setup();
+        c.run(|| {
+            let stranger = Address::generate(&c.env);
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 34, c.buyer.clone(), c.seller.clone(), 1_000_000);
+            dispute_transfer(&c.env, 34, stranger);
+        });
+    }
+
+    // ── Issue #1003: admin_resolve_dispute ────────────────────────────────────
+
+    /// Admin rules for the buyer: the full escrowed amount is refunded.
+    #[test]
+    fn admin_resolve_dispute_refunds_buyer() {
+        let c = setup();
+        let before = c.balance(&c.buyer);
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 200, c.buyer.clone(), c.seller.clone(), 10_000_000);
+        });
+        // Separate top-level calls: `buyer.require_auth()` can only be satisfied
+        // once per invocation frame under `mock_all_auths`.
+        c.run(|| {
+            dispute_transfer(&c.env, 200, c.buyer.clone());
+            admin_resolve_dispute(&c.env, 200, DisputeDecision::RefundBuyer);
+        });
+        assert_eq!(c.balance(&c.buyer), before);
+        assert_eq!(c.balance(&c.seller), 0);
+        assert_eq!(c.balance(&c.contract), 0);
+        c.run(|| {
+            assert_eq!(get_escrow(&c.env, 200).unwrap().status, EscrowStatus::Resolved);
+        });
+    }
+
+    /// Admin rules for the seller: the full escrowed amount is paid out.
+    #[test]
+    fn admin_resolve_dispute_pays_seller() {
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 201, c.buyer.clone(), c.seller.clone(), 10_000_000);
+        });
+        c.run(|| {
+            dispute_transfer(&c.env, 201, c.buyer.clone());
+            admin_resolve_dispute(&c.env, 201, DisputeDecision::PaySeller);
+        });
+        assert_eq!(c.balance(&c.seller), 10_000_000);
+        assert_eq!(c.balance(&c.contract), 0);
+        c.run(|| {
+            assert_eq!(get_escrow(&c.env, 201).unwrap().status, EscrowStatus::Resolved);
+        });
+    }
+
+    /// Admin splits the escrowed amount between buyer and seller.
+    #[test]
+    fn admin_resolve_dispute_split_decision() {
+        let c = setup();
+        let before = c.balance(&c.buyer);
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 202, c.buyer.clone(), c.seller.clone(), 10_000_000);
+        });
+        c.run(|| {
+            dispute_transfer(&c.env, 202, c.buyer.clone());
+            admin_resolve_dispute(&c.env, 202, DisputeDecision::Split(3_000));
+        });
+        assert_eq!(c.balance(&c.seller), 3_000_000);
+        assert_eq!(c.balance(&c.buyer), before - 10_000_000 + 7_000_000);
+        assert_eq!(c.balance(&c.contract), 0);
+        c.run(|| {
+            assert_eq!(get_escrow(&c.env, 202).unwrap().status, EscrowStatus::Resolved);
+        });
+    }
+
+    /// admin_resolve_dispute can only be called from the Disputed state.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn admin_resolve_dispute_rejects_non_disputed_state() {
+        let c = setup();
+        c.run(|| {
+            init_escrow_config(&c.env, 250, c.platform.clone(), c.token.clone());
+            deposit_fee(&c.env, 203, c.buyer.clone(), c.seller.clone(), 1_000_000);
+            admin_resolve_dispute(&c.env, 203, DisputeDecision::RefundBuyer);
         });
     }
 }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/lib.rs
@@ -93,7 +93,6 @@ pub enum TransferType {
     Multisig,
 }
 
-/// A single chain-of-custody entry appended on every ownership change.
 /// ======================================================
 /// ADOPTION WAITING PERIOD (Issue #653)
 /// ======================================================
@@ -212,7 +211,6 @@ enum DataKey {
     JurisdictionAdoptionConfig(String), // jurisdiction -> AdoptionConfig
     Admin,                        // adoption contract admin set on first set_adoption_config call
     OwnerPetSet((Address, u64)),   // (owner, pet_id) -> bool for O(1) membership checks
-    Admin,                      // adoption contract admin set on first set_adoption_config call
 }
 
 /// ======================================================
@@ -226,6 +224,7 @@ const EVT_TRANSFER_FINALIZED: Symbol = symbol_short!("xfer_fin");
 const EVT_TRANSFER_DISPUTED: Symbol = symbol_short!("xfer_disp");
 const EVT_TRUSTED_UPDATED: Symbol = symbol_short!("trust_upd");
 const EVT_TRANSFER_EXPIRED: Symbol = symbol_short!("xfer_exp");
+const EVT_ADOPTION_EXPIRED: Symbol = symbol_short!("adopt_exp");
 
 /// ======================================================
 /// ERRORS
@@ -268,8 +267,8 @@ pub enum ContractError {
     InvalidApprover = 30,
     InvalidTimeoutDays = 31,
     AdopterApprovalRequired = 32,
-    InputStringTooLong = 32,
-    AdoptionNotExpired = 32,
+    InputStringTooLong = 33,
+    AdoptionNotExpired = 34,
 }
 
 /// ======================================================
@@ -321,8 +320,8 @@ fn save_history(env: &Env, pet_id: u64, history: &Vec<OwnershipRecord>) {
     }
 
     let len = history.len();
-    let (trim_count, trimmed) = if len > MAX_OWNERSHIP_HISTORY_LEN as usize {
-        let t = len - MAX_OWNERSHIP_HISTORY_LEN as usize;
+    let (trim_count, trimmed) = if len > MAX_OWNERSHIP_HISTORY_LEN {
+        let t = len - MAX_OWNERSHIP_HISTORY_LEN;
         for i in 0..t {
             env.storage()
                 .persistent()
@@ -337,10 +336,10 @@ fn save_history(env: &Env, pet_id: u64, history: &Vec<OwnershipRecord>) {
     env.storage()
         .persistent()
         .set(&DataKey::OwnershipCount(pet_id), &new_count);
-    for (i, record) in history.iter().skip(trimmed).enumerate() {
+    for (i, record) in history.iter().skip(trimmed as usize).enumerate() {
         env.storage()
             .persistent()
-            .set(&DataKey::OwnershipEntry((pet_id, (i as u64) + 1)), record);
+            .set(&DataKey::OwnershipEntry((pet_id, (i as u64) + 1)), &record);
     }
 }
 
@@ -370,19 +369,6 @@ fn append_custody_entry(
         .persistent()
         .set(&DataKey::CustodyChain(pet_id), &chain);
 }
-
-/// ======================================================
-/// EVENTS
-/// ======================================================
-
-const EVT_TRANSFER_INITIATED: Symbol = symbol_short!("xfer_init");
-const EVT_TRANSFER_CANCELLED: Symbol = symbol_short!("xfer_cncl");
-const EVT_TRANSFER_ESCROWED: Symbol = symbol_short!("xfer_escr");
-const EVT_TRANSFER_FINALIZED: Symbol = symbol_short!("xfer_fin");
-const EVT_TRANSFER_DISPUTED: Symbol = symbol_short!("xfer_disp");
-const EVT_TRUSTED_UPDATED: Symbol = symbol_short!("trust_upd");
-const EVT_TRANSFER_EXPIRED: Symbol = symbol_short!("xfer_exp");
-const EVT_ADOPTION_EXPIRED: Symbol = symbol_short!("adopt_exp");
 
 fn get_owner_pet_ids(env: &Env, owner: &Address) -> Vec<u64> {
     env.storage()
@@ -582,12 +568,11 @@ impl PetOwnershipContract {
         admin.require_auth();
         let config = AdoptionConfig {
             waiting_period_days,
+            expiry_seconds: ADOPTION_EXPIRY_SECONDS,
         };
         env.storage()
             .persistent()
             .set(&DataKey::AdoptionConfig, &config);
-        let config = AdoptionConfig { waiting_period_days, expiry_seconds: ADOPTION_EXPIRY_SECONDS };
-        env.storage().persistent().set(&DataKey::AdoptionConfig, &config);
         env.storage().persistent().set(&DataKey::Admin, &admin);
     }
 
@@ -605,21 +590,16 @@ impl PetOwnershipContract {
             .get(&DataKey::AdoptionConfig)
             .unwrap_or(AdoptionConfig {
                 waiting_period_days: 0,
+                expiry_seconds: ADOPTION_EXPIRY_SECONDS,
             });
-
-        let new_config = AdoptionConfig {
-            waiting_period_days,
-        };
-        env.storage()
-            .persistent()
-            .set(&DataKey::AdoptionConfig, &new_config);
-            .unwrap_or(AdoptionConfig { waiting_period_days: 0, expiry_seconds: ADOPTION_EXPIRY_SECONDS });
 
         let new_config = AdoptionConfig {
             waiting_period_days,
             expiry_seconds: old_config.expiry_seconds,
         };
-        env.storage().persistent().set(&DataKey::AdoptionConfig, &new_config);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AdoptionConfig, &new_config);
 
         env.events().publish(
             (Symbol::new(&env, "cfg_adoption"),),
@@ -634,9 +614,8 @@ impl PetOwnershipContract {
             .get(&DataKey::AdoptionConfig)
             .unwrap_or(AdoptionConfig {
                 waiting_period_days: 0,
+                expiry_seconds: ADOPTION_EXPIRY_SECONDS,
             })
-        env.storage().persistent().get(&DataKey::AdoptionConfig)
-            .unwrap_or(AdoptionConfig { waiting_period_days: 0, expiry_seconds: ADOPTION_EXPIRY_SECONDS })
     }
 
     /// Set a per-species adoption waiting period override.
@@ -836,10 +815,6 @@ impl PetOwnershipContract {
             (EVT_TRANSFER_EXPIRED, pet_id),
             (transfer.from, transfer.to),
         );
-    }
-
-        env.events()
-            .publish((EVT_TRANSFER_EXPIRED, pet_id), (transfer.from, transfer.to));
     }
 
     /// Reject a pending adoption. Any participant may cancel the adoption.
@@ -1565,79 +1540,5 @@ impl PetOwnershipContract {
         env.storage()
             .persistent()
             .get(&DataKey::EscrowedTransfer(pet_id))
-    }
-
-    /// Returns the timeout_secs for the pending transfer of `pet_id`, or `None`.
-    pub fn get_transfer_timeout_secs(env: Env, pet_id: u64) -> Option<u64> {
-        let transfer: Option<PendingTransfer> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::PendingTransfer(pet_id));
-        transfer.map(|t| t.timeout_secs)
-    }
-
-    // ----------------------------------
-    // TRUSTED CONTRACT / MULTISIG ADMIN
-    // ----------------------------------
-
-    /// Initialise the trusted contract address and multisig admin list.
-    /// Can only be called once.
-    pub fn init_trusted_contract(env: Env, trusted: Address, admins: Vec<Address>, threshold: u32) {
-        if env.storage().instance().has(&DataKey::TrustedContract) {
-            panic_with_error!(env, ContractError::AlreadyInitialized);
-        }
-        if threshold == 0 || threshold > admins.len() {
-            panic_with_error!(env, ContractError::InvalidThreshold);
-        }
-        env.storage()
-            .instance()
-            .set(&DataKey::TrustedContract, &trusted);
-        env.storage()
-            .instance()
-            .set(&DataKey::TrustedAdmins, &admins);
-        env.storage()
-            .instance()
-            .set(&DataKey::TrustedThreshold, &threshold);
-    }
-
-    /// Returns `true` if `callee` equals the stored trusted contract address.
-    /// Panics with `UntrustedContract` otherwise.
-    pub fn validate_trusted_contract(env: Env, callee: Address) -> bool {
-        require_trusted_contract(&env, &callee);
-        true
-    }
-
-    /// Returns the currently stored trusted contract address.
-    pub fn get_trusted_contract_address(env: Env) -> Address {
-        get_trusted_contract(&env)
-    }
-
-    /// Cast a multisig vote to update the trusted contract address.
-    /// Returns `true` when the threshold is met and the address is updated.
-    pub fn update_trusted_contract(env: Env, new_address: Address, signer: Address) -> bool {
-        let (admins, threshold) = require_trusted_multisig_admin(&env, &signer);
-
-        let key = DataKey::TrustedUpdateApprovals((new_address.clone(), signer.clone()));
-        env.storage().instance().set(&key, &true);
-
-        // Count approvals
-        let mut count: u32 = 0;
-        for admin in admins.iter() {
-            let k = DataKey::TrustedUpdateApprovals((new_address.clone(), admin.clone()));
-            if env.storage().instance().has(&k) {
-                count += 1;
-            }
-        }
-
-        if count >= threshold {
-            env.storage()
-                .instance()
-                .set(&DataKey::TrustedContract, &new_address);
-            clear_trusted_update_approvals(&env, &admins, &new_address);
-            env.events().publish((EVT_TRUSTED_UPDATED,), (new_address,));
-            return true;
-        }
-
-        false
     }
 }

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -1,10 +1,7 @@
 use super::{
-    AdoptionState, ContractError, CustodyEntry, DataKey, EscrowedTransfer, OwnershipRecord,
+    AdoptionState, ContractError, DataKey,
     PetOwnershipContract, PetOwnershipContractClient, TransferType, TrustedUpdateApprovalKey,
-    DISPUTE_WINDOW_SECONDS,
-    PetOwnershipContract, PetOwnershipContractClient, TransferType, DISPUTE_WINDOW_SECONDS,
-    MAX_REJECTION_REASON_LEN,
-    MAX_CUSTODY_CHAIN_LENGTH,
+    DISPUTE_WINDOW_SECONDS, MAX_REJECTION_REASON_LEN, MAX_CUSTODY_CHAIN_LENGTH,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -359,7 +356,7 @@ fn finalize_transfer_errors_when_history_is_missing() {
     env.as_contract(&contract_id, || {
         env.storage()
             .persistent()
-            .remove(&DataKey::OwnershipHistory(pet_id));
+            .remove(&DataKey::OwnershipCount(pet_id));
     });
 
     env.ledger().with_mut(|l| {
@@ -383,11 +380,10 @@ fn finalize_transfer_errors_when_history_is_empty() {
     create_pending_transfer(&client, pet_id, &owner, &new_owner);
     client.accept_transfer(&pet_id); // → Escrowed
 
-    let empty_history = Vec::<OwnershipRecord>::new(&env);
     env.as_contract(&contract_id, || {
         env.storage()
             .persistent()
-            .set(&DataKey::OwnershipHistory(pet_id), &empty_history);
+            .set(&DataKey::OwnershipCount(pet_id), &0u64);
     });
 
     env.ledger().with_mut(|l| {
@@ -1161,11 +1157,6 @@ fn update_adoption_config_fails_without_prior_set() {
 
 #[test]
 fn complete_adoption_without_adopter_approval_is_rejected() {
-// cancel_expired_adoption tests (Issue #1009)
-// ======================================================
-
-#[test]
-fn cancel_expired_adoption_before_expiry_is_rejected() {
     let (env, owner, adopter, pet_id) = setup();
     let contract_id = env.register_contract(None, PetOwnershipContract);
     let client = PetOwnershipContractClient::new(&env, &contract_id);
@@ -1185,6 +1176,19 @@ fn cancel_expired_adoption_before_expiry_is_rejected() {
 
     // Pet ownership must not have changed
     assert_eq!(client.get_current_owner(&pet_id), owner);
+}
+
+// ======================================================
+// cancel_expired_adoption tests (Issue #1009)
+// ======================================================
+
+#[test]
+fn cancel_expired_adoption_before_expiry_is_rejected() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
     client.sign_adoption(&pet_id, &adopter, &None);
 
     // Well within the 30-day window — must fail
@@ -1226,6 +1230,22 @@ fn cancel_expired_adoption_after_expiry_succeeds() {
 #[test]
 fn cancel_expired_adoption_without_pending_adoption_is_rejected() {
     let (env, owner, _adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    // No adoption was ever signed
+
+    let result = client.try_cancel_expired_adoption(&pet_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::NoPendingAdoption as u32,
+        )))
+    );
+}
+
+// ======================================================
 // Custody chain length cap tests (Issue #1011)
 // ======================================================
 
@@ -1254,13 +1274,6 @@ fn custody_chain_is_capped_at_max_length() {
 
     client.create_pet(&pet_id, &owner);
 
-    let result = client.try_cancel_expired_adoption(&pet_id);
-    assert_eq!(
-        result,
-        Err(Ok(Error::from_contract_error(
-            ContractError::NoPendingAdoption as u32,
-        )))
-    );
     // Exactly MAX_CUSTODY_CHAIN_LENGTH transfers — nothing is dropped yet.
     for i in 0..MAX_CUSTODY_CHAIN_LENGTH {
         let to = if i % 2 == 0 { &new_owner } else { &owner };

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs
@@ -304,7 +304,7 @@ impl VetRegistryContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Error, String};
 
     fn setup() -> (Env, Address, Address, VetRegistryContractClient<'static>) {
         let env = Env::default();


### PR DESCRIPTION
## Related Issue

Closes #1003

## Description of Changes

Adds `admin_resolve_dispute(env, transfer_id, decision)` to `escrow.rs`, where `decision` is a new `DisputeDecision` enum (`RefundBuyer`, `PaySeller`, `Split(bps)`). Only the configured `FeeRecipient` can call it, and it's only valid from the `Disputed` state. It executes the appropriate token transfer(s) and emits a `DISPUTE_RESOLVED` event.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Done

- [x] All existing tests pass (`cargo test`)
- [x] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [x] Manually verified expected behavior

### Test Environment

- Rust version: stable-x86_64-pc-windows-msvc
- Stellar CLI version: n/a
- OS: Windows 11

## Checklist

- [x] My code follows the project's code style guidelines (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] No hardcoded secrets, keys, or credentials are included in this PR
- [x] No plaintext encryption keys or sensitive data are exposed in the code
- [x] Input validation is properly implemented for all public functions
- [x] Authentication checks are in place for state-changing operations
- [x] I have read and followed the Contributing Guide

## Security Considerations

`admin_resolve_dispute` requires `require_auth()` from the stored `FeeRecipient` address and only transitions out of the `Disputed` state, so it can't be used to bypass the normal deposit/finalize/refund flow.

## Additional Notes

`escrow.rs` and `lib.rs` in this crate had leftover unresolved-merge duplication (duplicate function bodies, clashing storage key variants, mismatched types in `save_history`, and an interleaved `test.rs`) that left the crate not compiling. Cleaned that up as part of getting `cargo test` green here. Also pinned `ed25519-dalek` in `Cargo.toml` since the crate's dev-dependency resolution was picking an incompatible major version for `soroban-env-host`'s test utilities.