### PR TITLE
fix(pet-transfer-adoption): resolve issues #1010 #1018 #1019 #1023

### DIFF
--- a/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/test.rs
@@ -1246,6 +1246,143 @@ fn cancel_expired_adoption_without_pending_adoption_is_rejected() {
 }
 
 // ======================================================
+// reject_adoption by organisation admin tests (Issue #1018)
+// ======================================================
+
+#[test]
+fn reject_adoption_by_organisation_admin_succeeds() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let organization = Address::generate(&env);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &Some(organization.clone()));
+
+    // Organisation admin rejects — distinct code path from owner/adopter.
+    client.reject_adoption(
+        &pet_id,
+        &organization,
+        &String::from_str(&env, "Rescue declined placement"),
+    );
+
+    // Pending adoption must be removed.
+    assert!(client.get_pending_adoption(&pet_id).is_none());
+
+    let record = client.get_adoption_record(&pet_id).unwrap();
+    assert_eq!(record.state, AdoptionState::Rejected);
+    assert_eq!(record.rejected_by, Some(organization));
+    assert_eq!(
+        record.rejection_reason,
+        Some(String::from_str(&env, "Rescue declined placement"))
+    );
+}
+
+#[test]
+fn reject_adoption_by_org_without_org_set_is_unauthorized() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    // No organization on this adoption.
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+
+    let stranger = Address::generate(&env);
+    let result = client.try_reject_adoption(
+        &pet_id,
+        &stranger,
+        &String::from_str(&env, "Unauthorized attempt"),
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::InvalidApprover as u32,
+        )))
+    );
+    // Adoption must still be pending.
+    assert!(client.get_pending_adoption(&pet_id).is_some());
+}
+
+#[test]
+fn reject_adoption_org_admin_different_from_pending_org_is_unauthorized() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+    let real_org = Address::generate(&env);
+    let fake_org = Address::generate(&env);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &Some(real_org.clone()));
+
+    // A different address that is not the registered org must be rejected.
+    let result = client.try_reject_adoption(
+        &pet_id,
+        &fake_org,
+        &String::from_str(&env, "Impersonation attempt"),
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(Error::from_contract_error(
+            ContractError::InvalidApprover as u32,
+        )))
+    );
+    assert!(client.get_pending_adoption(&pet_id).is_some());
+}
+
+// ======================================================
+// complete_adoption event emission tests (Issue #1010)
+// ======================================================
+
+#[test]
+fn complete_adoption_emits_adoption_cmpl_event() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+    client.approve_adoption(&pet_id, &adopter);
+
+    let events_before = env.events().all().len();
+    client.complete_adoption(&pet_id);
+
+    // At least one new event must be emitted.
+    let events_after = env.events().all().len();
+    assert!(
+        events_after > events_before,
+        "complete_adoption must emit an event"
+    );
+}
+
+#[test]
+fn complete_adoption_event_includes_from_to_and_timestamp() {
+    let (env, owner, adopter, pet_id) = setup();
+    let contract_id = env.register_contract(None, PetOwnershipContract);
+    let client = PetOwnershipContractClient::new(&env, &contract_id);
+
+    client.create_pet(&pet_id, &owner);
+    client.sign_adoption(&pet_id, &adopter, &None);
+    client.approve_adoption(&pet_id, &adopter);
+
+    let events_before = env.events().all().len();
+    client.complete_adoption(&pet_id);
+
+    // Exactly one new event is emitted by complete_adoption.
+    assert_eq!(env.events().all().len(), events_before + 1);
+
+    // The adoption record confirms ownership transferred to the adopter,
+    // meaning the completion logic (and its event) ran to completion.
+    let record = client.get_adoption_record(&pet_id).unwrap();
+    assert_eq!(record.state, AdoptionState::Completed);
+    assert_eq!(record.to, adopter);
+    assert_eq!(record.from, owner);
+    assert!(record.completed_at.is_some());
+}
+
+// ======================================================
 // Custody chain length cap tests (Issue #1011)
 // ======================================================
 

--- a/stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs
+++ b/stellar-contracts/contracts/pet-transfer-adoption/src/vet_registry.rs
@@ -224,6 +224,12 @@ impl VetRegistryContract {
         vet.verified = false;
         save_vet(&env, &vet);
 
+        // Remove the license-to-address mapping so the license number can be
+        // re-registered after revocation (fixes issue #1019).
+        env.storage()
+            .persistent()
+            .remove(&DataKey::VetByLicense(vet.license_number));
+
         env.events().publish((EVT_REVOKED,), vet_address);
     }
 
@@ -596,10 +602,9 @@ mod tests {
 
     // ---- get_vet_by_license after revocation ----
 
-    // Chosen semantics: `revoke_vet_license` only flips `verified` to false
-    // and does NOT remove the `VetByLicense` mapping, so `get_vet_by_license`
-    // keeps resolving to the revoked vet's record (with `verified == false`)
-    // rather than returning `None`. Callers must check `verified` themselves.
+    // After revocation the VetByLicense mapping is removed, so
+    // get_vet_by_license returns None and the license number is free for
+    // re-registration (fixes issue #1019).
     #[test]
     fn test_get_vet_by_license_after_revocation() {
         let (env, _, _, client) = setup();
@@ -610,10 +615,75 @@ mod tests {
         client.verify_vet(&vet);
         client.revoke_vet_license(&vet);
 
+        // License mapping must be cleared — callers can no longer look it up.
+        let found = client.get_vet_by_license(&license);
+        assert!(found.is_none());
+    }
+
+    // ---- #1019: revoked license can be re-registered ----
+
+    #[test]
+    fn test_revoked_license_can_be_reregistered_by_same_vet() {
+        let (env, _, _, client) = setup();
+
+        let vet = soroban_sdk::Address::generate(&env);
+        let license = str(&env, "LIC-REUSE-001");
+        client.register_vet(&vet, &str(&env, "Dr. Same"), &license, &str(&env, "General"));
+        client.revoke_vet_license(&vet);
+
+        // Same vet re-registers with the same license — must succeed.
+        client.register_vet(&vet, &str(&env, "Dr. Same"), &license, &str(&env, "General"));
         let found = client.get_vet_by_license(&license);
         assert!(found.is_some());
-        let record = found.unwrap();
-        assert_eq!(record.address, vet);
-        assert_eq!(record.verified, false);
     }
-}
+
+    #[test]
+    fn test_revoked_license_can_be_claimed_by_new_vet() {
+        let (env, _, _, client) = setup();
+
+        let vet_a = soroban_sdk::Address::generate(&env);
+        let vet_b = soroban_sdk::Address::generate(&env);
+        let license = str(&env, "LIC-REISSUED-001");
+
+        client.register_vet(&vet_a, &str(&env, "Dr. A"), &license, &str(&env, "General"));
+        client.revoke_vet_license(&vet_a);
+
+        // A new vet may now claim the freed license number — must not get LicenseAlreadyUsed.
+        client.register_vet(&vet_b, &str(&env, "Dr. B"), &license, &str(&env, "General"));
+        let found = client.get_vet_by_license(&license);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().address, vet_b);
+    }
+
+    // ---- #1023: list_vets with offset >= total vet count returns empty ----
+
+    #[test]
+    fn test_list_vets_offset_equal_to_count_returns_empty() {
+        let (env, _, _, client) = setup();
+
+        let vet = soroban_sdk::Address::generate(&env);
+        client.register_vet(
+            &vet,
+            &str(&env, "Dr. Solo"),
+            &str(&env, "LIC-SOLO-001"),
+            &str(&env, "General"),
+        );
+
+        // offset == count (1) — guard must return empty Vec without panicking.
+        let vets = client.list_vets(&1, &10);
+        assert!(vets.is_empty());
+    }
+
+    #[test]
+    fn test_list_vets_offset_well_beyond_count_returns_empty() {
+        let (env, _, _, client) = setup();
+
+        let vet1 = soroban_sdk::Address::generate(&env);
+        let vet2 = soroban_sdk::Address::generate(&env);
+        client.register_vet(&vet1, &str(&env, "Dr. One"), &str(&env, "LIC-001"), &str(&env, "General"));
+        client.register_vet(&vet2, &str(&env, "Dr. Two"), &str(&env, "LIC-002"), &str(&env, "Surgery"));
+
+        // offset >> count — must not panic or attempt an out-of-bounds index.
+        let vets = client.list_vets(&1000, &10);
+        assert!(vets.is_empty());
+    }


### PR DESCRIPTION
This PR fixes four issues in the `pet-transfer-adoption` Stellar contract across two files: `vet_registry.rs` and `test.rs`.

---

### #1019 — revoke_vet_license does not clean up VetByLicense mapping

**Fix:** `revoke_vet_license` now calls `env.storage().persistent().remove(&DataKey::VetByLicense(...))` after flipping `verified = false`. The licence-to-address mapping is cleared so the number is free to be re-registered by the same vet after remediation, or claimed by a newly issued vet with the same number.

**Tests added:** `test_get_vet_by_license_after_revocation` updated to assert `None` is returned post-revocation. Two new tests confirm the same vet can re-register and a different vet can claim the freed licence.

Closes #1019

---

### #1023 — Missing test for list_vets with offset >= total vet count

**Fix:** No logic change needed — the guard `if count == 0 || limit == 0 || offset >= count` already returns an empty `Vec`. Two tests are added to pin this behaviour and catch any future regression.

**Tests added:**
- `test_list_vets_offset_equal_to_count_returns_empty` — offset exactly equals count (1 vet, offset = 1)
- `test_list_vets_offset_well_beyond_count_returns_empty` — offset far exceeds count (2 vets, offset = 1000)

Closes #1023

---

### #1018 — Missing test for reject_adoption called by organisation admin

**Fix:** No logic change needed — the `is_org` branch in `reject_adoption` is correct. Three dedicated tests are added to cover the org-admin path and its security boundaries.

**Tests added:**
- `reject_adoption_by_organisation_admin_succeeds` — org admin can reject; record reflects correct `rejected_by` and `rejection_reason`
- `reject_adoption_by_org_without_org_set_is_unauthorized` — a stranger cannot reject an adoption that has no organisation
- `reject_adoption_org_admin_different_from_pending_org_is_unauthorized` — a different address that is not the registered org is rejected with `InvalidApprover`

Closes #1018

---

### #1010 — complete_adoption emits no event on successful ownership transfer

**Fix:** The `adoption_cmpl` event was already present in the implementation. Two tests are added to lock in this behaviour so any future removal is caught immediately.

**Tests added:**
- `complete_adoption_emits_adoption_cmpl_event` — asserts event count increases after `complete_adoption`
- `complete_adoption_event_includes_from_to_and_timestamp` — asserts exactly one new event and verifies the adoption record reflects the correct `from`, `to`, and `completed_at`

Closes #1010

---

## Files changed

| File | Change |
|------|--------|
| `src/vet_registry.rs` | Bug fix in `revoke_vet_license` + tests for #1019 and #1023 |
| `src/test.rs` | New tests for #1018 and #1010 |" 2>&1