### PR TITLE
backend-2fa & stellar-contracts: config fixes (#1033, #1035, #1036, #1037)

### DIFF
--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -399,6 +399,23 @@ impl TwoFactorHandlers {
         }
     }
 
+    /// Create a `TwoFactorHandlers` instance with both a custom [`RateLimiter`]
+    /// and a custom [`TwoFactorStore`], without requiring a custom issuer.
+    ///
+    /// Intended for integration tests that need to inject a mock store and a
+    /// mock limiter simultaneously (e.g. asserting rate-limit behavior against
+    /// a controlled store), which previously required chaining workarounds.
+    pub fn with_limiter_and_store(
+        limiter: Arc<dyn RateLimiter>,
+        store: Arc<dyn TwoFactorStore>,
+    ) -> Self {
+        Self {
+            limiter,
+            store,
+            issuer: "PetChain".to_string(),
+        }
+    }
+
     pub fn with_store_and_issuer(
         store: Arc<dyn TwoFactorStore>,
         issuer: impl Into<String>,
@@ -1561,11 +1578,6 @@ impl MultiTenantHandlers {
         if let RateLimitResult::Blocked {
             retry_after_secs, ..
         } = self.limiter.record_failure(key.as_str())
-        let max_failures = self.store.config.rate_limit_max_failures;
-        let tenant_id = self.store.config.tenant_id.clone();
-        let key = format!("verify:{user_id}");
-        if let RateLimitResult::Blocked { retry_after_secs, .. } =
-            self.limiter.check(Some(&tenant_id), &key)
         {
             return Err(ApiError::rate_limited(
                 format!(

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -1050,6 +1050,7 @@ pub enum DataKey {
     NonceMaxUse((u64, String)),
     NonceUsage((u64, String, Bytes)),
     RetentionPeriod,
+    MaxSubscriptionsPerAddress,
 }
 
 #[contracttype]
@@ -2449,7 +2450,7 @@ impl PetChainContract {
             }
         }
 
-        if active_count >= MAX_ACTIVE_SUBSCRIPTIONS_PER_ADDRESS {
+        if active_count >= Self::max_subscriptions_per_address(env.clone()) {
             panic_with_error!(&env, ContractError::TooManyItems);
         }
 
@@ -2488,6 +2489,28 @@ impl PetChainContract {
         );
 
         subscription_id
+    }
+
+    /// Admin-only: override the per-address active subscription cap enforced
+    /// by `register_subscription`. Lets private deployments (e.g. hospital
+    /// instances) scale the limit without redeploying the contract.
+    pub fn set_max_subscriptions_per_address(env: Env, admin: Address, max: u32) {
+        admin.require_auth();
+        if !Self::is_admin_address(&env, &admin) {
+            panic_with_error!(&env, ContractError::NotAnAdmin);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxSubscriptionsPerAddress, &max);
+    }
+
+    /// Current per-address active subscription cap: the admin-configured
+    /// value if one has been set, otherwise the default of 10.
+    pub fn max_subscriptions_per_address(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::MaxSubscriptionsPerAddress)
+            .unwrap_or(MAX_ACTIVE_SUBSCRIPTIONS_PER_ADDRESS)
     }
 
     pub fn get_subscription(env: Env, subscription_id: u64) -> Option<EventSubscription> {


### PR DESCRIPTION
## Summary

- **#1033** — `stellar-contracts`: replaced the hardcoded `MAX_ACTIVE_SUBSCRIPTIONS_PER_ADDRESS` constant with an admin-configurable `DataKey::MaxSubscriptionsPerAddress` instance-storage entry (default 10), plus a new admin-only `set_max_subscriptions_per_address(env, admin, max)` function and a `max_subscriptions_per_address(env)` getter used by the enforcement check in `register_subscription`.
- **#1035** — `backend-2fa`: added `TwoFactorHandlers::with_limiter_and_store(limiter, store)` so callers (e.g. integration tests) can inject both a custom rate limiter and a custom store without also having to specify an issuer.
- **#1036** — `TwoFactorHandlers::enable_two_factor` is already a deprecated convenience wrapper around the instance method `enroll()` with a `#[deprecated]` attribute and migration doc comment on `main`; no further change was needed.
- **#1037** — `AuthenticatedUser::authorize` already returns `Result<(), ApiError>` (using `ApiError::forbidden`) on `main`, and all call sites already propagate it with `?`; no further change was needed.

As a drive-by fix required to get the touched file compiling again: `MultiTenantHandlers::verify_and_activate` in `backend-2fa/src/handlers.rs` contained a leftover, unresolved merge artifact (an `if let` with no block body followed by duplicate/conflicting statements) from a previous merge. Removed the dead duplicate lines so it matches the working pattern used by the sibling `disable_two_factor` method.

Per instructions for this batch of issues, test additions were skipped.

Closes #1033
Closes #1035
Closes #1036
Closes #1037

