### PR TITLE
fix(webhooks): reject serialisation failures instead of firing empty …

### DIFF
--- a/backend-2fa/src/webhooks.rs
+++ b/backend-2fa/src/webhooks.rs
@@ -870,7 +870,40 @@ impl WebhookManager {
             metadata,
         };
 
-        let body = serde_json::to_string(&payload).unwrap_or_default();
+        let body = match serde_json::to_string(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(
+                    event_type = %event_type,
+                    user_id = %user_id,
+                    error = %e,
+                    "webhook payload serialisation failed — webhook not fired"
+                );
+                // Record a PermanentFailure log entry for every registered URL
+                // so operators know the event was lost rather than silently dropped.
+                let id_base = self.next_log_id.fetch_add(urls.len(), Ordering::Relaxed);
+                let mut log = self.delivery_log.lock().unwrap();
+                for (i, url) in urls.iter().enumerate() {
+                    let entry = WebhookDeliveryLog {
+                        id: id_base + i,
+                        event_type: event_type.to_string(),
+                        user_id: user_id.to_string(),
+                        timestamp,
+                        url: url.clone(),
+                        attempts: 0,
+                        success: false,
+                        last_error: Some(format!("serialisation failed: {e}")),
+                        status: DeliveryStatus::PermanentFailure,
+                        attempt_history: vec![],
+                    };
+                    if self.max_log_entries > 0 && log.len() >= self.max_log_entries {
+                        log.pop_front();
+                    }
+                    log.push_back(entry);
+                }
+                return;
+            }
+        };
         let signature = sign_webhook_payload(&self.signing_secret, body.as_bytes());
         let event_str = event_type.to_string();
         let user_str = user_id.to_string();
@@ -948,7 +981,40 @@ impl WebhookManager {
             metadata,
         };
 
-        let body = serde_json::to_string(&payload).unwrap_or_default();
+        let body = match serde_json::to_string(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::error!(
+                    event_type = %event_type,
+                    user_id = %user_id,
+                    error = %e,
+                    "webhook payload serialisation failed — webhook not fired"
+                );
+                // Record a PermanentFailure log entry for every registered URL
+                // so operators know the event was lost rather than silently dropped.
+                let id_base = self.next_log_id.fetch_add(urls.len(), Ordering::Relaxed);
+                let mut log = self.delivery_log.lock().unwrap();
+                for (i, url) in urls.iter().enumerate() {
+                    let entry = WebhookDeliveryLog {
+                        id: id_base + i,
+                        event_type: event_type.to_string(),
+                        user_id: user_id.to_string(),
+                        timestamp,
+                        url: url.clone(),
+                        attempts: 0,
+                        success: false,
+                        last_error: Some(format!("serialisation failed: {e}")),
+                        status: DeliveryStatus::PermanentFailure,
+                        attempt_history: vec![],
+                    };
+                    if self.max_log_entries > 0 && log.len() >= self.max_log_entries {
+                        log.pop_front();
+                    }
+                    log.push_back(entry);
+                }
+                return;
+            }
+        };
         let signature_header = sign_webhook_payload(&self.signing_secret, body.as_bytes());
         let event_str = event_type.to_string();
         let user_str = user_id.to_string();


### PR DESCRIPTION


Closes #1057

## Problem

Both `WebhookManager::fire()` and `WebhookManager::fire_sync()` contained the following pattern immediately before dispatching webhooks:

    let body = serde_json::to_string(&payload).unwrap_or_default();

`unwrap_or_default()` silently returns an empty `String` on serialisation error.  The code then:

1. Signed the empty body with HMAC-SHA-256.
2. Fired the HTTP request to every registered URL with an empty body.
3. Recorded `DeliveryStatus::Success` in the delivery log if the remote server responded 2xx.

From the sending side everything looked fine.  From the receiving side, a TwoFactorEnabled (or any other) event arrived with an empty body, failed JSON parsing, and was silently discarded.  No retry was triggered because the delivery was logged as a success.  The event was permanently lost with no observable indication on either side.

## Root cause

`serde_json::to_string` returns `Err` for values that contain non-finite floats, maps with non-string keys, or types that implement `Serialize` in a way that signals failure.  `WebhookPayload` itself is unlikely to trigger this today, but the footgun existed: any future change to the struct (e.g. embedding a user-supplied `f64` field) would silently corrupt all webhook deliveries without a compile-time error.

## Fix

In **both** `fire()` and `fire_sync()`, replace the `unwrap_or_default()` call with an explicit `match`:

- **On `Ok(body)`** — behaviour is unchanged; proceed to sign and deliver.
- **On `Err(e)`**:
  1. Emit `tracing::error!` with `event_type`, `user_id`, and the serialisation error so the problem is immediately visible in logs/traces.
  2. Atomically allocate one delivery-log ID per registered URL and write a `WebhookDeliveryLog` entry for each with:
     - `success: false`
     - `status: DeliveryStatus::PermanentFailure` - `last_error: Some("serialisation failed: <error>")` - `attempts: 0` / `attempt_history: []` (no HTTP attempt was made)
  3. `return` early — no HTTP request is fired.

This ensures:
- The delivery log truthfully reflects that the event was not delivered.
- Operators can observe the failure through the existing log query API.
- No empty-body HTTP requests are sent to subscribers.
- The signing step is skipped (no point signing an empty body we are not sending).

## Files changed

- `backend-2fa/src/webhooks.rs`
  - `WebhookManager::fire()` (line ~873): replaced `unwrap_or_default()` with `match` + early-return error path.
  - `WebhookManager::fire_sync()` (line ~984): same replacement.

# Pull Request

## Related Issue

