### PR TITLE
Add X-Request-ID propagation through tracing middleware

### DIFF
--- a/backend-2fa/src/db.rs
+++ b/backend-2fa/src/db.rs
@@ -150,11 +150,10 @@ impl PostgresTwoFactorStore {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(30);
-
-        // sqlx's pool has a single `acquire_timeout` covering both "wait for
-        // a free slot" and "make the initial TCP connection" — apply the
-        // tighter of the two configured bounds so either one is honored.
-        let effective_timeout_secs = acquire_timeout_secs.min(connect_timeout_secs);
+        let connect_timeout_secs: u64 = std::env::var("DB_POOL_CONNECT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
 
         // sqlx's pool has a single `acquire_timeout` covering both "wait for
         // a free slot" and "make the initial TCP connection" — apply the
@@ -167,7 +166,6 @@ impl PostgresTwoFactorStore {
                     .min_connections(min_conns)
                     .max_connections(max_conns)
                     .acquire_timeout(Duration::from_secs(effective_timeout_secs))
-                    .acquire_timeout(Duration::from_secs(acquire_timeout_secs))
                     .connect(database_url),
             )
             .map_err(|e| format!(
@@ -1471,7 +1469,7 @@ mod tests {
     /// rather than hanging the process indefinitely.
     ///
     /// We use a non-routable IP address (RFC 5737 TEST-NET-1: 192.0.2.1) and
-    /// set `DB_ACQUIRE_TIMEOUT_SECS` to 1 so the test completes within the
+    /// set `DB_POOL_ACQUIRE_TIMEOUT_SECS` to 1 so the test completes within the
     /// default test runner timeout.  A successful `Err` return with a
     /// descriptive message proves the timeout fired.
     #[test]
@@ -1479,13 +1477,13 @@ mod tests {
         let unreachable_url = "postgres://user:pass@192.0.2.1:5432/db";
 
         // Override acquire timeout to 1 second so the test is fast.
-        std::env::set_var("DB_ACQUIRE_TIMEOUT_SECS", "1");
+        std::env::set_var("DB_POOL_ACQUIRE_TIMEOUT_SECS", "1");
 
         let start = std::time::Instant::now();
         let result = PostgresTwoFactorStore::connect(unreachable_url);
         let elapsed = start.elapsed();
 
-        std::env::remove_var("DB_ACQUIRE_TIMEOUT_SECS");
+        std::env::remove_var("DB_POOL_ACQUIRE_TIMEOUT_SECS");
 
         assert!(
             result.is_err(),

--- a/backend-2fa/src/handlers.rs
+++ b/backend-2fa/src/handlers.rs
@@ -1561,11 +1561,6 @@ impl MultiTenantHandlers {
         if let RateLimitResult::Blocked {
             retry_after_secs, ..
         } = self.limiter.record_failure(key.as_str())
-        let max_failures = self.store.config.rate_limit_max_failures;
-        let tenant_id = self.store.config.tenant_id.clone();
-        let key = format!("verify:{user_id}");
-        if let RateLimitResult::Blocked { retry_after_secs, .. } =
-            self.limiter.check(Some(&tenant_id), &key)
         {
             return Err(ApiError::rate_limited(
                 format!(

--- a/backend-2fa/src/tests.rs
+++ b/backend-2fa/src/tests.rs
@@ -5710,8 +5710,9 @@ mod algorithm_upgrade_tests {
         // limiter directly to drive it past the threshold without needing
         // valid TOTP tokens.
         let limiter = Arc::new(InMemoryRateLimiter::default());
+        let limiter_dyn: Arc<dyn RateLimiter> = limiter.clone();
         let store = Arc::new(crate::two_factor::InMemoryStore::default());
-        let handlers = TwoFactorHandlers::with_store_and_limiter(store, limiter.clone());
+        let handlers = TwoFactorHandlers::with_store_and_limiter(store, limiter_dyn.clone());
 
         // Simulate repeated enroll attempts for the same user via the SHARED
         // handlers instance.  The key used by `enroll` is "enroll:<user_id>".
@@ -5737,7 +5738,7 @@ mod algorithm_upgrade_tests {
         // Confirm that the shared handlers' limiter is the very same object —
         // it would not accumulate state if a fresh instance had been created.
         assert!(
-            Arc::ptr_eq(handlers.limiter(), &limiter),
+            Arc::ptr_eq(handlers.limiter(), &limiter_dyn),
             "handlers must hold the shared limiter, not a fresh one"
         );
     }

--- a/backend-2fa/src/tracing_middleware.rs
+++ b/backend-2fa/src/tracing_middleware.rs
@@ -18,6 +18,11 @@ use tracing::Instrument;
 use uuid::Uuid;
 
 pub const REQUEST_ID_HEADER: &str = "x-request-id";
+/// Maximum accepted length for an incoming `x-request-id`. Longer values are
+/// discarded in favor of a freshly generated UUID to prevent a client from
+/// injecting oversized or malicious content into every log line for the
+/// request.
+pub const MAX_REQUEST_ID_LEN: usize = 128;
 pub const TRACEPARENT_HEADER: &str = "traceparent";
 
 /// Represents a parsed W3C Trace Context traceparent header
@@ -155,11 +160,14 @@ where
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        // Reuse incoming request-id or generate a new one.
+        // Reuse incoming request-id or generate a new one. Reject oversized
+        // values instead of trusting them, since they end up in every log
+        // line for the request.
         let request_id = req
             .headers()
             .get(REQUEST_ID_HEADER)
             .and_then(|v| v.to_str().ok())
+            .filter(|s| !s.is_empty() && s.len() <= MAX_REQUEST_ID_LEN)
             .map(|s| s.to_owned())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
@@ -530,5 +538,85 @@ mod tests {
         );
 
         std::env::remove_var("TRACE_CONTEXT_AUTOGENERATE");
+    }
+
+    // ── Issue #817: X-Request-ID propagation ───────────────────────────────
+
+    async fn ok_handler() -> actix_web::HttpResponse {
+        actix_web::HttpResponse::Ok().finish()
+    }
+
+    #[actix_web::test]
+    async fn request_id_is_echoed_back_when_provided() {
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .wrap(RequestIdMiddleware)
+                .route("/", actix_web::web::get().to(ok_handler)),
+        )
+        .await;
+
+        let req = actix_web::test::TestRequest::get()
+            .uri("/")
+            .insert_header((REQUEST_ID_HEADER, "my-custom-request-id"))
+            .to_request();
+        let res = actix_web::test::call_service(&app, req).await;
+
+        let echoed = res
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert_eq!(echoed, "my-custom-request-id");
+    }
+
+    #[actix_web::test]
+    async fn absent_request_id_generates_a_valid_uuid() {
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .wrap(RequestIdMiddleware)
+                .route("/", actix_web::web::get().to(ok_handler)),
+        )
+        .await;
+
+        let req = actix_web::test::TestRequest::get().uri("/").to_request();
+        let res = actix_web::test::call_service(&app, req).await;
+
+        let generated = res
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert!(
+            Uuid::parse_str(generated).is_ok(),
+            "expected a valid UUID, got {generated}"
+        );
+    }
+
+    #[actix_web::test]
+    async fn oversized_request_id_is_replaced_with_a_generated_uuid() {
+        let app = actix_web::test::init_service(
+            actix_web::App::new()
+                .wrap(RequestIdMiddleware)
+                .route("/", actix_web::web::get().to(ok_handler)),
+        )
+        .await;
+
+        let oversized = "a".repeat(MAX_REQUEST_ID_LEN + 1);
+        let req = actix_web::test::TestRequest::get()
+            .uri("/")
+            .insert_header((REQUEST_ID_HEADER, oversized.clone()))
+            .to_request();
+        let res = actix_web::test::call_service(&app, req).await;
+
+        let returned = res
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert_ne!(returned, oversized, "oversized request id must be rejected");
+        assert!(
+            Uuid::parse_str(returned).is_ok(),
+            "expected a generated UUID, got {returned}"
+        );
     }
 }


### PR DESCRIPTION
Closes #817

Reads the incoming `X-Request-ID` header and attaches it to the request's tracing span; if the header is absent or exceeds 128 characters (to prevent log injection), a generated UUID v4 is used instead. The resulting ID is echoed back in the response headers.

Also fixes a few pre-existing bugs in `db.rs`, `handlers.rs`, and `tests.rs` (duplicate/mismatched pool timeout config, a stale rate limiter check, and a type mismatch in a shared-limiter test) that were preventing the crate from compiling.

- `cargo test` passes