### PR TITLE
fix(stellar-contracts): cap ActivityStreak milestones at MAX_MILESTONES=32, implement streak tracking

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -199,6 +199,26 @@ const MAX_BATCH_ERROR_MESSAGES: usize = 50;
 /// owner's storage quota. `add_attachment` enforces this cap. (Issue #774)
 const MAX_ATTACHMENTS_PER_RECORD: u32 = 20;
 
+/// Maximum number of milestone entries that can be stored in
+/// [`ActivityStreak::milestones_reached`].
+///
+/// The `milestones_reached` Vec is embedded inline inside `ActivityStreak` and
+/// serialised in a single XDR entry in Soroban persistent storage. An unbounded
+/// Vec could exceed the XDR entry size limit if many milestones are added over
+/// time (e.g. 365-day, 1000-day, etc.) or via a bug that appends duplicates.
+/// Once the entry exceeds the XDR limit every subsequent `add_activity_record`
+/// call would panic, effectively bricking all activity updates for the pet.
+///
+/// 32 slots is far more than the current milestone set (7, 30, 100 days) and
+/// leaves ample room for future milestones while keeping the entry size bounded.
+const MAX_MILESTONES: u32 = 32;
+
+/// Standard activity-streak milestones (in streak-days).
+/// A new milestone entry is recorded in `ActivityStreak::milestones_reached`
+/// the first time a pet's consecutive-day streak reaches one of these values,
+/// subject to the [`MAX_MILESTONES`] cap.
+const STREAK_MILESTONE_DAYS: &[u64] = &[7, 30, 100, 365, 1000];
+
 // --- STORAGE QUOTA CONSTANTS ---
 const DEFAULT_STORAGE_QUOTA: u64 = 1000; // Default max storage entries per pet
 
@@ -10120,7 +10140,129 @@ impl PetChainContract {
             .instance()
             .set(&ActivityKey::PetActivityCount(pet_id), &pet_index);
 
+        // ── STREAK TRACKING ──────────────────────────────────────────────────
+        // Update the pet's consecutive-day activity streak.
+        //
+        // The streak is stored in persistent storage (not instance storage) so
+        // it survives ledger TTL extension.  The last-activity-date entry is
+        // stored alongside it for gap detection.
+        //
+        // Day boundaries use whole-day slots: `timestamp / 86400`.
+        let seconds_per_day: u64 = 86400;
+        let today: u64 = now / seconds_per_day;
+
+        let mut streak: ActivityStreak = env
+            .storage()
+            .persistent()
+            .get(&ActivityKey::PetActivityStreak(pet_id))
+            .unwrap_or(ActivityStreak {
+                pet_id,
+                current_streak: 0,
+                longest_streak: 0,
+                last_activity_date: 0,
+                milestones_reached: Vec::new(&env),
+            });
+
+        let last_day = streak.last_activity_date;
+
+        if last_day == 0 {
+            // First-ever activity for this pet.
+            streak.current_streak = 1;
+        } else if today == last_day {
+            // Same calendar day — streak already counted for today; no change.
+        } else if today == last_day + 1 {
+            // Consecutive day — extend streak.
+            streak.current_streak = streak.current_streak.saturating_add(1);
+        } else {
+            // Gap of >1 day — streak resets to 1 (today counts as day 1 of a
+            // new streak but does not carry forward old milestone progress).
+            streak.current_streak = 1;
+        }
+
+        // Update longest streak.
+        if streak.current_streak > streak.longest_streak {
+            streak.longest_streak = streak.current_streak;
+        }
+
+        // Record any newly-crossed milestones.
+        // Guard with MAX_MILESTONES so the Vec never grows without bound.
+        for &milestone in STREAK_MILESTONE_DAYS {
+            if streak.current_streak >= milestone {
+                // Only append if not already present AND cap not exceeded.
+                let already_recorded = streak.milestones_reached.contains(&milestone);
+                let under_cap =
+                    (streak.milestones_reached.len() as u32) < MAX_MILESTONES;
+
+                if !already_recorded && under_cap {
+                    streak.milestones_reached.push_back(milestone);
+
+                    // Emit a streak-milestone event.
+                    env.events().publish(
+                        (
+                            soroban_sdk::Symbol::new(&env, "streak_milestone"),
+                            pet_id,
+                        ),
+                        StreakMilestoneEvent {
+                            pet_id,
+                            milestone_days: milestone,
+                            timestamp: now,
+                        },
+                    );
+                }
+            }
+        }
+
+        // Advance the last-activity-date only when we move to a new day or on
+        // the very first activity (last_day == 0).
+        if today != last_day {
+            streak.last_activity_date = today;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&ActivityKey::PetActivityStreak(pet_id), &streak);
+
         activity_id
+    }
+
+    /// Return the current [`ActivityStreak`] for a pet.
+    ///
+    /// If the pet has never had an activity recorded the returned streak has all
+    /// fields set to zero / empty.  Returns a default struct rather than
+    /// panicking so callers can distinguish "no data yet" from an error.
+    pub fn get_activity_streak(env: Env, pet_id: u64) -> ActivityStreak {
+        env.storage()
+            .persistent()
+            .get(&ActivityKey::PetActivityStreak(pet_id))
+            .unwrap_or(ActivityStreak {
+                pet_id,
+                current_streak: 0,
+                longest_streak: 0,
+                last_activity_date: 0,
+                milestones_reached: Vec::new(&env),
+            })
+    }
+
+    /// Return `true` if `pet_id` has reached the given `milestone_days` streak.
+    ///
+    /// This checks [`ActivityStreak::milestones_reached`] for the exact value.
+    /// The milestone is recorded when the consecutive-day streak first reaches
+    /// (or exceeds) that value inside [`Self::add_activity_record`].
+    pub fn has_reached_milestone(env: Env, pet_id: u64, milestone_days: u64) -> bool {
+        let streak: ActivityStreak = env
+            .storage()
+            .persistent()
+            .get(&ActivityKey::PetActivityStreak(pet_id))
+            .unwrap_or(ActivityStreak {
+                pet_id,
+                current_streak: 0,
+                longest_streak: 0,
+                last_activity_date: 0,
+                milestones_reached: Vec::new(&env),
+            });
+        streak
+            .milestones_reached
+            .contains(&milestone_days)
     }
 
     pub fn set_activity_idempotency_window(env: Env, admin: Address, window_seconds: u64) {

--- a/stellar-contracts/src/test_activity.rs
+++ b/stellar-contracts/src/test_activity.rs
@@ -1941,3 +1941,145 @@ fn test_get_activity_record_by_id_multiple_records() {
     let missing_id = id3 + 999;
     assert!(client.get_activity_record_by_id(&missing_id).is_none());
 }
+
+    /// Verifies that milestones_reached never exceeds MAX_MILESTONES (32) even
+    /// when the milestone list is artificially driven past the cap.
+    ///
+    /// Because the standard milestone set only has 5 entries (7, 30, 100, 365,
+    /// 1000) we cannot reach 32 via normal consecutive-day activity in a test.
+    /// This test therefore checks the boundary condition directly via the
+    /// get_activity_streak read-path: after 7 consecutive days the Vec must
+    /// contain exactly the milestones that were actually reached (≤ 32 entries)
+    /// and must NOT contain more entries than the cap allows.
+    #[test]
+    fn test_milestones_capped_at_max_milestones() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.init_admin(&owner);
+
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "Cap-Test"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Labrador"),
+            &String::from_str(&env, "Black"),
+            &30,
+            &None,
+            &PrivacyLevel::Public,
+        );
+
+        // Drive a 7-day streak so the first milestone (7-day) is recorded.
+        for day in 0..7u64 {
+            env.ledger().with_mut(|l| {
+                l.timestamp = day * 86_400;
+            });
+            client.add_activity_record(
+                &pet_id,
+                &ActivityType::Walk,
+                &30,
+                &5,
+                &1000,
+                &String::from_str(&env, "Walk"),
+            );
+        }
+
+        let streak = client.get_activity_streak(&pet_id);
+
+        // 7-day milestone must be present.
+        assert!(
+            streak.milestones_reached.contains(&7),
+            "7-day milestone must be recorded after 7 consecutive days"
+        );
+
+        // The Vec must never exceed the cap, regardless of how many
+        // milestones exist in STREAK_MILESTONE_DAYS.
+        let milestone_count = streak.milestones_reached.len() as u32;
+        assert!(
+            milestone_count <= 32,
+            "milestones_reached must not exceed MAX_MILESTONES=32, got {}",
+            milestone_count
+        );
+    }
+
+    /// After reaching the 7-day milestone, the milestone is not duplicated on
+    /// subsequent activity records on the same or following days.
+    #[test]
+    fn test_milestone_not_duplicated_on_repeated_activity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let contract_id = env.register_contract(None, PetChainContract);
+        let client = PetChainContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.init_admin(&owner);
+
+        let pet_id = client.register_pet(
+            &owner,
+            &String::from_str(&env, "No-Dup"),
+            &String::from_str(&env, "2020-01-01"),
+            &Gender::Male,
+            &Species::Dog,
+            &String::from_str(&env, "Beagle"),
+            &String::from_str(&env, "Tri"),
+            &12,
+            &None,
+            &PrivacyLevel::Public,
+        );
+
+        // Build a 7-day streak.
+        for day in 0..7u64 {
+            env.ledger().with_mut(|l| {
+                l.timestamp = day * 86_400;
+            });
+            client.add_activity_record(
+                &pet_id,
+                &ActivityType::Walk,
+                &30,
+                &5,
+                &500,
+                &String::from_str(&env, "Walk"),
+            );
+        }
+
+        // Continue for 3 more days — streak is now 10, 7-day milestone already set.
+        for day in 7..10u64 {
+            env.ledger().with_mut(|l| {
+                l.timestamp = day * 86_400;
+            });
+            client.add_activity_record(
+                &pet_id,
+                &ActivityType::Run,
+                &20,
+                &7,
+                &800,
+                &String::from_str(&env, "Run"),
+            );
+        }
+
+        let streak = client.get_activity_streak(&pet_id);
+        assert_eq!(streak.current_streak, 10);
+        assert!(streak.milestones_reached.contains(&7));
+
+        // Count occurrences of 7 in milestones_reached — must be exactly 1.
+        let count_7 = streak
+            .milestones_reached
+            .iter()
+            .filter(|m| *m == 7)
+            .count();
+        assert_eq!(
+            count_7, 1,
+            "7-day milestone must appear exactly once in milestones_reached, got {}",
+            count_7
+        );
+    }
+} // end mod test_activity


### PR DESCRIPTION
Closes #1067

---

## Summary

`ActivityStreak::milestones_reached` is a `Vec<u64>` stored inline in a Soroban persistent storage entry. There was no bound on how many entries it could hold. As future milestones (365-day, 1000-day, etc.) are added, or if a bug causes duplicate appends, the Vec could grow past the XDR entry size limit. Once that happens, every subsequent call to `add_activity_record` for that pet would panic, permanently bricking all activity updates.

Additionally, the `get_activity_streak` and `has_reached_milestone` contract functions referenced in tests were not implemented anywhere in the contract.

## Changes

### stellar-contracts/src/lib.rs

**New constants**
- `MAX_MILESTONES: u32 = 32` — caps `milestones_reached` at 32 entries (well above the current 5-entry milestone set, with room for future additions).
- `STREAK_MILESTONE_DAYS: &[u64] = &[7, 30, 100, 365, 1000]` — the standard milestone thresholds.

**`add_activity_record`** — new streak update block appended before the return:
1. Loads the existing `ActivityStreak` from persistent storage, or initialises a zero-default.
2. Computes the current calendar day as `timestamp / 86400`.
3. Increments `current_streak` on consecutive days; resets to 1 on gaps >1 day; no-ops on the same day.
4. Updates `longest_streak` when `current_streak` exceeds it.
5. For each milestone in `STREAK_MILESTONE_DAYS`: appends only if (a) not already present (`Vec::contains`) and (b) the cap (`MAX_MILESTONES`) is not exceeded. Emits a `streak_milestone` event on first crossing.
6. Persists the updated `ActivityStreak` to persistent storage.

**New contract functions**
- `get_activity_streak(env, pet_id) -> ActivityStreak`: reads persistent streak entry or returns a zero-initialised default.
- `has_reached_milestone(env, pet_id, milestone_days) -> bool`: checks `milestones_reached` via `Vec::contains`.

### stellar-contracts/src/test_activity.rs
- **`test_milestones_capped_at_max_milestones`**: verifies `milestones_reached.len() <= 32` after 7 consecutive days and that the 7-day milestone is recorded.
- **`test_milestone_not_duplicated_on_repeated_activity`**: drives a 10-day streak (crossing the 7-day milestone on day 7) and asserts the 7-day entry appears exactly once in `milestones_reached`.
- Closes the `mod test_activity { ... }` module that was left open.

## Boundary enforcement

```rust
// Before appending, guard with the cap:
let already_recorded = streak.milestones_reached.contains(&milestone);
let under_cap = (streak.milestones_reached.len() as u32) < MAX_MILESTONES;
if !already_recorded && under_cap {
    streak.milestones_reached.push_back(milestone);
}
```

Even if an operator adds 50 new milestone thresholds in the future, the Vec will stop growing at 32 entries rather than exceeding the XDR limit.