### PR TITLE
Require full admin quorum for threshold changes

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -188,6 +188,8 @@ mod test_upgrade_proposal;
 #[cfg(test)]
 mod test_disputes;
 mod test_book_slot;
+#[cfg(test)]
+mod test_admin_threshold_quorum;
 
 const DEFAULT_NONCE_MAX_USES: u32 = 1;
 #[allow(dead_code)]
@@ -346,6 +348,7 @@ pub enum ContractError {
     ProposalNotFound = 39,
     RollbackWindowExpired = 40,
     NoPreviousUpgrade = 41,
+    QuorumNotMet = 45,
 }
 
 // --- MULTI-LANGUAGE ERROR REGISTRY (Issue #684) ---
@@ -1185,6 +1188,7 @@ pub enum SystemKey {
     PendingConfig, // Issue #626: Three-phase bootstrap
     Proposal(u64),
     ProposalCount,
+    PendingThresholdChange, // Issue #815: full-quorum threshold changes
 
     // Timelock and veto keys
     AdminTimelockConfig,
@@ -1850,6 +1854,14 @@ pub struct PendingConfig {
     pub threshold: u32,
     pub confirmations: Vec<Address>,
     pub proposed_at: u64,
+}
+
+/// A threshold change awaiting unanimous admin sign-off (Issue #815).
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingThresholdChange {
+    pub new_threshold: u32,
+    pub approvals: Vec<Address>,
 }
 
 /// Multi-signature configuration for a pet.
@@ -2899,7 +2911,7 @@ impl PetChainContract {
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NoAdminsConfigured));
 
         // Check threshold
-        if proposal.approvals.len() < proposal.required_approvals as usize {
+        if proposal.approvals.len() < proposal.required_approvals {
             panic_with_error!(&env, ContractError::ThresholdNotMet);
         }
 
@@ -3760,8 +3772,21 @@ impl PetChainContract {
             .unwrap_or(0u32)
     }
 
-    /// Update the multisig admin threshold via a multisig proposal.
-    /// Requires quorum approval. Rejects if an active proposal exists.
+    /// Propose or approve a change to the multisig admin threshold.
+    ///
+    /// Unlike other admin operations, a threshold change requires approval
+    /// from EVERY current admin, not just the currently configured
+    /// threshold. Otherwise a minimal quorum could lower the threshold to 1
+    /// and let a single compromised admin take over governance afterward.
+    /// This full-quorum rule applies only to threshold changes; regular
+    /// governance proposals keep using the configured threshold.
+    ///
+    /// Each admin calls this with the same `new_threshold`; the change is
+    /// only applied once every current admin has approved it. Until then
+    /// the change remains pending and the threshold is unchanged. Calling
+    /// with a different `new_threshold` than the one currently pending
+    /// discards the old pending change and starts a fresh one.
+    ///
     /// Validates 1 <= new_threshold <= signer_count.
     pub fn set_threshold(env: Env, proposer: Address, new_threshold: u32) {
         PetChainContract::require_admin_auth(&env, &proposer);
@@ -3794,6 +3819,41 @@ impl PetChainContract {
                 }
             }
         }
+
+        let mut pending: PendingThresholdChange = env
+            .storage()
+            .instance()
+            .get(&SystemKey::PendingThresholdChange)
+            .unwrap_or(PendingThresholdChange {
+                new_threshold,
+                approvals: Vec::new(&env),
+            });
+
+        // A differently-valued change supersedes whatever was pending.
+        if pending.new_threshold != new_threshold {
+            pending = PendingThresholdChange {
+                new_threshold,
+                approvals: Vec::new(&env),
+            };
+        }
+
+        if pending.approvals.contains(&proposer) {
+            panic_with_error!(&env, ContractError::AdminAlreadyApproved);
+        }
+        pending.approvals.push_back(proposer);
+
+        if pending.approvals.len() < admins.len() {
+            // Not every current admin has approved yet — remains pending.
+            env.storage()
+                .instance()
+                .set(&SystemKey::PendingThresholdChange, &pending);
+            return;
+        }
+
+        // Every current admin has approved — apply the change.
+        env.storage()
+            .instance()
+            .remove(&SystemKey::PendingThresholdChange);
 
         let old_threshold: u32 = env
             .storage()

--- a/stellar-contracts/src/test_admin_threshold_quorum.rs
+++ b/stellar-contracts/src/test_admin_threshold_quorum.rs
@@ -1,0 +1,80 @@
+use crate::{ContractError, PetChainContract, PetChainContractClient};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+fn setup_multisig(env: &Env, threshold: u32) -> (PetChainContractClient, Address, Address, Address) {
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(env, &contract_id);
+
+    let admin1 = Address::generate(env);
+    let admin2 = Address::generate(env);
+    let admin3 = Address::generate(env);
+
+    let admins = vec![env, admin1.clone(), admin2.clone(), admin3.clone()];
+    client.init_multisig(&admin1, &admins, &threshold);
+
+    (client, admin1, admin2, admin3)
+}
+
+// Threshold starts at 2 (below the admin count of 3). Lowering it must still
+// require all 3 admins to approve, not just the old threshold of 2 — a
+// minimal quorum should not be able to unilaterally weaken governance.
+#[test]
+fn threshold_change_updates_only_after_every_admin_approves() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin1, admin2, admin3) = setup_multisig(&env, 2);
+
+    client.set_threshold(&admin1, &1u32);
+    client.set_threshold(&admin2, &1u32);
+    assert_eq!(
+        client.get_admin_threshold(),
+        2u32,
+        "must remain pending until every admin approves"
+    );
+
+    client.set_threshold(&admin3, &1u32);
+    assert_eq!(client.get_admin_threshold(), 1u32);
+}
+
+#[test]
+fn threshold_change_remains_pending_when_one_admin_abstains() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin1, admin2, _admin3) = setup_multisig(&env, 2);
+
+    client.set_threshold(&admin1, &1u32);
+    client.set_threshold(&admin2, &1u32);
+    // admin3 never approves — the threshold must stay at its old value.
+    assert_eq!(client.get_admin_threshold(), 2u32);
+}
+
+#[test]
+fn threshold_change_same_admin_cannot_approve_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin1, _admin2, _admin3) = setup_multisig(&env, 2);
+
+    client.set_threshold(&admin1, &1u32);
+    let result = client.try_set_threshold(&admin1, &1u32);
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ContractError::AdminAlreadyApproved.into()
+    );
+}
+
+// A single-admin multisig is its own full quorum: one approval is enough.
+#[test]
+fn threshold_change_applies_immediately_with_single_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PetChainContract);
+    let client = PetChainContractClient::new(&env, &contract_id);
+    let admin1 = Address::generate(&env);
+    let admins = vec![&env, admin1.clone()];
+    client.init_multisig(&admin1, &admins, &1u32);
+
+    client.set_threshold(&admin1, &1u32);
+    assert_eq!(client.get_admin_threshold(), 1u32);
+}


### PR DESCRIPTION
# Pull Request

## Related Issue

Closes #815

## Description of Changes

`set_threshold` previously applied a new admin threshold as soon as it was called by a single admin, using only the *old* threshold as validation. That meant a minimal quorum could lower the threshold (e.g. to 1) and let a single compromised admin take over governance afterward.

`set_threshold` now collects approvals in a pending state and only applies the new threshold once every current admin has called it with the same value. Calling with a different value discards whatever was pending and starts over. Regular multisig proposals are unaffected.

While wiring up tests for this change, `cargo check` turned up a pre-existing compile error in `execute_proposal`'s quorum check (a `usize`/`u32` mismatch and a missing `ContractError::QuorumNotMet` variant) that blocked the crate from building at all. Fixed both as part of this PR since they sit in the same area and there was no way to verify anything without them.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Security fix

## Testing Done

- [x] All existing tests pass (`cargo test`)
- [x] New tests added for new functionality
- [ ] Tested on Stellar testnet
- [ ] Gas optimization verified (if applicable)
- [x] Manually verified expected behavior

### Test Environment

- Rust version: 1.90
- Stellar CLI version: n/a
- OS: Windows 11

## Checklist

- [x] My code follows the project's code style guidelines (`cargo fmt`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README, API docs, etc.)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] No hardcoded secrets, keys, or credentials are included in this PR
- [x] No plaintext encryption keys or sensitive data are exposed in the code
- [x] Input validation is properly implemented for all public functions
- [x] Authentication checks are in place for state-changing operations
- [x] I have read and followed the [Contributing Guide](../CONTRIBUTING.md)

## Security Considerations

This directly hardens admin governance: threshold changes now require unanimous admin approval instead of just meeting the currently configured threshold, closing the path for a minimal quorum to weaken the multisig setup on its own.

## Screenshots / Logs (if applicable)

N/A

## Additional Notes

N/A