### PR TITLE
fix(backend-2fa): block on the max_failures-th sliding-window failure

### DIFF
--- a/backend-2fa/src/rate_limiter.rs
+++ b/backend-2fa/src/rate_limiter.rs
@@ -849,7 +849,7 @@ impl<B: RedisBackend> RateLimiter for SlidingWindowRateLimiter<B> {
             cfg.window_secs,
         );
 
-        if count > cfg.max_failures as u64 {
+        if count >= cfg.max_failures as u64 {
             self.backend.set_ex(&lockout_key, "1", cfg.lockout_secs);
 
             // Extract user_id and endpoint from key


### PR DESCRIPTION
## Summary
- `SlidingWindowRateLimiter::record_failure` compared `count > cfg.max_failures`, which allowed one extra request past the configured limit (e.g. with `max_failures = 5`, the 6th attempt still succeeded instead of the 5th being blocked).
- Changed the comparison to `count >= cfg.max_failures` so the N-th failure where N equals `max_failures` is the one that triggers `Blocked`.

Fixes #1056

## Test plan
- [ ] `cargo test -p petchain-2fa` (not run in this environment — no Rust toolchain available; please verify in CI)