### PR TITLE
fix(backend-2fa): INVALID_TOKEN ApiError now returns 401, not 500

### DIFF
--- a/backend-2fa/src/error.rs
+++ b/backend-2fa/src/error.rs
@@ -95,6 +95,7 @@ impl ResponseError for ApiError {
             "FORBIDDEN" => StatusCode::FORBIDDEN,
             "NOT_FOUND" => StatusCode::NOT_FOUND,
             "CONFLICT" => StatusCode::CONFLICT,
+            "INVALID_TOKEN" => StatusCode::UNAUTHORIZED,
             "LOCKED" => StatusCode::LOCKED,
             "TOO_MANY_REQUESTS" => StatusCode::TOO_MANY_REQUESTS,
             "RATE_LIMITED" => StatusCode::TOO_MANY_REQUESTS,


### PR DESCRIPTION
## Summary
- `ApiError::status_code()` had no match arm for `INVALID_TOKEN`, so it fell through to the catch-all `_ => StatusCode::INTERNAL_SERVER_ERROR`. An invalid TOTP token therefore returned HTTP 500 instead of 401, which breaks client-side retry/auth-failure logic that branches on status code.
- Added `"INVALID_TOKEN" => StatusCode::UNAUTHORIZED` to the match in `backend-2fa/src/error.rs`.

## Test plan
- [ ] `cargo test -p backend-2fa`

Closes #1038.