### PR TITLE
Add PostgresFlaggedScoreStore for flagged-score persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +2711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3028,7 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.9",
  "sqlx",
  "tokio",
@@ -3023,6 +3045,7 @@ dependencies = [
 name = "petchain-stellar"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -3186,7 +3209,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -3217,6 +3240,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3286,12 @@ dependencies = [
  "image",
  "qrcodegen",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -3341,6 +3389,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -3521,8 +3578,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3600,6 +3670,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3803,6 +3885,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4427,6 +4522,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,6 +4865,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,6 +4918,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -4869,6 +4989,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/backend-2fa/Cargo.toml
+++ b/backend-2fa/Cargo.toml
@@ -34,6 +34,7 @@ aws-sdk-secretsmanager = "1"
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", features = ["html_reports"] }
+serde_yaml = "0.9"
 
 [features]
 webhook-client = []

--- a/backend-2fa/docs/openapi.yaml
+++ b/backend-2fa/docs/openapi.yaml
@@ -1,0 +1,105 @@
+openapi: 3.0.3
+info:
+  title: PetChain 2FA Service
+  version: 1.0.0
+  description: Multi-tenant two-factor authentication, leaderboard, and admin API.
+
+paths:
+  /2fa/enable:
+    post:
+      summary: Enable two-factor authentication for a user
+      responses:
+        "200":
+          description: 2FA setup details (secret, QR code, backup codes)
+  /2fa/disable:
+    post:
+      summary: Disable two-factor authentication for a user
+      responses:
+        "200":
+          description: Whether 2FA was disabled
+  /2fa/verify:
+    post:
+      summary: Verify a TOTP token and activate 2FA
+      responses:
+        "200":
+          description: Verification result
+  /2fa/login:
+    post:
+      summary: Verify a TOTP token during login
+      responses:
+        "200":
+          description: Login verification result
+  /2fa/recover:
+    post:
+      summary: Recover account access using a backup code
+      responses:
+        "200":
+          description: New secret and backup/recovery codes
+  /2fa/recovery-log:
+    get:
+      summary: Fetch the recovery-code usage audit log for a user
+      responses:
+        "200":
+          description: List of recovery code usage entries
+  /2fa/upgrade-algorithm:
+    post:
+      summary: Upgrade a user's TOTP HMAC algorithm
+      responses:
+        "200":
+          description: Upgrade result
+  /2fa/revoke-session:
+    post:
+      summary: Revoke a session by JWT ID
+      responses:
+        "200":
+          description: Revocation result
+  /admin/quota:
+    post:
+      summary: Grant a user an unlimited rate-limit quota
+      responses:
+        "200":
+          description: Quota update result
+  /admin/canary:
+    post:
+      summary: Create a canary token for breach detection
+      responses:
+        "200":
+          description: Canary creation result
+  /admin/flagged-scores:
+    get:
+      summary: List flagged leaderboard score submissions
+      responses:
+        "200":
+          description: List of flagged submissions
+  /admin/list-users:
+    get:
+      summary: List users with two-factor status
+      responses:
+        "200":
+          description: Paginated list of users
+  /admin/unlock:
+    post:
+      summary: Unlock a user locked out of two-factor verification
+      responses:
+        "200":
+          description: Unlock result
+  /admin/list-locked:
+    get:
+      summary: List users currently locked out
+      responses:
+        "200":
+          description: Paginated list of locked users
+  /tenant/provision:
+    post:
+      summary: Provision a new tenant (super-admin only)
+      responses:
+        "200":
+          description: Tenant configuration
+        "400":
+          description: Invalid tenant configuration (BAD_REQUEST)
+  /leaderboard/subscribe:
+    get:
+      summary: Subscribe to real-time leaderboard updates over WebSocket
+      responses:
+        "101":
+          description: Switching Protocols (WebSocket upgrade)

--- a/backend-2fa/migrations/006_create_flagged_scores.down.sql
+++ b/backend-2fa/migrations/006_create_flagged_scores.down.sql
@@ -1,0 +1,2 @@
+-- 006_create_flagged_scores.down.sql
+DROP TABLE IF EXISTS flagged_scores;

--- a/backend-2fa/migrations/006_create_flagged_scores.sql
+++ b/backend-2fa/migrations/006_create_flagged_scores.sql
@@ -1,0 +1,17 @@
+-- 006_create_flagged_scores.sql
+-- Creates the flagged_scores table backing PostgresFlaggedScoreStore
+-- (Issue #789), persisting leaderboard score submissions rejected by
+-- validate_score_submission (delta or z-score anomaly) across restarts.
+-- The in-memory FlaggedScoreStore implementation remains available for
+-- tests and for deployments without a configured database.
+
+CREATE TABLE IF NOT EXISTS flagged_scores (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     TEXT NOT NULL,
+    score       BIGINT NOT NULL,
+    reason      TEXT NOT NULL,
+    flagged_at  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_flagged_scores_user_id ON flagged_scores(user_id);
+CREATE INDEX IF NOT EXISTS idx_flagged_scores_flagged_at ON flagged_scores(flagged_at);

--- a/backend-2fa/src/content_type_guard.rs
+++ b/backend-2fa/src/content_type_guard.rs
@@ -161,12 +161,14 @@ mod tests {
         HttpResponse::Ok().json(serde_json::json!({ "ok": true }))
     }
 
-    fn build_app() -> impl actix_web::dev::ServiceFactory<
-        actix_web::dev::ServiceRequest,
-        Config = (),
-        Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
-        Error = actix_web::Error,
-        InitError = (),
+    fn build_app() -> App<
+        impl actix_web::dev::ServiceFactory<
+            actix_web::dev::ServiceRequest,
+            Config = (),
+            Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+            Error = actix_web::Error,
+            InitError = (),
+        >,
     > {
         App::new()
             .wrap(ContentTypeGuard)

--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -1,4 +1,5 @@
 use crate::ip_access::{CidrBlock, IpAccessEntry, IpAccessStore, IpListType};
+use crate::leaderboard::{FlaggedScoreStore, FlaggedScoreSubmission};
 use crate::two_factor::HmacAlgorithm;
 use crate::two_factor::{
     AuditLogEntry, LockedUserSummary, RecoveryCodeUsageLog, TwoFactorData, TwoFactorLockoutState,
@@ -127,6 +128,7 @@ fn load_encryption_key(provider: &dyn SecretProvider) -> Result<[u8; 32], String
         .map_err(|_| "TOTP_ENCRYPTION_KEY must be 32 bytes (64 hex chars)".to_string())
 }
 
+#[derive(Debug)]
 pub struct PostgresTwoFactorStore {
     pool: PgPool,
     runtime: Arc<Runtime>,
@@ -158,16 +160,17 @@ impl PostgresTwoFactorStore {
             .and_then(|v| v.parse().ok())
             .unwrap_or(10);
 
+        // sqlx's pool has a single `acquire_timeout` covering both "wait for
+        // a free slot" and "make the initial TCP connection" — apply the
+        // tighter of the two configured bounds so either one is honored.
+        let effective_timeout_secs = acquire_timeout_secs.min(connect_timeout_secs);
+
         let pool = runtime
             .block_on(
                 PgPoolOptions::new()
                     .min_connections(min_conns)
                     .max_connections(max_conns)
-                    .acquire_timeout(Duration::from_secs(acquire_timeout_secs))
-                    // connect_timeout governs each individual TCP connection
-                    // attempt, distinct from acquire_timeout which governs
-                    // waiting for a free slot in an already-built pool.
-                    .connect_timeout(Duration::from_secs(connect_timeout_secs))
+                    .acquire_timeout(Duration::from_secs(effective_timeout_secs))
                     .connect(database_url),
             )
             .map_err(|e| format!(
@@ -690,6 +693,9 @@ impl TwoFactorStore for PostgresTwoFactorStore {
                 locked: r.locked,
                 locked_at: r.locked_at.map(|ts| ts as u64),
                 updated_at: r.updated_at as u64,
+                // The Postgres-backed store does not yet persist a
+                // progressive-delay retry timestamp column.
+                retry_after_timestamp: None,
             })
             .unwrap_or_default())
     }
@@ -935,6 +941,135 @@ impl IpAccessStore for PostgresIpAccessStore {
                 .collect()
         })
         .unwrap_or_default()
+    }
+}
+
+/// Postgres-backed [`FlaggedScoreStore`] (Issue #789). Persists flagged
+/// leaderboard score submissions in the `flagged_scores` table
+/// (see `migrations/006_create_flagged_scores.sql`) so they survive process
+/// restarts. The in-memory `InMemoryFlaggedScoreStore` remains available for
+/// tests and for deployments without a configured database.
+#[derive(Clone)]
+pub struct PostgresFlaggedScoreStore {
+    pool: PgPool,
+    runtime: Arc<Runtime>,
+}
+
+impl PostgresFlaggedScoreStore {
+    pub fn connect(database_url: &str) -> Result<Self, String> {
+        let runtime = Arc::new(Runtime::new().map_err(|e| e.to_string())?);
+        let pool = runtime
+            .block_on(
+                PgPoolOptions::new()
+                    .max_connections(10)
+                    .connect(database_url),
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(Self { pool, runtime })
+    }
+
+    pub fn from_pool(pool: PgPool) -> Result<Self, String> {
+        let runtime = Arc::new(Runtime::new().map_err(|e| e.to_string())?);
+        Ok(Self { pool, runtime })
+    }
+
+    fn block_on<F, T>(&self, future: F) -> Result<T, String>
+    where
+        F: std::future::Future<Output = Result<T, sqlx::Error>>,
+    {
+        self.runtime.block_on(future).map_err(|e| e.to_string())
+    }
+}
+
+impl FlaggedScoreStore for PostgresFlaggedScoreStore {
+    fn add_flagged(&self, flagged: FlaggedScoreSubmission) {
+        let _ = self.block_on(
+            sqlx::query(
+                r#"
+                INSERT INTO flagged_scores (user_id, score, reason, flagged_at)
+                VALUES ($1, $2, $3, to_timestamp($4))
+                "#,
+            )
+            .bind(&flagged.user_id)
+            .bind(flagged.attempted_score as i64)
+            .bind(&flagged.reason)
+            .bind(flagged.timestamp as f64)
+            .execute(&self.pool),
+        );
+    }
+
+    fn get_flagged_by_user(&self, user_id: &str) -> Vec<FlaggedScoreSubmission> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            user_id: String,
+            score: i64,
+            reason: String,
+            flagged_at: i64,
+        }
+
+        let rows = self.block_on(
+            sqlx::query_as::<_, Row>(
+                r#"
+                SELECT user_id, score, reason,
+                       EXTRACT(EPOCH FROM flagged_at)::bigint AS flagged_at
+                FROM flagged_scores
+                WHERE user_id = $1
+                ORDER BY flagged_at
+                "#,
+            )
+            .bind(user_id)
+            .fetch_all(&self.pool),
+        );
+
+        rows.map(|rows| {
+            rows.into_iter()
+                .map(|r| FlaggedScoreSubmission {
+                    user_id: r.user_id,
+                    attempted_score: r.score.max(0) as u64,
+                    timestamp: r.flagged_at.max(0) as u64,
+                    reason: r.reason,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+    }
+
+    fn get_all_flagged(&self) -> Vec<FlaggedScoreSubmission> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            user_id: String,
+            score: i64,
+            reason: String,
+            flagged_at: i64,
+        }
+
+        let rows = self.block_on(
+            sqlx::query_as::<_, Row>(
+                r#"
+                SELECT user_id, score, reason,
+                       EXTRACT(EPOCH FROM flagged_at)::bigint AS flagged_at
+                FROM flagged_scores
+                ORDER BY flagged_at
+                "#,
+            )
+            .fetch_all(&self.pool),
+        );
+
+        rows.map(|rows| {
+            rows.into_iter()
+                .map(|r| FlaggedScoreSubmission {
+                    user_id: r.user_id,
+                    attempted_score: r.score.max(0) as u64,
+                    timestamp: r.flagged_at.max(0) as u64,
+                    reason: r.reason,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+    }
+
+    fn clear(&self) {
+        let _ = self.block_on(sqlx::query("DELETE FROM flagged_scores").execute(&self.pool));
     }
 }
 

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -1,9 +1,11 @@
 #[cfg(not(test))]
 use crate::db::PostgresTwoFactorStore;
 use crate::error::ApiError;
-use crate::leaderboard::{leaderboard_ws_endpoint, FlaggedScoreStore, FlaggedScoreSubmission};
+use crate::leaderboard::{
+    leaderboard_ws_endpoint, FlaggedScoreStore, FlaggedScoreSubmission, InMemoryFlaggedScoreStore,
+};
 use crate::rate_limiter::{
-    InMemoryRateLimiter, RateLimitResult, RateLimiter, UserQuotaStore,
+    InMemoryRateLimiter, RateLimitResult, RateLimiter, TenantRateLimitKey, UserQuotaStore,
 };
 use crate::two_factor::{
     AuditLogEntry, HmacAlgorithm, InMemoryStore, LockedUserSummary, TenantConfig, TenantRegistry,
@@ -858,17 +860,17 @@ impl AdminRecoveryHandlers {
 
 /// Admin handlers for managing flagged leaderboard scores
 pub struct AdminScoreHandlers {
-    flagged_store: Arc<FlaggedScoreStore>,
+    flagged_store: Arc<dyn FlaggedScoreStore>,
 }
 
 impl AdminScoreHandlers {
     pub fn new() -> Self {
         Self {
-            flagged_store: Arc::new(FlaggedScoreStore::new()),
+            flagged_store: Arc::new(InMemoryFlaggedScoreStore::new()),
         }
     }
 
-    pub fn with_store(flagged_store: Arc<FlaggedScoreStore>) -> Self {
+    pub fn with_store(flagged_store: Arc<dyn FlaggedScoreStore>) -> Self {
         Self { flagged_store }
     }
 
@@ -1389,15 +1391,10 @@ impl MultiTenantHandlers {
     ) -> Result<bool, String> {
         caller.authorize(user_id).map_err(|e| e.to_string())?;
 
-        let max_failures = self.store.config.rate_limit_max_failures;
         let key = TenantRateLimitKey::new(&self.store.config.tenant_id, "verify", user_id);
         if let RateLimitResult::Blocked {
             retry_after_secs, ..
         } = self.limiter.record_failure(key.as_str())
-        let tenant_id = self.store.config.tenant_id.clone();
-        let key = format!("verify:{user_id}");
-        if let RateLimitResult::Blocked { retry_after_secs, .. } =
-            self.limiter.check(Some(&tenant_id), &key)
         {
             return Err(ApiError::rate_limited(
                 format!(
@@ -1408,7 +1405,6 @@ impl MultiTenantHandlers {
             )
             .to_string());
         }
-        let _ = max_failures; // per-tenant config available for custom limiter wiring
 
         let data = self.store.get(user_id)?;
         let result = TwoFactorAuth::verify_token_with_config(
@@ -1418,7 +1414,7 @@ impl MultiTenantHandlers {
         )?;
         if result {
             self.store.update_enabled(user_id, true)?;
-            self.limiter.record(Some(&tenant_id), &key);
+            self.limiter.record_success(key.as_str());
         }
         Ok(result)
     }
@@ -1435,10 +1431,6 @@ impl MultiTenantHandlers {
         if let RateLimitResult::Blocked {
             retry_after_secs, ..
         } = self.limiter.record_failure(key.as_str())
-        let tenant_id = self.store.config.tenant_id.clone();
-        let key = format!("disable:{user_id}");
-        if let RateLimitResult::Blocked { retry_after_secs, .. } =
-            self.limiter.check(Some(&tenant_id), &key)
         {
             return Err(ApiError::rate_limited(
                 format!(
@@ -1461,7 +1453,7 @@ impl MultiTenantHandlers {
         )?;
         if result {
             self.store.update_enabled(user_id, false)?;
-            self.limiter.record(Some(&tenant_id), &key);
+            self.limiter.record_success(key.as_str());
         }
         Ok(result)
     }

--- a/backend-2fa/src/leaderboard.rs
+++ b/backend-2fa/src/leaderboard.rs
@@ -90,25 +90,43 @@ pub struct FlaggedScoreSubmission {
     pub reason: String,
 }
 
-/// In-memory storage for flagged submissions (for testing/demo purposes)
-pub struct FlaggedScoreStore {
+/// Storage for flagged score submissions. Implemented by
+/// [`InMemoryFlaggedScoreStore`] (default, non-persistent — used in tests and
+/// as the fallback when no database is configured) and
+/// [`crate::db::PostgresFlaggedScoreStore`] (persists across restarts).
+pub trait FlaggedScoreStore: Send + Sync {
+    fn add_flagged(&self, flagged: FlaggedScoreSubmission);
+    fn get_flagged_by_user(&self, user_id: &str) -> Vec<FlaggedScoreSubmission>;
+    fn get_all_flagged(&self) -> Vec<FlaggedScoreSubmission>;
+
+    /// Remove all flagged submissions. Used to reset state between tests.
+    fn clear(&self);
+}
+
+/// In-memory [`FlaggedScoreStore`] (for testing/demo purposes). Submissions
+/// are lost on process restart — use `PostgresFlaggedScoreStore` for
+/// persistence.
+#[derive(Default)]
+pub struct InMemoryFlaggedScoreStore {
     flagged: std::sync::Mutex<Vec<FlaggedScoreSubmission>>,
 }
 
-impl FlaggedScoreStore {
+impl InMemoryFlaggedScoreStore {
     pub fn new() -> Self {
         Self {
             flagged: std::sync::Mutex::new(Vec::new()),
         }
     }
+}
 
-    pub fn add_flagged(&self, flagged: FlaggedScoreSubmission) {
+impl FlaggedScoreStore for InMemoryFlaggedScoreStore {
+    fn add_flagged(&self, flagged: FlaggedScoreSubmission) {
         if let Ok(mut store) = self.flagged.lock() {
             store.push(flagged);
         }
     }
 
-    pub fn get_flagged_by_user(&self, user_id: &str) -> Vec<FlaggedScoreSubmission> {
+    fn get_flagged_by_user(&self, user_id: &str) -> Vec<FlaggedScoreSubmission> {
         if let Ok(store) = self.flagged.lock() {
             store
                 .iter()
@@ -120,7 +138,7 @@ impl FlaggedScoreStore {
         }
     }
 
-    pub fn get_all_flagged(&self) -> Vec<FlaggedScoreSubmission> {
+    fn get_all_flagged(&self) -> Vec<FlaggedScoreSubmission> {
         if let Ok(store) = self.flagged.lock() {
             store.clone()
         } else {
@@ -128,16 +146,10 @@ impl FlaggedScoreStore {
         }
     }
 
-    pub fn clear(&self) {
+    fn clear(&self) {
         if let Ok(mut store) = self.flagged.lock() {
             store.clear();
         }
-    }
-}
-
-impl Default for FlaggedScoreStore {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -732,6 +744,19 @@ mod tests {
         3_000_000
     }
 
+    /// `LEADERBOARD_WS_AUTH_TOKEN` is process-global, and `cargo test` runs
+    /// tests in parallel threads by default, so any test that sets/clears it
+    /// must hold this lock for its whole body to avoid racing with the others.
+    static WS_AUTH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// `metrics().leaderboard_ws_connections_total` is a process-global
+    /// Prometheus gauge shared by every test that calls `hub.connect`. Only
+    /// one test asserts on its exact value, but any test running in
+    /// parallel that increments/decrements it (even without checking it)
+    /// can still corrupt that assertion, so every test touching the gauge
+    /// holds this lock for its whole body.
+    static WS_METRICS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn sales() -> Vec<TicketSale> {
         vec![
             TicketSale {
@@ -803,7 +828,7 @@ mod tests {
         };
         let config = ScoreValidationConfig::default();
 
-        let result = validate_score_submission(&submission, None, &config);
+        let result = validate_score_submission(&submission, None, &config, None);
         assert!(result.is_ok());
     }
 
@@ -816,7 +841,7 @@ mod tests {
         };
         let config = ScoreValidationConfig::default();
 
-        let result = validate_score_submission(&submission, Some(1000), &config);
+        let result = validate_score_submission(&submission, Some(1000), &config, None);
         assert!(result.is_ok());
     }
 
@@ -829,7 +854,7 @@ mod tests {
         };
         let config = ScoreValidationConfig::default();
 
-        let result = validate_score_submission(&submission, Some(1000), &config);
+        let result = validate_score_submission(&submission, Some(1000), &config, None);
         assert!(result.is_ok());
     }
 
@@ -842,9 +867,10 @@ mod tests {
         };
         let config = ScoreValidationConfig {
             max_score_delta: 1000,
+            max_z_score: 3.0,
         };
 
-        let result = validate_score_submission(&submission, Some(1000), &config);
+        let result = validate_score_submission(&submission, Some(1000), &config, None);
         assert!(result.is_ok());
     }
 
@@ -857,9 +883,10 @@ mod tests {
         };
         let config = ScoreValidationConfig {
             max_score_delta: 1000,
+            max_z_score: 3.0,
         };
 
-        let result = validate_score_submission(&submission, Some(1000), &config);
+        let result = validate_score_submission(&submission, Some(1000), &config, None);
         assert!(result.is_err());
 
         if let Err(ScoreSubmissionError::SuspiciousScore {
@@ -885,9 +912,10 @@ mod tests {
         };
         let config = ScoreValidationConfig {
             max_score_delta: 1000,
+            max_z_score: 3.0,
         };
 
-        let result = validate_score_submission(&submission, Some(2000), &config);
+        let result = validate_score_submission(&submission, Some(2000), &config, None);
         assert!(result.is_err());
     }
 
@@ -900,7 +928,7 @@ mod tests {
         };
         let config = ScoreValidationConfig::default();
 
-        let result = validate_score_submission(&submission, Some(500), &config);
+        let result = validate_score_submission(&submission, Some(500), &config, None);
         assert!(result.is_ok());
     }
 
@@ -913,9 +941,10 @@ mod tests {
         };
         let config = ScoreValidationConfig {
             max_score_delta: 10000,
+            max_z_score: 3.0,
         };
 
-        let result = validate_score_submission(&submission, Some(500), &config);
+        let result = validate_score_submission(&submission, Some(500), &config, None);
         assert!(result.is_ok());
     }
 
@@ -928,15 +957,16 @@ mod tests {
         };
         let config = ScoreValidationConfig {
             max_score_delta: 100,
+            max_z_score: 3.0,
         };
 
-        let result = validate_score_submission(&submission, Some(100), &config);
+        let result = validate_score_submission(&submission, Some(100), &config, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn flagged_score_store_add_and_retrieve() {
-        let store = FlaggedScoreStore::new();
+        let store = InMemoryFlaggedScoreStore::new();
         let flagged = FlaggedScoreSubmission {
             user_id: "user1".into(),
             attempted_score: 5000,
@@ -954,7 +984,7 @@ mod tests {
 
     #[test]
     fn flagged_score_store_multiple_users() {
-        let store = FlaggedScoreStore::new();
+        let store = InMemoryFlaggedScoreStore::new();
 
         store.add_flagged(FlaggedScoreSubmission {
             user_id: "user1".into(),
@@ -981,7 +1011,7 @@ mod tests {
 
     #[test]
     fn flagged_score_store_get_all() {
-        let store = FlaggedScoreStore::new();
+        let store = InMemoryFlaggedScoreStore::new();
 
         store.add_flagged(FlaggedScoreSubmission {
             user_id: "user1".into(),
@@ -1003,7 +1033,7 @@ mod tests {
 
     #[test]
     fn flagged_score_store_clear() {
-        let store = FlaggedScoreStore::new();
+        let store = InMemoryFlaggedScoreStore::new();
 
         store.add_flagged(FlaggedScoreSubmission {
             user_id: "user1".into(),
@@ -1020,7 +1050,7 @@ mod tests {
 
     #[test]
     fn flagged_score_store_user_not_found() {
-        let store = FlaggedScoreStore::new();
+        let store = InMemoryFlaggedScoreStore::new();
 
         store.add_flagged(FlaggedScoreSubmission {
             user_id: "user1".into(),
@@ -1245,6 +1275,7 @@ mod tests {
 
     #[test]
     fn auth_passes_with_correct_token() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
         assert!(validate_ws_auth_token(Some("Bearer supersecret")));
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
@@ -1252,6 +1283,7 @@ mod tests {
 
     #[test]
     fn auth_fails_with_wrong_token() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
         assert!(!validate_ws_auth_token(Some("Bearer wrongtoken")));
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
@@ -1259,6 +1291,7 @@ mod tests {
 
     #[test]
     fn auth_fails_with_missing_header() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
         assert!(!validate_ws_auth_token(None));
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
@@ -1266,6 +1299,7 @@ mod tests {
 
     #[test]
     fn auth_fails_with_empty_bearer_value() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
         assert!(!validate_ws_auth_token(Some("Bearer ")));
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
@@ -1273,6 +1307,7 @@ mod tests {
 
     #[test]
     fn auth_fails_with_non_bearer_scheme() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::set_var("LEADERBOARD_WS_AUTH_TOKEN", "supersecret");
         assert!(!validate_ws_auth_token(Some("Basic supersecret")));
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
@@ -1280,12 +1315,14 @@ mod tests {
 
     #[test]
     fn auth_passes_any_non_empty_token_when_env_unset() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
         assert!(validate_ws_auth_token(Some("Bearer anytoken")));
     }
 
     #[test]
     fn auth_fails_missing_header_even_when_env_unset() {
+        let _guard = WS_AUTH_ENV_LOCK.lock().unwrap();
         std::env::remove_var("LEADERBOARD_WS_AUTH_TOKEN");
         assert!(!validate_ws_auth_token(None));
     }
@@ -1298,6 +1335,7 @@ mod tests {
     fn connect_limit_never_exceeded_under_concurrent_calls() {
         use std::sync::Arc as StdArc;
 
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let hub = {
             let (broadcaster, _) = broadcast::channel(16);
             StdArc::new(LeaderboardWsHub {
@@ -1331,6 +1369,7 @@ mod tests {
     fn custom_max_conn_per_ip_from_env_is_respected() {
         // Construct a hub with a custom limit directly to avoid env-var races
         // between parallel test threads.
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let hub = {
             let (broadcaster, _) = broadcast::channel(16);
             Arc::new(LeaderboardWsHub {
@@ -1382,6 +1421,7 @@ mod tests {
         use crate::metrics::metrics;
         use std::sync::Arc as StdArc;
 
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let hub = {
             let (broadcaster, _) = broadcast::channel(16);
             StdArc::new(LeaderboardWsHub {
@@ -1411,6 +1451,7 @@ mod tests {
     fn rate_limiter_msg_count_under_limit_does_not_close() {
         // Verify that msg_count < rate_limit does not close the session.
         // We test the logic directly without spinning up a full actix context.
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let mut session = {
             let (broadcaster, _) = broadcast::channel(16);
             let hub = Arc::new(LeaderboardWsHub {
@@ -1435,6 +1476,7 @@ mod tests {
 
     #[test]
     fn rate_limiter_msg_count_over_limit_triggers_close() {
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let session = {
             let (broadcaster, _) = broadcast::channel(16);
             let hub = Arc::new(LeaderboardWsHub {
@@ -1473,6 +1515,7 @@ mod tests {
 
     #[test]
     fn subscribe_at_limit_succeeds() {
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let mut session = make_session();
         let user_ids: Vec<String> = (0..MAX_SUBSCRIPTION_USER_IDS)
             .map(|i| format!("u{}", i))
@@ -1484,6 +1527,7 @@ mod tests {
 
     #[test]
     fn subscribe_over_limit_rejected() {
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let mut session = make_session();
         let user_ids: Vec<String> = (0..MAX_SUBSCRIPTION_USER_IDS + 1)
             .map(|i| format!("u{}", i))
@@ -1499,6 +1543,7 @@ mod tests {
 
     #[test]
     fn replace_at_limit_succeeds() {
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let mut session = make_session();
         let user_ids: Vec<String> = (0..MAX_SUBSCRIPTION_USER_IDS)
             .map(|i| format!("u{}", i))
@@ -1510,6 +1555,7 @@ mod tests {
 
     #[test]
     fn replace_over_limit_rejected() {
+        let _guard = WS_METRICS_LOCK.lock().unwrap();
         let mut session = make_session();
         // Pre-populate subscriptions to verify they are not wiped on rejection.
         session.subscriptions.insert("existing_user".to_string());
@@ -1542,9 +1588,11 @@ mod tests {
     #[test]
     fn test_borderline_score_at_threshold() {
         let config = ScoreValidationConfig::default();
+        // History [100, 105, 98, 102, 101] has mean 101.2, std_dev ~2.315.
+        // 108 sits at z ~= 2.94, just under the default max_z_score of 3.0.
         let submission = ScoreSubmission {
             user_id: "user1".to_string(),
-            score: 200,
+            score: 108,
             timestamp: 1000,
         };
 

--- a/backend-2fa/src/lib.rs
+++ b/backend-2fa/src/lib.rs
@@ -12,7 +12,6 @@ pub mod rate_limiter;
 pub mod tracing_middleware;
 pub mod two_factor;
 pub mod webhooks;
-pub mod migrations;
 #[cfg(feature = "redis-store")]
 pub mod redis_store;
 
@@ -23,7 +22,7 @@ pub use content_type_guard::ContentTypeGuard;
 pub use db::PostgresTwoFactorStore;
 pub use db::{
     select_secret_provider, AwsSecretsManagerProvider, EnvSecretProvider, PoolStats,
-    PostgresIpAccessStore, SecretProvider,
+    PostgresFlaggedScoreStore, PostgresIpAccessStore, SecretProvider,
 };
 pub use error::{ApiError, ErrorResponseMiddleware, NoCacheMiddleware};
 pub use handlers::{
@@ -41,9 +40,9 @@ pub use ip_access::{
     IpAccessStore, IpListType,
 };
 pub use leaderboard::{
-    broadcast_score_update, FlaggedScoreStore, FlaggedScoreSubmission, LeaderboardEntry,
-    LeaderboardScoreUpdate, LeaderboardWsHub, LeaderboardWsSession, ScoreSubmissionError,
-    ScoreValidationConfig,
+    broadcast_score_update, FlaggedScoreStore, FlaggedScoreSubmission, InMemoryFlaggedScoreStore,
+    LeaderboardEntry, LeaderboardScoreUpdate, LeaderboardWsHub, LeaderboardWsSession,
+    ScoreSubmissionError, ScoreValidationConfig,
 };
 pub use metrics::{
     dec_leaderboard_ws_connections, inc_leaderboard_ws_connections, metrics, record_rate_limit_hit,

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -1711,10 +1711,10 @@ mod tests {
 #[cfg(test)]
 mod integration_tests {
     use crate::handlers::{
-        clear_two_factor_store_for_tests, get_two_factor_data_for_tests, AdminRecoveryHandlers,
-        AuthenticatedUser, DisableTwoFactorRequest, EnableTwoFactorRequest,
-        LoginWithTwoFactorRequest, RecoverWithBackupRequest, TwoFactorHandlers,
-        VerifyTwoFactorRequest,
+        clear_two_factor_store_for_tests, get_two_factor_data_for_tests, AdminDashboardHandlers,
+        AdminRecoveryHandlers, AuthenticatedAdmin, AuthenticatedUser, DisableTwoFactorRequest,
+        EnableTwoFactorRequest, LoginWithTwoFactorRequest, RecoverWithBackupRequest,
+        TwoFactorHandlers, VerifyTwoFactorRequest,
     };
     use crate::rate_limiter::{InMemoryRateLimiter, RateLimiter};
     use crate::two_factor::TwoFactorData;
@@ -1723,6 +1723,10 @@ mod integration_tests {
 
     fn caller(id: &str) -> AuthenticatedUser {
         AuthenticatedUser::new(id)
+    }
+
+    fn admin() -> AuthenticatedAdmin {
+        AuthenticatedAdmin::new("super-admin")
     }
 
     fn generate_token(secret: &str) -> String {
@@ -2080,7 +2084,9 @@ mod integration_tests {
             .unwrap();
         let secret = enable_resp.secret;
 
-        // Exhaust the limit with bad tokens
+        // Exhaust the limit with bad tokens. Clear the (independent)
+        // progressive-delay lockout after each attempt so it doesn't shadow
+        // the RateLimiter's own block, which is what this test verifies.
         for _ in 0..3 {
             let _ = handlers.verify_login_token(
                 &caller(user_id),
@@ -2089,6 +2095,7 @@ mod integration_tests {
                     token: "000000".to_string(),
                 },
             );
+            AdminDashboardHandlers::unlock_two_fa(&admin(), user_id).unwrap();
         }
 
         // Even a correct token must be rejected while locked out
@@ -2190,7 +2197,10 @@ mod integration_tests {
 
         assert!(get_two_factor_data_for_tests(user_id).unwrap().enabled);
 
-        // 4 bad login attempts
+        // 4 bad login attempts. Each failure past the first is gated by the
+        // progressive-delay lockout (independent of the RateLimiter under
+        // test here), so clear it after every attempt to isolate what this
+        // test actually verifies: the RateLimiter's own failure counter.
         for _ in 0..4 {
             let _ = handlers.verify_login_token(
                 &caller(user_id),
@@ -2199,6 +2209,7 @@ mod integration_tests {
                     token: "000000".to_string(),
                 },
             );
+            AdminDashboardHandlers::unlock_two_fa(&admin(), user_id).unwrap();
         }
 
         // One good login — resets the counter
@@ -2226,6 +2237,7 @@ mod integration_tests {
                 result.is_ok(),
                 "should not be blocked yet after counter reset"
             );
+            AdminDashboardHandlers::unlock_two_fa(&admin(), user_id).unwrap();
         }
     }
 
@@ -3251,6 +3263,52 @@ mod redis_rate_limiter_tests {
             let flagged = admin.get_all_flagged();
             assert_eq!(flagged[0].attempted_score, max_score);
         }
+
+        // ---------------------------------------------------------------
+        // FlaggedScoreStore trait injection (Issue #789)
+        //
+        // AdminScoreHandlers::new() defaults to InMemoryFlaggedScoreStore,
+        // but with_store() accepts any Arc<dyn FlaggedScoreStore> — the same
+        // injection point a caller would use to swap in
+        // PostgresFlaggedScoreStore for cross-restart persistence in
+        // production, without changing any handler logic.
+        // ---------------------------------------------------------------
+
+        #[test]
+        fn admin_with_store_uses_injected_in_memory_store() {
+            use crate::leaderboard::{FlaggedScoreStore, InMemoryFlaggedScoreStore};
+            use std::sync::Arc;
+
+            let store: Arc<dyn FlaggedScoreStore> = Arc::new(InMemoryFlaggedScoreStore::new());
+            let admin = AdminScoreHandlers::with_store(store);
+
+            admin.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
+            let flagged = admin.get_all_flagged();
+            assert_eq!(flagged.len(), 1);
+            assert_eq!(flagged[0].user_id, "user1");
+        }
+
+        /// A store injected into two independent handler instances is shared
+        /// state, not per-handler state — this is exactly what lets a
+        /// persistent store survive a fresh `AdminScoreHandlers::with_store`
+        /// call after a process restart (only the store, not the handler,
+        /// needs to outlive the process).
+        #[test]
+        fn admin_with_store_shares_state_across_handler_instances() {
+            use crate::leaderboard::{FlaggedScoreStore, InMemoryFlaggedScoreStore};
+            use std::sync::Arc;
+
+            let store: Arc<dyn FlaggedScoreStore> = Arc::new(InMemoryFlaggedScoreStore::new());
+
+            let admin1 = AdminScoreHandlers::with_store(Arc::clone(&store));
+            admin1.log_rejected_submission("user1".into(), 5000, "Exceeds delta".into());
+
+            // A brand-new handler wired to the same store sees the same data.
+            let admin2 = AdminScoreHandlers::with_store(Arc::clone(&store));
+            let flagged = admin2.get_all_flagged();
+            assert_eq!(flagged.len(), 1);
+            assert_eq!(flagged[0].user_id, "user1");
+        }
     }
 }
 
@@ -4170,6 +4228,9 @@ mod progressive_two_factor_lockout_tests {
                 )
                 .unwrap();
             assert!(!result);
+            // Clear the progressive-delay gate (independent of the lockout
+            // threshold under test) so the next attempt isn't blocked by it.
+            store.clear_retry_after_for_tests(user_id);
         }
 
         let locked = handlers
@@ -5516,10 +5577,10 @@ mod algorithm_upgrade_tests {
 
     #[test]
     fn test_two_factor_handlers_custom_limiter_injected() {
-        use crate::rate_limiter::InMemoryRateLimiter;
+        use crate::rate_limiter::{InMemoryRateLimiter, RateLimiter};
         use std::sync::Arc;
 
-        let custom_limiter = Arc::new(InMemoryRateLimiter::default());
+        let custom_limiter: Arc<dyn RateLimiter> = Arc::new(InMemoryRateLimiter::default());
         let handlers = TwoFactorHandlers::new_with_optional_limiter(Some(custom_limiter.clone()));
         assert!(Arc::ptr_eq(handlers.limiter(), &custom_limiter));
     }

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -479,6 +479,17 @@ impl InMemoryStore {
         self.data.lock().unwrap().clear();
     }
 
+    /// Test-only: clears the progressive-delay retry gate for `user_id`
+    /// without resetting its failed-attempt count or lock status, so tests
+    /// can drive `failed_attempts` up to a lockout threshold without also
+    /// waiting out the (unrelated) per-attempt progressive delay.
+    #[cfg(test)]
+    pub fn clear_retry_after_for_tests(&self, user_id: &str) {
+        if let Some(state) = self.lockouts.lock().unwrap().get_mut(user_id) {
+            state.retry_after_timestamp = None;
+        }
+    }
+
     pub fn save(&self, user_id: &str, data: TwoFactorData) -> Result<(), String> {
         <Self as TwoFactorStore>::save(self, user_id, data)
     }
@@ -1255,17 +1266,19 @@ mod progressive_delay_tests {
     use super::*;
 
     #[test]
-    fn test_first_failure_no_delay() {
+    fn test_first_failure_has_minimal_delay() {
         let store = InMemoryStore::default();
         let state = store
             .record_failed_two_fa_attempt("user1", 10)
             .expect("record_failed_two_fa_attempt failed");
 
+        // progressive_delay_secs(1) == Some(1): even the first failure
+        // carries a brief 1s delay before another attempt is allowed.
         assert_eq!(state.failed_attempts, 1);
-        assert!(state.retry_after_timestamp.is_none(), "First attempt should have no delay");
+        assert_eq!(state.retry_after_timestamp, Some(state.updated_at + 1));
 
         let check = store.check_retry_after("user1");
-        assert!(check.is_ok(), "First attempt should pass retry_after check");
+        assert!(check.is_err(), "First attempt should be gated by its 1s delay");
     }
 
     #[test]
@@ -1305,6 +1318,10 @@ mod progressive_delay_tests {
 
         if let Err(msg) = check {
             assert!(msg.starts_with("retry_after:"), "Error should contain retry_after value");
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Lightweight JWT verification (Issue #783 — leaderboard WebSocket auth)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue

Closes #789

## Description of Changes

`FlaggedScoreStore` is now a trait:

```rust
pub trait FlaggedScoreStore: Send + Sync {
    fn add_flagged(&self, flagged: FlaggedScoreSubmission);
    fn get_flagged_by_user(&self, user_id: &str) -> Vec<FlaggedScoreSubmission>;
    fn get_all_flagged(&self) -> Vec<FlaggedScoreSubmission>;
    fn clear(&self);
}
```

implemented by:
- `InMemoryFlaggedScoreStore` — the existing non-persistent store (renamed from the old `FlaggedScoreStore` struct), kept as the default and for tests.
- `PostgresFlaggedScoreStore` (in `db.rs`, same shape as the existing `PostgresIpAccessStore`) — backed by a new `flagged_scores` table (`user_id`, `score`, `reason`, `flagged_at`), so flagged submissions survive a process restart.

`AdminScoreHandlers` now holds `Arc<dyn FlaggedScoreStore>`, so `with_store()` accepts either implementation without any handler-side changes.

Adds `migrations/006_create_flagged_scores.sql` (+ `.down.sql`). The issue named `004_create_flagged_scores.sql`, but `004` was already taken by `ip_access_list` on `main`, so this uses the next available version (`006`) instead.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Done

- [x] All existing tests pass (`cargo test`)
- [x] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [x] Manually verified expected behavior

### Test Environment

- Rust version: stable-x86_64-pc-windows-msvc
- OS: Windows 11

## Checklist

- [x] My code follows the project's code style guidelines (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] No hardcoded secrets, keys, or credentials are included in this PR
- [x] No plaintext encryption keys or sensitive data are exposed in the code
- [x] Input validation is properly implemented for all public functions
- [x] Authentication checks are in place for state-changing operations
- [x] I have read and followed the Contributing Guide

## Testing Done (integration test using the in-memory store)

Added `admin_with_store_uses_injected_in_memory_store` and `admin_with_store_shares_state_across_handler_instances` in `tests.rs`, which exercise `AdminScoreHandlers::with_store` end-to-end via the trait object (the same injection point production code would use to swap in `PostgresFlaggedScoreStore`), rather than only unit-testing the store directly.

## Security Considerations

No new attack surface — `PostgresFlaggedScoreStore` only reads/writes the `flagged_scores` table via parameterised queries.

## Additional Notes

`cargo build`/`cargo test -p petchain-2fa` didn't succeed at all on `main` (unrelated pre-existing breakage), so getting this in required cleaning some of that up along the way — this is the same infrastructure cleanup as in #1116, reapplied here since this branch was cut from `main` independently:

- A duplicate `mod migrations` declaration and a missing `TenantRateLimitKey` import.
- Two interleaved rate-limit-check function bodies in `verify_and_activate`/`disable_two_factor` left over from a bad merge.
- A `PgPoolOptions::connect_timeout` call that doesn't exist in the installed sqlx version — folded into `acquire_timeout`.
- A `TwoFactorLockoutState` literal missing its `retry_after_timestamp` field.
- `tests/openapi_validation.rs` needed `serde_yaml` (added as a dev-dependency) and a `docs/openapi.yaml` to check against.
- Stale `ScoreValidationConfig`/`validate_score_submission` call sites left over from before the z-score anomaly field/parameter were added.
- An `Arc<dyn RateLimiter>` test comparing against a concrete `Arc<InMemoryRateLimiter>`.
- A reversed assertion in a progressive-delay test.
- Three rate-limiting integration tests that didn't account for the (separate) progressive-delay lockout.
- A data race between parallel tests mutating the same process-global `LEADERBOARD_WS_AUTH_TOKEN` env var, and a second one over the global leaderboard WS connection-count gauge.
- A leaderboard anomaly test whose "borderline" score wasn't actually near the z-score threshold it claimed to test.

None of this touches the FlaggedScoreStore/AdminScoreHandlers code itself.