### PR TITLE
fix(backend-2fa): enroll race, backup code ordering, delete cleanup

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -16,7 +16,7 @@ use crate::webhooks::{SecurityEventType, WebhookManager};
 use actix_web::{web::Payload, Error, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 #[cfg(not(test))]
 use std::sync::OnceLock;
 
@@ -276,6 +276,10 @@ pub struct TwoFactorHandlers {
     limiter: Arc<dyn RateLimiter>,
     store: Arc<dyn TwoFactorStore>,
     issuer: String,
+    /// Serialises the check-then-act read/save sequence in `enroll()` so
+    /// that two concurrent enrollment requests for the same user cannot
+    /// both observe "not enabled" and both proceed to `save()`.
+    enroll_lock: Arc<Mutex<()>>,
 }
 
 impl TwoFactorHandlers {
@@ -290,6 +294,7 @@ impl TwoFactorHandlers {
             limiter: Arc::new(InMemoryRateLimiter::default()),
             store: two_factor_store(),
             issuer: "PetChain".to_string(),
+            enroll_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -336,6 +341,7 @@ impl TwoFactorHandlers {
             limiter: lim,
             store: two_factor_store(),
             issuer: "PetChain".to_string(),
+            enroll_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -349,6 +355,7 @@ impl TwoFactorHandlers {
             limiter,
             store: two_factor_store(),
             issuer: "PetChain".to_string(),
+            enroll_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -357,6 +364,7 @@ impl TwoFactorHandlers {
             limiter: Arc::new(InMemoryRateLimiter::default()),
             store,
             issuer: "PetChain".to_string(),
+            enroll_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -396,6 +404,7 @@ impl TwoFactorHandlers {
             limiter,
             store,
             issuer: "PetChain".to_string(),
+            enroll_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -407,6 +416,7 @@ impl TwoFactorHandlers {
             limiter: Arc::new(InMemoryRateLimiter::default()),
             store,
             issuer: issuer.into(),
+            enroll_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -512,6 +522,12 @@ impl TwoFactorHandlers {
                 }
             }
         }
+
+        // Serialise the read-check-save sequence below: without this lock, two
+        // concurrent enroll() calls for the same user could both observe
+        // "not enabled" and both proceed to save(), with the second save
+        // silently overwriting the first (see issue #1050).
+        let _enroll_guard = self.enroll_lock.lock().unwrap();
 
         if let Ok(existing) = self.store_get(&req.user_id) {
             if existing.enabled {

--- a/backend-2fa/src/two_factor.rs
+++ b/backend-2fa/src/two_factor.rs
@@ -273,7 +273,9 @@ impl TwoFactorAuth {
                 rng.gen_range(0..10000)
             ));
         }
-        codes.into_iter().collect()
+        let mut codes: Vec<String> = codes.into_iter().collect();
+        codes.sort();
+        codes
     }
 
     pub fn verify_backup_code(stored_codes: &[String], provided_code: &str) -> Option<usize> {
@@ -808,6 +810,19 @@ impl TwoFactorStore for InMemoryStore {
             .unwrap()
             .remove(user_id)
             .ok_or_else(|| format!("No 2FA data found for user: {}", user_id))?;
+
+        // Clean up all other per-user state so nothing lingers after deletion.
+        self.recovery_log
+            .lock()
+            .unwrap()
+            .retain(|entry| entry.user_id != user_id);
+        self.audit_log
+            .lock()
+            .unwrap()
+            .retain(|entry| entry.user_id != user_id);
+        self.lockouts.lock().unwrap().remove(user_id);
+        self.recovery_log_reset_at.lock().unwrap().remove(user_id);
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- **#1050**: `enroll()` had a check-then-act race — two concurrent enrollment requests for the same user could both see "not enabled" and both proceed to `save()`, with the second silently overwriting the first. Added a lock around the read-check-save sequence in `TwoFactorHandlers::enroll` so it's now atomic.
- **#1049**: `generate_backup_codes` collected codes from a `HashSet`, giving non-deterministic order. Codes are now sorted before being returned.
- **#1048**: `InMemoryStore::delete()` only removed the `TwoFactorData` entry, leaving the recovery usage log, audit log, and lockout state behind indefinitely. `delete()` now clears all of these for the user.

## Test plan
- [ ] `cargo test -p backend-2fa`

Closes #1050 
 closes #1049 
 closes #1048 